### PR TITLE
feat: support merging jobs for tfmigrate and terraform

### DIFF
--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -1,0 +1,25 @@
+name: apply
+description: apply
+inputs:
+  github_app_token:
+    description: 'GitHub Access Token'
+    required: true
+
+  github_token:
+    description: 'GitHub Access Token'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - uses: suzuki-shunsuke/tfaction/terraform-apply@main
+      if: env.TFACTION_JOB_TYPE == 'terraform'
+      with:
+        github_app_token: ${{inputs.github_app_token}}
+        github_token: ${{inputs.github_token}}
+
+    - uses: suzuki-shunsuke/tfaction/tfmigrate-apply@main
+      if: env.TFACTION_JOB_TYPE == 'tfmigrate'
+      with:
+        github_app_token: ${{inputs.github_app_token}}
+        github_token: ${{inputs.github_token}}

--- a/list-targets-with-changed-files/action.yaml
+++ b/list-targets-with-changed-files/action.yaml
@@ -22,6 +22,8 @@ outputs:
     description: list of tfmigrate targets
   terraform_targets:
     description: list of terraform targets
+  targets:
+    description: list of targets
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/list-targets-with-changed-files/dist/index.js
+++ b/list-targets-with-changed-files/dist/index.js
@@ -13662,6 +13662,7 @@ function getTargetConfigByTarget(targets, target, isApply, jobType) {
                 runs_on: t.runs_on ? t.runs_on : 'ubuntu-latest',
                 environment: t.environment ? t.environment : null,
                 secrets: t.secrets,
+                job_type: jobType,
             };
         }
         return {
@@ -13669,6 +13670,7 @@ function getTargetConfigByTarget(targets, target, isApply, jobType) {
             runs_on: jobConfig.runs_on ? jobConfig.runs_on : (t.runs_on ? t.runs_on : 'ubuntu-latest'),
             environment: jobConfig.environment ? jobConfig.environment : (t.environment ? t.environment : null),
             secrets: jobConfig.secrets ? jobConfig.secrets : t.secrets,
+            job_type: jobType,
         };
     }
     throw 'target is invalid';
@@ -13783,6 +13785,7 @@ try {
     }
     core.setOutput('tfmigrate_targets', tfmigrateObjs);
     core.setOutput('terraform_targets', terraformTargetObjs);
+    core.setOutput('targets', terraformTargetObjs.concat(tfmigrateObjs));
 }
 catch (error) {
     core.setFailed(error instanceof Error ? error.message : JSON.stringify(error));

--- a/list-targets-with-changed-files/src/index.ts
+++ b/list-targets-with-changed-files/src/index.ts
@@ -7,6 +7,7 @@ import * as lib from './lib';
 interface TargetConfig {
   target: string
   runs_on: string
+  job_type: string
   environment: string | object | null
   secrets: object | undefined
 }
@@ -24,6 +25,7 @@ function getTargetConfigByTarget(targets: Array<lib.TargetConfig>, target: strin
         runs_on: t.runs_on ? t.runs_on : 'ubuntu-latest',
         environment: t.environment ? t.environment : null,
         secrets: t.secrets,
+        job_type: jobType,
       };
     }
     return {
@@ -31,6 +33,7 @@ function getTargetConfigByTarget(targets: Array<lib.TargetConfig>, target: strin
       runs_on: jobConfig.runs_on ? jobConfig.runs_on : (t.runs_on ? t.runs_on : 'ubuntu-latest'),
       environment: jobConfig.environment ? jobConfig.environment : (t.environment ? t.environment : null),
       secrets: jobConfig.secrets ? jobConfig.secrets : t.secrets,
+      job_type: jobType,
     };
   }
   throw 'target is invalid';
@@ -158,6 +161,7 @@ try {
 
   core.setOutput('tfmigrate_targets', tfmigrateObjs);
   core.setOutput('terraform_targets', terraformTargetObjs);
+  core.setOutput('targets', terraformTargetObjs.concat(tfmigrateObjs));
 } catch (error) {
   core.setFailed(error instanceof Error ? error.message : JSON.stringify(error));
 }

--- a/list-targets/action.yaml
+++ b/list-targets/action.yaml
@@ -15,6 +15,10 @@ outputs:
   modules:
     description: list of changed modules
     value: ${{ steps.list-modules.outputs.modules }}
+
+  targets:
+    description: list of targets
+    value: ${{ steps.list-targets.outputs.targets }}
 runs:
   using: composite
   steps:

--- a/plan/action.yaml
+++ b/plan/action.yaml
@@ -1,0 +1,25 @@
+name: plan
+description: plan
+inputs:
+  github_app_token:
+    description: 'GitHub Access Token'
+    required: true
+
+  github_token:
+    description: 'GitHub Access Token'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - uses: suzuki-shunsuke/tfaction/terraform-plan@main
+      if: env.TFACTION_JOB_TYPE == 'terraform'
+      with:
+        github_app_token: ${{inputs.github_app_token}}
+        github_token: ${{inputs.github_token}}
+
+    - uses: suzuki-shunsuke/tfaction/tfmigrate-plan@main
+      if: env.TFACTION_JOB_TYPE == 'tfmigrate'
+      with:
+        github_app_token: ${{inputs.github_app_token}}
+        github_token: ${{inputs.github_token}}


### PR DESCRIPTION
Close #223

Added new actions `plan` and `apply`.
You can replace actions `terraform-plan` and `tfmigrate-plan` with `plan`, and can replace `terraform-apply` and `tfmigrate-apply` with `apply`.
You can merge jobs for `tfmigrate` with jobs for `terraform`.
You can simplify workflows.

This pull request keeps the compatibility.

## How to merge jobs

1. Fix outputs of `setup` job
1. Remove jobs for tfmigrate
1. (Optional) Rename jobs `terraform-plan` and `terraform-apply` to `plan` and `apply`
1. Fix `TFACTION_JOB_TYPE`
1. Replace actions `terraform-plan` and `terraform-apply` with `plan` and `apply`

### 1. Fix outputs of `setup` job

Before

```yaml
    outputs:
      tfmigrate_targets: ${{ steps.list-targets.outputs.tfmigrate_targets }}
      terraform_targets: ${{ steps.list-targets.outputs.terraform_targets }}
```

```yaml
      matrix:
        target: ${{fromJSON(needs.setup.outputs.terraform_targets)}}
```

After

```yaml
    outputs:
      targets: ${{ steps.list-targets.outputs.targets }}
```

```yaml
      matrix:
        target: ${{fromJSON(needs.setup.outputs.targets)}}
```

### 4. Fix `TFACTION_JOB_TYPE`

Before

```yaml
TFACTION_JOB_TYPE: terraform
```

After

```yaml
TFACTION_JOB_TYPE: ${{matrix.target.job_type}}
```

### 5. Replace actions `terraform-plan` and `terraform-apply` with `plan` and `apply`

You don't need to change inputs.

Before

```yaml
     - uses: suzuki-shunsuke/tfaction/terraform-plan@v0.7.3
```

```yaml
     - uses: suzuki-shunsuke/tfaction/terraform-apply@v0.7.3
```

After

```yaml
     - uses: suzuki-shunsuke/tfaction/plan@v0.7.4
```

```yaml
     - uses: suzuki-shunsuke/tfaction/apply@v0.7.4
```