### PR TITLE
fix: added header for `terraform validate` comment

### DIFF
--- a/test/action.yaml
+++ b/test/action.yaml
@@ -19,6 +19,7 @@ runs:
       run: |
         github-comment exec \
           -config "${GITHUB_ACTION_PATH}/github-comment.yaml" \
+          -k terraform-validate \
           -var "tfaction_target:${TFACTION_TARGET}" \
           -- terraform validate
       working-directory: ${{ steps.target-config.outputs.working_directory }}

--- a/test/github-comment.yaml
+++ b/test/github-comment.yaml
@@ -1,6 +1,6 @@
 # https://github.com/suzuki-shunsuke/github-comment
 exec:
-  default:
+  terraform-validate:
   - when: ExitCode != 0
     template: |
       ## :x: {{.Vars.tfaction_target}}: terraform validate

--- a/test/github-comment.yaml
+++ b/test/github-comment.yaml
@@ -1,9 +1,19 @@
 # https://github.com/suzuki-shunsuke/github-comment
 exec:
+  default:
+    - when: ExitCode != 0
+      template: |
+        :x: {{.Vars.tfaction_target}}
+
+        {{template "link" .}}
+
+        {{template "join_command" .}}
+
+        {{template "hidden_combined_output" .}}
   terraform-validate:
-  - when: ExitCode != 0
-    template: |
-      ## :x: {{.Vars.tfaction_target}}: terraform validate
+    - when: ExitCode != 0
+      template: |
+        ## :x: {{.Vars.tfaction_target}}: terraform validate
 
         {{template "link" .}}
 

--- a/test/github-comment.yaml
+++ b/test/github-comment.yaml
@@ -3,7 +3,7 @@ exec:
   default:
   - when: ExitCode != 0
     template: |
-      :x: {{.Vars.tfaction_target}}
+      ## :x: {{.Vars.tfaction_target}}: terraform validate
 
       {{template "link" .}}
 


### PR DESCRIPTION
Hi, @suzuki-shunsuke 

I added header for `terraform validate` comment.

before
![image](https://github.com/suzuki-shunsuke/tfaction/assets/29038315/97e8bd89-c3fd-4f82-9ef6-3e7435c2f3e5)

after
![image](https://github.com/suzuki-shunsuke/tfaction/assets/29038315/9dec7f9c-a4ca-4c07-91fe-b5cce5b40f23)

refer to tfmigrate template
https://github.com/suzuki-shunsuke/tfaction/blob/main/tfmigrate-plan/github-comment.yaml