### PR TITLE
feat: support trivy

### DIFF
--- a/get-target-config/action.yaml
+++ b/get-target-config/action.yaml
@@ -27,6 +27,13 @@ outputs:
 
   providers_lock_opts:
     description: terraform providers lock options
+
+  enable_tfsec:
+    description: If tfsec is enabled in test action
+  enable_tflint:
+    description: If tflint is enabled in test action
+  enable_trivy:
+    description: If trivy is enabled in test action
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/get-target-config/dist/index.js
+++ b/get-target-config/dist/index.js
@@ -6887,6 +6887,9 @@ try {
             'gcp_workload_identity_provider',
         ], [jobConfig, wdConfig, rootJobConfig, targetConfig, config]);
         lib.setEnvs(config, targetConfig, rootJobConfig, wdConfig, jobConfig);
+        core.setOutput('enable_tfsec', config.tfsec == null || config.tfsec.enabled == null || config.tfsec.enabled);
+        core.setOutput('enable_tflint', config.tflint == null || config.tflint.enabled == null || config.tflint.enabled);
+        core.setOutput('enable_trivy', config.trivy != null && config.trivy.enabled);
     }
 }
 catch (error) {

--- a/get-target-config/src/index.ts
+++ b/get-target-config/src/index.ts
@@ -64,6 +64,10 @@ try {
     ], [jobConfig, wdConfig, rootJobConfig, targetConfig, config]);
 
     lib.setEnvs(config, targetConfig, rootJobConfig, wdConfig, jobConfig);
+
+    core.setOutput('enable_tfsec', config.tfsec == null || config.tfsec.enabled == null || config.tfsec.enabled);
+    core.setOutput('enable_tflint', config.tflint == null || config.tflint.enabled == null || config.tflint.enabled);
+    core.setOutput('enable_trivy', config.trivy != null && config.trivy.enabled);
   }
 } catch (error) {
   core.setFailed(error instanceof Error ? error.message : JSON.stringify(error));

--- a/get-target-config/src/lib.ts
+++ b/get-target-config/src/lib.ts
@@ -7,6 +7,9 @@ interface Config {
   working_directory_file: string | undefined
   target_groups: Array<TargetConfig>
   env: Record<string, string> | undefined
+  tfsec: TfsecConfig | undefined
+  trivy: TrivyConfig | undefined
+  tflint: TflintConfig | undefined
 }
 
 interface TargetConfig {
@@ -31,6 +34,19 @@ interface TargetConfig {
   terraform_apply_config: JobConfig | undefined
   tfmigrate_apply_config: JobConfig | undefined
   env: Record<string, string> | undefined
+  tfsec: TfsecConfig | undefined
+}
+
+export interface TfsecConfig {
+  enabled: boolean
+}
+
+export interface TflintConfig {
+  enabled: boolean
+}
+
+export interface TrivyConfig {
+  enabled: boolean
 }
 
 export interface JobConfig {

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -27,7 +27,15 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
+    - uses: suzuki-shunsuke/trivy-config-action@98c78ddbed860a39a12772c43412006b628553a8 # v0.1.0
+      if: fromJSON(steps.target-config.outputs.enable_trivy)
+      with:
+        github_token: ${{ inputs.github_token }}
+        working_directory: ${{ steps.target-config.outputs.working_directory }}
+        github_comment: 'true'
+
     - uses: suzuki-shunsuke/github-action-tfsec@122c054cace4044e52656e25ef9592b7fafecd89 # v0.1.8
+      if: fromJSON(steps.target-config.outputs.enable_tfsec)
       with:
         github_token: ${{ inputs.github_token }}
         working_directory: ${{ steps.target-config.outputs.working_directory }}
@@ -36,6 +44,7 @@ runs:
 
     # deep check requires AWS credentials
     - uses: suzuki-shunsuke/github-action-tflint@4c64bc69d01df97ddb0a1f87ffab0c732f1c86de # v0.1.6
+      if: fromJSON(steps.target-config.outputs.enable_tflint)
       with:
         github_token: ${{ inputs.github_token }}
         working_directory: ${{ steps.target-config.outputs.working_directory }}


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/tfaction/discussions/957
- https://github.com/aquasecurity/tfsec/discussions/1994
- https://github.com/aquasecurity/tfsec/blob/master/docs/index.md#-tfsec-to-trivy-migration

Update `test` action to support running `trivy config` command.
You can run trivy instead of tfsec.

This pull request doesn't change the default behaviour, which means by default tfsec is run and trivy isn't run.
To run trivy instead of tfsec, you need to set up following to the below.

trivy is run with [suzuki-shunsuke/trivy-config-action](https://github.com/suzuki-shunsuke/trivy-config-action).

![image](https://github.com/suzuki-shunsuke/trivy-config-action/assets/13323303/e4d7f6f7-3df3-44bb-8f98-535173ce096e)

--

![image](https://github.com/suzuki-shunsuke/trivy-config-action/assets/13323303/2d0c6224-8ae4-42f0-80d8-06488ff18f56)

## Set up

1. Add `aquasecurity/trivy` to aqua.yaml

```sh
$ aqua g -i aquasecurity/trivy
```

2. Update `tfaction-root.yaml` to enable `trivy` and disable `tfsec`

tfaction-root.yaml

```yaml
tfsec:
  enabled: false # By default, this is true
trivy:
  enabled: true # By default, this is false
# tflint:
#   enabled: true # By default, this is true
```