### PR TITLE
feat(tfmigrate-plan): support testing with Conftest

### DIFF
--- a/tfmigrate-plan/github-comment.yaml
+++ b/tfmigrate-plan/github-comment.yaml
@@ -20,3 +20,14 @@ exec:
       {{template "join_command" .}}
 
       {{template "hidden_combined_output" .}}
+
+  conftest:
+  - when: ExitCode != 0
+    template: |
+      ## :x: {{if .Vars.tfaction_target}}{{.Vars.tfaction_target}}: {{end}}Violate Conftest Policy
+
+      {{template "link" .}} 
+
+      {{template "join_command" .}}
+
+      {{.CombinedOutput | AvoidHTMLEscape}}

--- a/tfmigrate-plan/main.sh
+++ b/tfmigrate-plan/main.sh
@@ -40,4 +40,14 @@ github-comment exec \
 	--config "${GITHUB_ACTION_PATH}/github-comment.yaml" \
 	-k tfmigrate-plan \
 	-var "tfaction_target:$TFACTION_TARGET" \
-	-- tfmigrate plan
+	-- tfmigrate plan --out tfplan.binary
+
+if [ -d "$ROOT_DIR/policy" ]; then
+	github-comment exec -- terraform show -json tfplan.binary >tfplan.json
+	conftest -v # Install conftest in advance to exclude aqua lazy install log from github-comment's comment
+	github-comment exec \
+		--config "${GITHUB_ACTION_PATH}/github-comment.yaml" \
+		-var "tfaction_target:$TFACTION_TARGET" \
+		-k conftest -- \
+			conftest test --no-color -p "$ROOT_DIR/policy" tfplan.json
+fi


### PR DESCRIPTION
Close #511

## Features

#511 #516 tfmigrate-plan: Support testing with Conftest

In the job `tfmigrate-plan`, `conftest test` wasn't run so violated change could be missed.
This pull request fixes `tfmigrate-plan` to run `contest test` after running `tfmigrate plan`.

For this change, we use `tfmigrate plan`'s `--out` option.
This option was deprecated, but the deprecation was reverted.

- https://github.com/minamijoyo/tfmigrate/issues/106#issuecomment-1246495788

So there is no problem to use this option.

## Test

It works. 👍 

This screenshot shows the case that `tfmigrate plan` passed but `contest test` failed.

<img width="962" alt="image" src="https://user-images.githubusercontent.com/13323303/190139136-e1480673-cb63-4a09-a4de-bcf4885e0acc.png">