### PR TITLE
feat(export-secrets): change configuration structure of GitHub Secrets

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -58,9 +58,9 @@ target_groups:
     # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
     name: production
     url: https://github.com
-  secrets:
-    # enviornment variable name: secret name
-    FOO: FOO_STAGING
+  secrets: # GitHub Secrets
+  - env_name: FOO # Environment variable name
+    secret_name: FOO_STAGING # Secret name
 
   gcs_bucket_name_plan_file: '<Google Cloud Storage Bucket Name for Terraform Plan File>'
   terraform_plan_config:
@@ -201,8 +201,9 @@ target_groups:
 - working_directory: atlas/staging/
   # ...
   secrets:
-    # <environment variable name>: <GitHub Secrets Name>
-    ATLAS_API_KEY: ATLAS_API_KEY_STAGING # export the secret `ATLAS_API_KEY_STAGING` as the environment variable `ATLAS_API_KEY`
+  # export the secret `ATLAS_API_KEY_STAGING` as the environment variable `ATLAS_API_KEY`
+  - env_name: ATLAS_API_KEY
+    secret_name: ATLAS_API_KEY_STAGING
 ```
 
 Job Configuration
@@ -216,8 +217,8 @@ target_groups:
   terraform_plan_config:
     # ...
     secrets:
-      # <environment variable name>: <GitHub Secrets Name>
-      ATLAS_API_KEY: ATLAS_API_KEY_STAGING_READ_ONLY
+    - env_name: ATLAS_API_KEY
+      secret_name: ATLAS_API_KEY_STAGING_READ_ONLY
 ```
 
 ### AWS Secrets Manager

--- a/export-secrets/dist/index.js
+++ b/export-secrets/dist/index.js
@@ -5811,18 +5811,35 @@ function getTargetConfig(targets, target) {
     throw 'target is invalid';
 }
 exports.getTargetConfig = getTargetConfig;
+function setSecretToMap(secrets, m) {
+    for (let i = 0; i < secrets.length; i++) {
+        const secret = secrets[i];
+        if (secret.env_name) {
+            if (secret.secret_name) {
+                m.set(secret.env_name, secret.secret_name);
+            }
+            else {
+                m.set(secret.env_name, secret.env_name);
+            }
+        }
+        else {
+            if (secret.secret_name) {
+                m.set(secret.secret_name, secret.secret_name);
+            }
+            else {
+                throw 'either secret_name or env_name is required';
+            }
+        }
+    }
+}
 function getSecrets(targetConfig, jobConfig) {
     const targetSecrets = targetConfig.secrets;
     const secrets = new Map();
     if (targetSecrets != undefined) {
-        for (let [k, v] of Object.entries(targetSecrets)) {
-            secrets.set(k, v);
-        }
+        setSecretToMap(targetSecrets, secrets);
     }
     if (jobConfig != undefined && jobConfig.secrets != undefined) {
-        for (let [k, v] of Object.entries(jobConfig.secrets)) {
-            secrets.set(k, v);
-        }
+        setSecretToMap(jobConfig.secrets, secrets);
     }
     return secrets;
 }


### PR DESCRIPTION
BREAKING CHANGE: the structure of `secrets` is changed

AS IS

```yaml
secrets:
  <environment variable name>: <secret name>
```

TO BE

```yaml
secrets:
- env_name: <environment variable name>
  secret_name: <secret name>
```