### PR TITLE
feat(setup): update aqua-checksums.json

### DIFF
--- a/get-global-config/action.yaml
+++ b/get-global-config/action.yaml
@@ -30,6 +30,13 @@ outputs:
     description: If true, tflint is enabled in test action
   enable_trivy:
     description: If true, trivy is enabled in test action
+
+  aqua_update_checksum_enabled:
+    description: If true, aqua-checksums.json on working directories is updated
+  aqua_update_checksum_skip_push:
+    description: aqua update-checksum's `skip_push`
+  aqua_update_checksum_prune:
+    description: aqua update-checksum's `prune`
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/get-global-config/dist/index.js
+++ b/get-global-config/dist/index.js
@@ -6872,6 +6872,9 @@ try {
         core.setOutput('disable_update_related_pull_requests', 'false');
     }
     core.exportVariable('TFACTION_SKIP_ADDING_AQUA_PACKAGES', JSON.stringify(config.scaffold_working_directory && config.scaffold_working_directory.skip_adding_aqua_packages));
+    core.setOutput('aqua_update_checksum_enable', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.enabled !== false);
+    core.setOutput('aqua_update_checksum_skip_push', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.skip_push);
+    core.setOutput('aqua_update_checksum_prune', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.prune);
     core.setOutput('enable_tfsec', config.tfsec == null || config.tfsec.enabled == null || config.tfsec.enabled);
     core.setOutput('enable_tflint', config.tflint == null || config.tflint.enabled == null || config.tflint.enabled);
     core.setOutput('enable_trivy', config.trivy != null && config.trivy.enabled);

--- a/get-global-config/dist/index.js
+++ b/get-global-config/dist/index.js
@@ -6872,7 +6872,7 @@ try {
         core.setOutput('disable_update_related_pull_requests', 'false');
     }
     core.exportVariable('TFACTION_SKIP_ADDING_AQUA_PACKAGES', JSON.stringify(config.scaffold_working_directory && config.scaffold_working_directory.skip_adding_aqua_packages));
-    core.setOutput('aqua_update_checksum_enable', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.enabled !== false);
+    core.setOutput('aqua_update_checksum_enabled', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.enabled !== false);
     core.setOutput('aqua_update_checksum_skip_push', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.skip_push);
     core.setOutput('aqua_update_checksum_prune', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.prune);
     core.setOutput('enable_tfsec', config.tfsec == null || config.tfsec.enabled == null || config.tfsec.enabled);

--- a/get-global-config/src/index.ts
+++ b/get-global-config/src/index.ts
@@ -49,7 +49,7 @@ try {
   }
   core.exportVariable('TFACTION_SKIP_ADDING_AQUA_PACKAGES', JSON.stringify(config.scaffold_working_directory && config.scaffold_working_directory.skip_adding_aqua_packages));
 
-  core.setOutput('aqua_update_checksum_enable', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.enabled !== false);
+  core.setOutput('aqua_update_checksum_enabled', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.enabled !== false);
   core.setOutput('aqua_update_checksum_skip_push', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.skip_push);
   core.setOutput('aqua_update_checksum_prune', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.prune);
 

--- a/get-global-config/src/index.ts
+++ b/get-global-config/src/index.ts
@@ -49,6 +49,10 @@ try {
   }
   core.exportVariable('TFACTION_SKIP_ADDING_AQUA_PACKAGES', JSON.stringify(config.scaffold_working_directory && config.scaffold_working_directory.skip_adding_aqua_packages));
 
+  core.setOutput('aqua_update_checksum_enable', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.enabled !== false);
+  core.setOutput('aqua_update_checksum_skip_push', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.skip_push);
+  core.setOutput('aqua_update_checksum_prune', config.aqua && config.aqua.update_checksum && config.aqua.update_checksum.prune);
+
   core.setOutput('enable_tfsec', config.tfsec == null || config.tfsec.enabled == null || config.tfsec.enabled);
   core.setOutput('enable_tflint', config.tflint == null || config.tflint.enabled == null || config.tflint.enabled);
   core.setOutput('enable_trivy', config.trivy != null && config.trivy.enabled);

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -43,12 +43,10 @@ runs:
       id: target-config
 
     - uses: aquaproj/update-checksum-action@2fb7f676d407d4fb8c2c466c19d09d3ddec4f82f # v0.2.2
-      # if: steps.global-config.outputs.enable_aqua_update_checksum == 'true'
+      if: steps.global-config.outputs.aqua_update_checksum_enabled == 'true'
       with:
-        skip_push: "false"
-        prune: "true"
-        # skip_push: ${{steps.global-config.outputs.aqua_update_checksum_skip_push}}
-        # prune: ${{steps.global-config.outputs.aqua_update_checksum_prune}}
+        skip_push: ${{ steps.global-config.outputs.aqua_update_checksum_skip_push }}
+        prune: ${{ steps.global-config.outputs.aqua_update_checksum_prune }}
         working_directory: ${{ steps.target-config.outputs.working_directory }}
       env:
         GITHUB_TOKEN: ${{inputs.github_app_token}}

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -36,8 +36,22 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
+    - uses: suzuki-shunsuke/tfaction/get-global-config@main
+      id: global-config
+
     - uses: suzuki-shunsuke/tfaction/get-target-config@main
       id: target-config
+
+    - uses: aquaproj/update-checksum-action@2fb7f676d407d4fb8c2c466c19d09d3ddec4f82f # v0.2.2
+      # if: steps.global-config.outputs.enable_aqua_update_checksum == 'true'
+      with:
+        skip_push: "false"
+        prune: "true"
+        # skip_push: ${{steps.global-config.outputs.aqua_update_checksum_skip_push}}
+        # prune: ${{steps.global-config.outputs.aqua_update_checksum_prune}}
+        working_directory: ${{ steps.target-config.outputs.working_directory }}
+      env:
+        GITHUB_TOKEN: ${{inputs.github_app_token}}
 
     - run: aqua i -l -a
       shell: bash


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/tfaction-docs/pull/128

Support updating `aqua-checksums.json` by [aquaproj/update-checksum-action](https://github.com/aquaproj/update-checksum-action).
By default, this feature is disabled.
To enable it, please configure it in `tfaction-root.yaml`.

tfaction-root.yaml

```yaml
aqua:
  update_checksum:
    # Update aqua-checksums.json in `setup` action
    enabled: true # default is false
    skip_push: false # default is false
    prune: true # default is false
```