### PR TITLE
fix(test-module): Fix ghcp argument to use implicitly GITHUB_TOKEN

### DIFF
--- a/test-module/action.yaml
+++ b/test-module/action.yaml
@@ -71,8 +71,7 @@ runs:
           fi
           ghcp commit -r "$GITHUB_REPOSITORY" -b "$GITHUB_HEAD_REF" \
             -m "docs($TFACTION_TARGET): generate Terraform Module document by terraform-docs" \
-            -C "$GITHUB_WORKSPACE" "$TFACTION_TARGET/README.md" \
-            --token "$GITHUB_APP_TOKEN"
+            -C "$GITHUB_WORKSPACE" "$TFACTION_TARGET/README.md"
           exit 1
         fi
 


### PR DESCRIPTION
Hi, I faced an error on `tfaction/test-module` action.

The bug is appeared  in v0.6.4, but the actual behavior seems to be broken for a long time.

Since `ghcp` uses `GITHUB_TOKEN` environment variable implicitly, we don't need to pass via `--token` argument.
See https://github.com/int128/ghcp#getting-started .

<img width="1492" alt="image" src="https://github.com/suzuki-shunsuke/tfaction/assets/802339/a69fe3ff-11a4-4b25-aca0-51564c3b917b">


Ref:
- https://github.com/suzuki-shunsuke/tfaction/pull/1110