### PR TITLE
make directory copies idempotent

### DIFF
--- a/scaffold-working-dir/action.yaml
+++ b/scaffold-working-dir/action.yaml
@@ -18,7 +18,10 @@ runs:
     - run: mkdir -p "$(dirname "${{steps.target-config.outputs.working_directory}}")"
       shell: bash
 
-    - run: cp -R "${{steps.target-config.outputs.template_dir}}/." "${{steps.target-config.outputs.working_directory}}"
+    - run: |
+        if [ ! -d "${{steps.target-config.outputs.working_directory}}" ]; then
+          cp -R "${{steps.target-config.outputs.template_dir}}" "${{steps.target-config.outputs.working_directory}}"
+        fi
       shell: bash
 
     - run: echo '{}' > '${{steps.global-config.outputs.working_directory_file}}'

--- a/scaffold-working-dir/action.yaml
+++ b/scaffold-working-dir/action.yaml
@@ -18,7 +18,7 @@ runs:
     - run: mkdir -p "$(dirname "${{steps.target-config.outputs.working_directory}}")"
       shell: bash
 
-    - run: cp -R "${{steps.target-config.outputs.template_dir}}" "${{steps.target-config.outputs.working_directory}}"
+    - run: cp -R "${{steps.target-config.outputs.template_dir}}/." "${{steps.target-config.outputs.working_directory}}"
       shell: bash
 
     - run: echo '{}' > '${{steps.global-config.outputs.working_directory_file}}'


### PR DESCRIPTION
Thanks for the great project.
I have made one improvements to directory copy command.


The copy command `cp -R ${from} ${to}` creates an extra directory in the destination directory if it already exists.
```
to
├── main.tf
└── from
    └── main.tf
```
So I changed the command to overwrite it.
`cp -R ${from}/. ${to}`
```
to
└── main.tf
```
I prefer this behavior.