### PR TITLE
feat: support configuring `runs_on`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,7 @@ targets:
   aws_region: ap-northeast-1
   s3_bucket_name_tfmigrate_history: '<S3 Bucket Name for tfmigrate history files>'
   template_dir: templates/github
+  runs_on: ubuntu-latest # default is "ubuntu-latest". This is useful to use GitHub Actions Self Hosted Runner for the specific provider
   gcs_bucket_name_plan_file: '<Google Cloud Storage Bucket Name for Terraform Plan File>'
   gcp_service_account: terraform@my-project.iam.gserviceaccount.com
   gcp_workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'

--- a/list-targets-with-changed-files/dist/index.js
+++ b/list-targets-with-changed-files/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 156:
+/***/ 836:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28,7 +28,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(37));
-const utils_1 = __nccwpck_require__(288);
+const utils_1 = __nccwpck_require__(171);
 /**
  * Commands
  *
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 11:
+/***/ 324:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -135,12 +135,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(156);
-const file_command_1 = __nccwpck_require__(698);
-const utils_1 = __nccwpck_require__(288);
+const command_1 = __nccwpck_require__(836);
+const file_command_1 = __nccwpck_require__(965);
+const utils_1 = __nccwpck_require__(171);
 const os = __importStar(__nccwpck_require__(37));
 const path = __importStar(__nccwpck_require__(17));
-const oidc_utils_1 = __nccwpck_require__(745);
+const oidc_utils_1 = __nccwpck_require__(76);
 /**
  * The code to exit an action
  */
@@ -419,7 +419,7 @@ exports.getIDToken = getIDToken;
 
 /***/ }),
 
-/***/ 698:
+/***/ 965:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -450,7 +450,7 @@ exports.issueCommand = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(147));
 const os = __importStar(__nccwpck_require__(37));
-const utils_1 = __nccwpck_require__(288);
+const utils_1 = __nccwpck_require__(171);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -468,7 +468,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 745:
+/***/ 76:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -484,9 +484,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(219);
-const auth_1 = __nccwpck_require__(51);
-const core_1 = __nccwpck_require__(11);
+const http_client_1 = __nccwpck_require__(209);
+const auth_1 = __nccwpck_require__(89);
+const core_1 = __nccwpck_require__(324);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -552,7 +552,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 288:
+/***/ 171:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -599,7 +599,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 51:
+/***/ 89:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -665,7 +665,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 219:
+/***/ 209:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -673,7 +673,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const http = __nccwpck_require__(685);
 const https = __nccwpck_require__(687);
-const pm = __nccwpck_require__(352);
+const pm = __nccwpck_require__(986);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1092,7 +1092,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(45);
+                tunnel = __nccwpck_require__(700);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1210,7 +1210,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 352:
+/***/ 986:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1275,15 +1275,15 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 716:
+/***/ 502:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 
-var loader = __nccwpck_require__(159);
-var dumper = __nccwpck_require__(494);
+var loader = __nccwpck_require__(355);
+var dumper = __nccwpck_require__(953);
 
 
 function renamed(from, to) {
@@ -1294,32 +1294,32 @@ function renamed(from, to) {
 }
 
 
-module.exports.Type = __nccwpck_require__(944);
-module.exports.Schema = __nccwpck_require__(727);
-module.exports.FAILSAFE_SCHEMA = __nccwpck_require__(644);
-module.exports.JSON_SCHEMA = __nccwpck_require__(79);
-module.exports.CORE_SCHEMA = __nccwpck_require__(208);
-module.exports.DEFAULT_SCHEMA = __nccwpck_require__(931);
+module.exports.Type = __nccwpck_require__(973);
+module.exports.Schema = __nccwpck_require__(300);
+module.exports.FAILSAFE_SCHEMA = __nccwpck_require__(367);
+module.exports.JSON_SCHEMA = __nccwpck_require__(449);
+module.exports.CORE_SCHEMA = __nccwpck_require__(499);
+module.exports.DEFAULT_SCHEMA = __nccwpck_require__(520);
 module.exports.load                = loader.load;
 module.exports.loadAll             = loader.loadAll;
 module.exports.dump                = dumper.dump;
-module.exports.YAMLException = __nccwpck_require__(906);
+module.exports.YAMLException = __nccwpck_require__(397);
 
 // Re-export all types in case user wants to create custom schema
 module.exports.types = {
-  binary:    __nccwpck_require__(959),
-  float:     __nccwpck_require__(656),
-  map:       __nccwpck_require__(164),
-  null:      __nccwpck_require__(800),
-  pairs:     __nccwpck_require__(896),
-  set:       __nccwpck_require__(847),
-  timestamp: __nccwpck_require__(787),
-  bool:      __nccwpck_require__(230),
-  int:       __nccwpck_require__(533),
-  merge:     __nccwpck_require__(185),
-  omap:      __nccwpck_require__(920),
-  seq:       __nccwpck_require__(118),
-  str:       __nccwpck_require__(737)
+  binary:    __nccwpck_require__(212),
+  float:     __nccwpck_require__(649),
+  map:       __nccwpck_require__(51),
+  null:      __nccwpck_require__(935),
+  pairs:     __nccwpck_require__(406),
+  set:       __nccwpck_require__(13),
+  timestamp: __nccwpck_require__(382),
+  bool:      __nccwpck_require__(641),
+  int:       __nccwpck_require__(920),
+  merge:     __nccwpck_require__(215),
+  omap:      __nccwpck_require__(352),
+  seq:       __nccwpck_require__(720),
+  str:       __nccwpck_require__(952)
 };
 
 // Removed functions from JS-YAML 3.0.x
@@ -1330,7 +1330,7 @@ module.exports.safeDump            = renamed('safeDump', 'dump');
 
 /***/ }),
 
-/***/ 329:
+/***/ 643:
 /***/ ((module) => {
 
 "use strict";
@@ -1397,7 +1397,7 @@ module.exports.extend         = extend;
 
 /***/ }),
 
-/***/ 494:
+/***/ 953:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1405,9 +1405,9 @@ module.exports.extend         = extend;
 
 /*eslint-disable no-use-before-define*/
 
-var common              = __nccwpck_require__(329);
-var YAMLException       = __nccwpck_require__(906);
-var DEFAULT_SCHEMA      = __nccwpck_require__(931);
+var common              = __nccwpck_require__(643);
+var YAMLException       = __nccwpck_require__(397);
+var DEFAULT_SCHEMA      = __nccwpck_require__(520);
 
 var _toString       = Object.prototype.toString;
 var _hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -2370,7 +2370,7 @@ module.exports.dump = dump;
 
 /***/ }),
 
-/***/ 906:
+/***/ 397:
 /***/ ((module) => {
 
 "use strict";
@@ -2433,7 +2433,7 @@ module.exports = YAMLException;
 
 /***/ }),
 
-/***/ 159:
+/***/ 355:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2441,10 +2441,10 @@ module.exports = YAMLException;
 
 /*eslint-disable max-len,no-use-before-define*/
 
-var common              = __nccwpck_require__(329);
-var YAMLException       = __nccwpck_require__(906);
-var makeSnippet         = __nccwpck_require__(401);
-var DEFAULT_SCHEMA      = __nccwpck_require__(931);
+var common              = __nccwpck_require__(643);
+var YAMLException       = __nccwpck_require__(397);
+var makeSnippet         = __nccwpck_require__(431);
+var DEFAULT_SCHEMA      = __nccwpck_require__(520);
 
 
 var _hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -4168,7 +4168,7 @@ module.exports.load    = load;
 
 /***/ }),
 
-/***/ 727:
+/***/ 300:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4176,8 +4176,8 @@ module.exports.load    = load;
 
 /*eslint-disable max-len*/
 
-var YAMLException = __nccwpck_require__(906);
-var Type          = __nccwpck_require__(944);
+var YAMLException = __nccwpck_require__(397);
+var Type          = __nccwpck_require__(973);
 
 
 function compileList(schema, name) {
@@ -4297,7 +4297,7 @@ module.exports = Schema;
 
 /***/ }),
 
-/***/ 208:
+/***/ 499:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4311,12 +4311,12 @@ module.exports = Schema;
 
 
 
-module.exports = __nccwpck_require__(79);
+module.exports = __nccwpck_require__(449);
 
 
 /***/ }),
 
-/***/ 931:
+/***/ 520:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4330,23 +4330,23 @@ module.exports = __nccwpck_require__(79);
 
 
 
-module.exports = (__nccwpck_require__(208).extend)({
+module.exports = (__nccwpck_require__(499).extend)({
   implicit: [
-    __nccwpck_require__(787),
-    __nccwpck_require__(185)
+    __nccwpck_require__(382),
+    __nccwpck_require__(215)
   ],
   explicit: [
-    __nccwpck_require__(959),
-    __nccwpck_require__(920),
-    __nccwpck_require__(896),
-    __nccwpck_require__(847)
+    __nccwpck_require__(212),
+    __nccwpck_require__(352),
+    __nccwpck_require__(406),
+    __nccwpck_require__(13)
   ]
 });
 
 
 /***/ }),
 
-/***/ 644:
+/***/ 367:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4357,21 +4357,21 @@ module.exports = (__nccwpck_require__(208).extend)({
 
 
 
-var Schema = __nccwpck_require__(727);
+var Schema = __nccwpck_require__(300);
 
 
 module.exports = new Schema({
   explicit: [
-    __nccwpck_require__(737),
-    __nccwpck_require__(118),
-    __nccwpck_require__(164)
+    __nccwpck_require__(952),
+    __nccwpck_require__(720),
+    __nccwpck_require__(51)
   ]
 });
 
 
 /***/ }),
 
-/***/ 79:
+/***/ 449:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4386,26 +4386,26 @@ module.exports = new Schema({
 
 
 
-module.exports = (__nccwpck_require__(644).extend)({
+module.exports = (__nccwpck_require__(367).extend)({
   implicit: [
-    __nccwpck_require__(800),
-    __nccwpck_require__(230),
-    __nccwpck_require__(533),
-    __nccwpck_require__(656)
+    __nccwpck_require__(935),
+    __nccwpck_require__(641),
+    __nccwpck_require__(920),
+    __nccwpck_require__(649)
   ]
 });
 
 
 /***/ }),
 
-/***/ 401:
+/***/ 431:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 
-var common = __nccwpck_require__(329);
+var common = __nccwpck_require__(643);
 
 
 // get snippet for a single line, respecting maxLength
@@ -4507,13 +4507,13 @@ module.exports = makeSnippet;
 
 /***/ }),
 
-/***/ 944:
+/***/ 973:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var YAMLException = __nccwpck_require__(906);
+var YAMLException = __nccwpck_require__(397);
 
 var TYPE_CONSTRUCTOR_OPTIONS = [
   'kind',
@@ -4581,7 +4581,7 @@ module.exports = Type;
 
 /***/ }),
 
-/***/ 959:
+/***/ 212:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4590,7 +4590,7 @@ module.exports = Type;
 /*eslint-disable no-bitwise*/
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 
 // [ 64, 65, 66 ] -> [ padding, CR, LF ]
@@ -4714,13 +4714,13 @@ module.exports = new Type('tag:yaml.org,2002:binary', {
 
 /***/ }),
 
-/***/ 230:
+/***/ 641:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 function resolveYamlBoolean(data) {
   if (data === null) return false;
@@ -4757,14 +4757,14 @@ module.exports = new Type('tag:yaml.org,2002:bool', {
 
 /***/ }),
 
-/***/ 656:
+/***/ 649:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var common = __nccwpck_require__(329);
-var Type   = __nccwpck_require__(944);
+var common = __nccwpck_require__(643);
+var Type   = __nccwpck_require__(973);
 
 var YAML_FLOAT_PATTERN = new RegExp(
   // 2.5e4, 2.5 and integers
@@ -4862,14 +4862,14 @@ module.exports = new Type('tag:yaml.org,2002:float', {
 
 /***/ }),
 
-/***/ 533:
+/***/ 920:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var common = __nccwpck_require__(329);
-var Type   = __nccwpck_require__(944);
+var common = __nccwpck_require__(643);
+var Type   = __nccwpck_require__(973);
 
 function isHexCode(c) {
   return ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */)) ||
@@ -5026,13 +5026,13 @@ module.exports = new Type('tag:yaml.org,2002:int', {
 
 /***/ }),
 
-/***/ 164:
+/***/ 51:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 module.exports = new Type('tag:yaml.org,2002:map', {
   kind: 'mapping',
@@ -5042,13 +5042,13 @@ module.exports = new Type('tag:yaml.org,2002:map', {
 
 /***/ }),
 
-/***/ 185:
+/***/ 215:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 function resolveYamlMerge(data) {
   return data === '<<' || data === null;
@@ -5062,13 +5062,13 @@ module.exports = new Type('tag:yaml.org,2002:merge', {
 
 /***/ }),
 
-/***/ 800:
+/***/ 935:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 function resolveYamlNull(data) {
   if (data === null) return true;
@@ -5105,13 +5105,13 @@ module.exports = new Type('tag:yaml.org,2002:null', {
 
 /***/ }),
 
-/***/ 920:
+/***/ 352:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 var _hasOwnProperty = Object.prototype.hasOwnProperty;
 var _toString       = Object.prototype.toString;
@@ -5157,13 +5157,13 @@ module.exports = new Type('tag:yaml.org,2002:omap', {
 
 /***/ }),
 
-/***/ 896:
+/***/ 406:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 var _toString = Object.prototype.toString;
 
@@ -5218,13 +5218,13 @@ module.exports = new Type('tag:yaml.org,2002:pairs', {
 
 /***/ }),
 
-/***/ 118:
+/***/ 720:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 module.exports = new Type('tag:yaml.org,2002:seq', {
   kind: 'sequence',
@@ -5234,13 +5234,13 @@ module.exports = new Type('tag:yaml.org,2002:seq', {
 
 /***/ }),
 
-/***/ 847:
+/***/ 13:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 var _hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -5271,13 +5271,13 @@ module.exports = new Type('tag:yaml.org,2002:set', {
 
 /***/ }),
 
-/***/ 737:
+/***/ 952:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 module.exports = new Type('tag:yaml.org,2002:str', {
   kind: 'scalar',
@@ -5287,13 +5287,13 @@ module.exports = new Type('tag:yaml.org,2002:str', {
 
 /***/ }),
 
-/***/ 787:
+/***/ 382:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(944);
+var Type = __nccwpck_require__(973);
 
 var YAML_DATE_REGEXP = new RegExp(
   '^([0-9][0-9][0-9][0-9])'          + // [1] year
@@ -5383,15 +5383,15 @@ module.exports = new Type('tag:yaml.org,2002:timestamp', {
 
 /***/ }),
 
-/***/ 45:
+/***/ 700:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(577);
+module.exports = __nccwpck_require__(617);
 
 
 /***/ }),
 
-/***/ 577:
+/***/ 617:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5663,7 +5663,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 406:
+/***/ 192:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -5688,10 +5688,22 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(11));
+const core = __importStar(__nccwpck_require__(324));
 const fs = __importStar(__nccwpck_require__(147));
 const path = __importStar(__nccwpck_require__(17));
-const lib = __importStar(__nccwpck_require__(181));
+const lib = __importStar(__nccwpck_require__(463));
+function getTargetConfigByTarget(targets, target) {
+    for (let i = 0; i < targets.length; i++) {
+        const t = targets[i];
+        if (target.startsWith(t.target)) {
+            return {
+                target: target,
+                runs_on: t.runs_on ? t.runs_on : 'ubuntu-latest',
+            };
+        }
+    }
+    throw 'target is invalid';
+}
 try {
     const config = lib.getConfig();
     const configWorkingDirMap = new Map();
@@ -5715,6 +5727,8 @@ try {
     const terraformTargets = new Set();
     const tfmigrates = new Set();
     const ignores = new Set();
+    const terraformTargetObjs = new Array();
+    const tfmigrateObjs = new Array();
     const targetPrefix = (config.label_prefixes != undefined && config.label_prefixes.target != undefined && config.label_prefixes.target != '') ?
         config.label_prefixes.target : 'target:';
     const ignorePrefix = (config.label_prefixes != undefined && config.label_prefixes.ignore != undefined && config.label_prefixes.ignore != '') ?
@@ -5728,12 +5742,18 @@ try {
         }
         if (label.startsWith(targetPrefix)) {
             const target = label.slice(targetPrefix.length);
-            terraformTargets.add(target);
+            if (!terraformTargets.has(target)) {
+                terraformTargets.add(target);
+                terraformTargetObjs.push(getTargetConfigByTarget(config.targets, target));
+            }
             continue;
         }
         if (label.startsWith(tfmigratePrefix)) {
             const target = label.slice(tfmigratePrefix.length);
-            tfmigrates.add(target);
+            if (!tfmigrates.has(target)) {
+                tfmigrates.add(target);
+                tfmigrateObjs.push(getTargetConfigByTarget(config.targets, target));
+            }
             continue;
         }
         if (label.startsWith(ignorePrefix)) {
@@ -5760,13 +5780,14 @@ try {
                 const changedTarget = changedWorkingDir.replace(target.working_directory, target.target);
                 if (!terraformTargets.has(changedTarget) && !ignores.has(changedTarget) && !tfmigrates.has(changedTarget)) {
                     terraformTargets.add(changedTarget);
+                    terraformTargetObjs.push(getTargetConfigByTarget(config.targets, changedTarget));
                 }
                 break;
             }
         }
     }
-    core.setOutput('tfmigrate_targets', Array.from(tfmigrates));
-    core.setOutput('terraform_targets', Array.from(terraformTargets));
+    core.setOutput('tfmigrate_targets', tfmigrateObjs);
+    core.setOutput('terraform_targets', terraformTargetObjs);
 }
 catch (error) {
     core.setFailed(error instanceof Error ? error.message : JSON.stringify(error));
@@ -5775,7 +5796,7 @@ catch (error) {
 
 /***/ }),
 
-/***/ 181:
+/***/ 463:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -5802,8 +5823,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.setValue = exports.getIsApply = exports.getTarget = exports.getConfig = void 0;
 const fs = __importStar(__nccwpck_require__(147));
-const core = __importStar(__nccwpck_require__(11));
-const yaml = __nccwpck_require__(716);
+const core = __importStar(__nccwpck_require__(324));
+const yaml = __nccwpck_require__(502);
 function getConfig() {
     let configFilePath = process.env.TFACTION_CONFIG;
     if (configFilePath == '' || configFilePath == undefined) {
@@ -5954,7 +5975,7 @@ module.exports = require("util");
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(406);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(192);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE: the output format of list-targets has been changed from `string` to `object`

e.g.

AS IS: `github/foo`
TO BE: `{target: 'github/foo', runs_on: 'ubuntu-latest'}`

```yaml
  tfmigrate:
    name: "tfmigrate (${{matrix.target.target}})" # CHANGED
    runs-on: ${{matrix.target.runs_on}} # CHANGED
    needs: setup
    if: "join(fromJSON(needs.setup.outputs.tfmigrate_targets), '') != ''"
    strategy:
      fail-fast: false
      matrix:
        target: ${{fromJSON(needs.setup.outputs.tfmigrate_targets)}}
    env:
      TFACTION_TARGET: ${{matrix.target.target}} # CHANGED

  terraform:
    name: "terraform (${{matrix.target.target}})" # CHANGED
    runs-on: ${{matrix.target.runs_on}} # CHANGED
    needs: setup
    if: "join(fromJSON(needs.setup.outputs.terraform_targets), '') != ''"
    strategy:
      fail-fast: false
      matrix:
        target: ${{fromJSON(needs.setup.outputs.terraform_targets)}}
    env:
      TFACTION_TARGET: ${{matrix.target.target}} # CHANGED
```

## Feature: support configuring GitHub Actions job's `runs-on` per target

This is useful when you want to use Self Hosted Runner for some Terraform Provider.

e.g. tfaction-root.yaml

```yaml
targets:
- working_directory: atlas/
  runs_on: <self hosted runner> # default is "ubuntu-latest"
  # ...
```