### PR TITLE
chore: stop using `config:base` preset because it ignores `test` directory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,12 @@
 {
   "extends": [
-    "config:base",
+    ":dependencyDashboard",
+    ":semanticPrefixFixDepsChoreOthers",
+    ":autodetectPinVersions",
+    "group:monorepos",
+    "group:recommended",
+    "workarounds:all",
+
     "helpers:pinGitHubActionDigests",
     "github>suzuki-shunsuke/renovate-config",
     "github>aquaproj/aqua-renovate-config#1.3.0",


### PR DESCRIPTION
* https://docs.renovatebot.com/configuration-options/#ignorepaths
* https://docs.renovatebot.com/presets-config/#configbase