### PR TITLE
fix: specify AWS_DEFAULT_REGION

### DIFF
--- a/terraform-apply/action.yaml
+++ b/terraform-apply/action.yaml
@@ -18,6 +18,7 @@ runs:
       working-directory: ${{ steps.target-config.outputs.working_directory }}
       shell: bash
       env:
+        AWS_DEFAULT_REGION: ${{ steps.target-config.outputs.aws_region }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         GITHUB_APP_TOKEN: ${{ inputs.github_app_token }}
         S3_BUCKET_NAME_PLAN_FILE: ${{ steps.target-config.outputs.s3_bucket_name_plan_file }}

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -20,6 +20,7 @@ runs:
       working-directory: ${{ steps.target-config.outputs.working_directory }}
       shell: bash
       env:
+        AWS_DEFAULT_REGION: ${{ steps.target-config.outputs.aws_region }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         ROOT_DIR: ${{ github.workspace }}
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/tfmigrate-plan/action.yaml
+++ b/tfmigrate-plan/action.yaml
@@ -18,6 +18,7 @@ runs:
       working-directory: ${{ steps.target-config.outputs.working_directory }}
       shell: bash
       env:
+        AWS_DEFAULT_REGION: ${{ steps.target-config.outputs.aws_region }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         GITHUB_APP_TOKEN: ${{ inputs.github_app_token }}
         WORKING_DIR: ${{ steps.target-config.outputs.working_directory }}


### PR DESCRIPTION
https://github.com/aws/aws-cli/issues/5262#issuecomment-705832151

It failed to run `aws s3 cp` because the region isn't specified.