### PR TITLE
feat(scaffold-working-directory): support skipping to add aqua packages

### DIFF
--- a/get-global-config/dist/index.js
+++ b/get-global-config/dist/index.js
@@ -6852,6 +6852,7 @@ try {
     else {
         core.setOutput('disable_update_related_pull_requests', 'false');
     }
+    core.exportVariable('TFACTION_SKIP_ADDING_AQUA_PACKAGES', config.scaffold_working_directory && config.scaffold_working_directory.skip_adding_aqua_packages);
 }
 catch (error) {
     core.setFailed(error instanceof Error ? error.message : JSON.stringify(error));

--- a/get-global-config/src/index.ts
+++ b/get-global-config/src/index.ts
@@ -27,6 +27,7 @@ try {
   } else {
     core.setOutput('disable_update_related_pull_requests', 'false');
   }
+  core.exportVariable('TFACTION_SKIP_ADDING_AQUA_PACKAGES', config.scaffold_working_directory && config.scaffold_working_directory.skip_adding_aqua_packages);
 } catch (error) {
   core.setFailed(error instanceof Error ? error.message : JSON.stringify(error));
 }

--- a/scaffold-working-dir/action.yaml
+++ b/scaffold-working-dir/action.yaml
@@ -1,9 +1,5 @@
 name: Scaffold a working directory
 description: Scaffold a working directory
-inputs:
-  skip_adding_aqua_packages:
-    description: If this is true, adding required packages to aqua.yaml is skipped
-    required: false
 outputs:
   working_directory:
     description: Working Directory
@@ -44,7 +40,7 @@ runs:
     - run: aqua g -i open-policy-agent/conftest terraform-linters/tflint aquasecurity/tfsec hashicorp/terraform
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}
-      if: !fromJSON(inputs.skip_adding_aqua_packages)
+      if: env.TFACTION_SKIP_ADDING_AQUA_PACKAGES == '' || !fromJSON(env.TFACTION_SKIP_ADDING_AQUA_PACKAGES)
 
     - run: git add .
       shell: bash

--- a/scaffold-working-dir/action.yaml
+++ b/scaffold-working-dir/action.yaml
@@ -1,5 +1,9 @@
 name: Scaffold a working directory
 description: Scaffold a working directory
+inputs:
+  skip_adding_aqua_packages:
+    description: If this is true, adding required packages to aqua.yaml is skipped
+    required: false
 outputs:
   working_directory:
     description: Working Directory
@@ -40,6 +44,7 @@ runs:
     - run: aqua g -i open-policy-agent/conftest terraform-linters/tflint aquasecurity/tfsec hashicorp/terraform
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}
+      if: !fromJSON(inputs.skip_adding_aqua_packages)
 
     - run: git add .
       shell: bash

--- a/scaffold-working-dir/action.yaml
+++ b/scaffold-working-dir/action.yaml
@@ -37,6 +37,7 @@ runs:
     - run: aqua init
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}
+      if: env.TFACTION_SKIP_ADDING_AQUA_PACKAGES == '' || !fromJSON(env.TFACTION_SKIP_ADDING_AQUA_PACKAGES)
     - run: aqua g -i open-policy-agent/conftest terraform-linters/tflint aquasecurity/tfsec hashicorp/terraform
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}


### PR DESCRIPTION
By default scaffold-working-directory creates `aqua.yaml` and add some packages.

```sh
aqua init
aqua g -i open-policy-agent/conftest terraform-linters/tflint aquasecurity/tfsec hashicorp/terraform
```

You can skip this.

tfaction-root.yaml

```yaml
scaffold_working_directory:
  skip_adding_aqua_packages: true
```

You can configure packages and their versions in your template or you can also manage them in repository root's aqua.yaml.