### PR TITLE
Fix typo of `$TFACTION_TARGET`

### DIFF
--- a/tfmigrate-apply/main.sh
+++ b/tfmigrate-apply/main.sh
@@ -6,7 +6,7 @@ set -o pipefail
 set +e
 github-comment exec \
 	--config "${GITHUB_ACTION_PATH}/github-comment.yaml" \
-	-var "tfaction_target:$TFACION_TARGET" \
+	-var "tfaction_target:$TFACTION_TARGET" \
 	-k tfmigrate-apply -- \
 		tfmigrate apply
 code=$?


### PR DESCRIPTION
## Problem to solve
We got the following error on applying tfmigrate:

```
...
Run suzuki-shunsuke/tfaction/tfmigrate-apply@v0.5.14
Run suzuki-shunsuke/tfaction/get-target-config@v0.5.14
Run bash /home/runner/work/_actions/suzuki-shunsuke/tfaction/v0.5.14/tfmigrate-apply/main.sh
/home/runner/work/_actions/suzuki-shunsuke/tfaction/v0.5.14/tfmigrate-apply/main.sh: line 7: TFACION_TARGET: unbound variable
Error: Process completed with exit code 1.
```

I noticed `TFACION_TARGET` is not set. Instead `TFACTION_TARGET` is set.

## How to solve
Fix the typo.

Thanks.