### PR TITLE
feat(scaffold-module): require module templates

### DIFF
--- a/create-scaffold-module-pr/action.yaml
+++ b/create-scaffold-module-pr/action.yaml
@@ -9,10 +9,6 @@ inputs:
       pull-requests:write - Create pull requests
     required: true
 
-  module_path:
-    description: 'Module path'
-    required: true
-
 runs:
   using: composite
   steps:
@@ -22,39 +18,34 @@ runs:
       shell: bash
       if: inputs.github_token == ''
     - run: |
-        echo "::error ::module_path is required"
+        echo "::error ::env.TFACTION_MODULE_PATH is required"
         exit 1
       shell: bash
-      if: inputs.module_path == ''
+      if: env.TFACTION_MODULE_PATH == ''
 
     - uses: suzuki-shunsuke/tfaction/get-global-config@main
       id: global-config
 
     - run: aqua i -l -a
       shell: bash
-      working-directory: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
 
     - run: |
-        echo "branch=scaffold-module-${MODULE_PATH/\//_}-$(date +%Y%m%dT%H%M%S)" >> "$GITHUB_OUTPUT"
+        echo "branch=scaffold-module-${TFACTION_MODULE_PATH/\//_}-$(date +%Y%m%dT%H%M%S)" >> "$GITHUB_OUTPUT"
       id: branch
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
 
-    - run: git add "$MODULE_PATH"
+    - run: git add "$TFACTION_MODULE_PATH"
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
 
     - run: |
         git diff --cached --name-only |
           xargs ghcp commit -r "$GITHUB_REPOSITORY" \
             -b "${{steps.branch.outputs.branch}}" \
-            -m "chore($MODULE_PATH): scaffold a Terraform Module"
+            -m "chore($TFACTION_MODULE_PATH): scaffold a Terraform Module"
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        MODULE_PATH: ${{inputs.module_path}}
 
     - run: |
         draft_pr=""
@@ -70,7 +61,7 @@ runs:
         $CODE_BLOCK
         gh pr create -R "$GITHUB_REPOSITORY" $draft_pr\\
           -H "${{steps.branch.outputs.branch}}" \\
-          -t "Scaffold a Terraform Module (${MODULE_PATH})" \\
+          -t "Scaffold a Terraform Module (${TFACTION_MODULE_PATH})" \\
           -b "This pull request was created by [GitHub Actions]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
         $CODE_BLOCK
 
@@ -79,11 +70,10 @@ runs:
       if: "fromJSON(steps.global-config.outputs.skip_create_pr)"
       shell: bash
       env:
-        MODULE_PATH: ${{inputs.module_path}}
         CODE_BLOCK: "```"
 
     - run: |
-        opts=(-H "${{steps.branch.outputs.branch}}" -a "$GITHUB_ACTOR" -t "Scaffold a Terraform Module (${MODULE_PATH})" -b "@$GITHUB_ACTOR This pull request was created by [GitHub Actions workflow_dispatch event]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)")
+        opts=(-H "${{steps.branch.outputs.branch}}" -a "$GITHUB_ACTOR" -t "Scaffold a Terraform Module (${TFACTION_MODULE_PATH})" -b "@$GITHUB_ACTOR This pull request was created by [GitHub Actions workflow_dispatch event]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)")
         if [ "${{steps.global-config.outputs.draft_pr}}" = "true" ]; then
           opts+=( -d )
         fi
@@ -92,4 +82,3 @@ runs:
       if: "!fromJSON(steps.global-config.outputs.skip_create_pr)"
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        MODULE_PATH: ${{inputs.module_path}}

--- a/scaffold-module/action.yaml
+++ b/scaffold-module/action.yaml
@@ -9,10 +9,6 @@ inputs:
       pull-requests:write - Create pull requests
     required: true
 
-  module_path:
-    description: 'Module path'
-    required: true
-
 runs:
   using: composite
   steps:
@@ -22,87 +18,93 @@ runs:
       shell: bash
       if: inputs.github_token == ''
     - run: |
-        echo "::error ::module_path is required"
+        echo "::error ::env.TFACTION_MODULE_PATH is required"
         exit 1
       shell: bash
-      if: inputs.module_path == ''
+      if: env.TFACTION_MODULE_PATH == ''
+    - run: |
+        echo "::error ::env.TFACTION_MODULE_TEMPLATE_DIR is required"
+        exit 1
+      shell: bash
+      if: env.TFACTION_MODULE_TEMPLATE_DIR == ''
 
     - run: |
-        if [ -e "${MODULE_PATH}" ]; then
+        if [ -e "${TFACTION_MODULE_PATH}" ]; then
           echo "::error ::file exists"
           exit 1
         fi
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
+
+    - run: |
+        if [ ! -d "${TFACTION_MODULE_TEMPLATE_DIR}" ]; then
+          echo "::error ::$TFACTION_MODULE_TEMPLATE_DIR doesn't exist"
+          exit 1
+        fi
+      shell: bash
 
     - uses: suzuki-shunsuke/tfaction/get-global-config@main
       id: global-config
 
     - run: |
-        mkdir -p "$(dirname "$MODULE_PATH")"
+        mkdir -p "$(dirname "$TFACTION_MODULE_PATH")"
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
 
-    - run: cp -R "${GITHUB_ACTION_PATH}/template" "$MODULE_PATH"
+    - run: cp -R "${TFACTION_MODULE_TEMPLATE_DIR}" "$TFACTION_MODULE_PATH"
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
 
-    - run: |
-        sed -i "s|%%MODULE_NAME%%|$(basename "$MODULE_PATH")|g" "${MODULE_PATH}/docs/header.md"
+    - run: git add .
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
 
     - run: |
-        sed -i "s|%%MODULE_PATH%%|$MODULE_PATH|g" "${MODULE_PATH}/docs/header.md"
+        git ls-files | xargs -n 1 sed -i "s|%%MODULE_NAME%%|$(basename "$TFACTION_MODULE_PATH")|g"
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
 
     - run: |
-        sed -i "s|%%GITHUB_REPOSITORY%%|$GITHUB_REPOSITORY|g" "${MODULE_PATH}/docs/header.md"
+        git ls-files | xargs -n 1 sed -i "s|%%MODULE_PATH%%|$MODULE_PATH|g"
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
 
     - run: |
-        sed -i "s|%%REF%%|module_${MODULE_PATH/\//_}_v0.1.0|g" "${MODULE_PATH}/docs/header.md"
+        git ls-files | xargs -n 1 sed -i "s|%%GITHUB_REPOSITORY%%|$GITHUB_REPOSITORY|g"
       shell: bash
-      env:
-        MODULE_PATH: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
+
+    - run: |
+        git ls-files | xargs -n 1 sed -i "s|%%REF%%|module_${MODULE_PATH/\//_}_v0.1.0|g"
+      shell: bash
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
 
     - run: aqua init
       shell: bash
-      working-directory: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
       if: env.TFACTION_SKIP_ADDING_AQUA_PACKAGES != 'true'
 
     - run: aqua g -i hashicorp/terraform
       shell: bash
-      working-directory: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
       if: env.TFACTION_SKIP_ADDING_AQUA_PACKAGES != 'true'
 
     - run: aqua g -i aquasecurity/tfsec
       shell: bash
-      working-directory: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
       if: env.TFACTION_SKIP_ADDING_AQUA_PACKAGES != 'true' && fromJSON(steps.global-config.outputs.enable_tfsec)
 
     - run: aqua g -i aquasecurity/trivy
       shell: bash
-      working-directory: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
       if: env.TFACTION_SKIP_ADDING_AQUA_PACKAGES != 'true' && fromJSON(steps.global-config.outputs.enable_trivy)
 
     - run: aqua g -i terraform-linters/tflint
       shell: bash
-      working-directory: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
       if: env.TFACTION_SKIP_ADDING_AQUA_PACKAGES != 'true' && fromJSON(steps.global-config.outputs.enable_tflint)
 
     - run: aqua i -l -a
       shell: bash
-      working-directory: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}
 
     - run: terraform-docs . > README.md
       shell: bash
-      working-directory: ${{inputs.module_path}}
+      working-directory: ${{env.TFACTION_MODULE_PATH}}

--- a/test-module/action.yaml
+++ b/test-module/action.yaml
@@ -14,16 +14,6 @@ runs:
     - uses: suzuki-shunsuke/tfaction/get-global-config@main
       id: global-config
 
-    - run: |
-        github-comment exec \
-          -config "${GITHUB_ACTION_PATH}/github-comment.yaml" \
-          -var "tfaction_target:${TFACTION_TARGET}" \
-          -- terraform init -input=false
-      shell: bash
-      working-directory: ${{ env.TFACTION_TARGET }}
-      env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-
     - uses: suzuki-shunsuke/trivy-config-action@53935fc85b2ba4e195ad91b3be0ef454e33f905d # v0.2.0
       if: fromJSON(steps.global-config.outputs.enable_trivy)
       with:


### PR DESCRIPTION
## Overview

Actions `scaffold-module`, `create-scaffold-module-pr`, `test-module` are changed.

1. Templates for Terraform Modules are required.
2. Stop running `terraform init` in `test-module` action

## Why?

Users can customize templates of Terraform Modules.

## ⚠️ Breaking Changes

The action `scaffold-module` is changed.

- Remove the input `module_path`
- Add mandatory environment variables `TFACTION_MODULE_PATH` and `TFACTION_MODULE_TEMPLATE_DIR`
- Templates for scaffolding Terraform Modules are required

## How to migrate

- Remove the input `module_path`
- Set environment variables `TFACTION_MODULE_PATH` and `TFACTION_MODULE_TEMPLATE_DIR`
- Add templates for scaffolding Terraform Modules

Before

```yaml
on:
  workflow_dispatch:
    inputs:
      module_path:
        description: 'module path'
        required: true
jobs:
  scaffold:
    # ...
    steps:
      # ...
      - uses: suzuki-shunsuke/tfaction/scaffold-module@v0.7.3
        with:
          github_token: ${{steps.generate_token.outputs.token}}
          module_path: ${{inputs.module_path}}
```

After

```yaml
on:
  workflow_dispatch:
    inputs:
      module_path:
        description: 'module path'
        required: true
      template_dir: # Add the input
        type: choice
        default: templates/module-aws
        options:
          - templates/module-aws
jobs:
  scaffold:
    # ...
    env: # Set environment variables
      TFACTION_MODULE_PATH: ${{inputs.module_path}}
      TFACTION_MODULE_TEMPLATE_DIR: ${{inputs.template_dir}}
    steps:
      # ...
      - uses: suzuki-shunsuke/tfaction/scaffold-module@v1.0.0
        with: # Remove the input module_path
          github_token: ${{steps.generate_token.outputs.token}}
      - uses: suzuki-shunsuke/tfaction/create-scaffold-module-pr@v1.0.0
        with:
          github_token: ${{steps.generate_token.outputs.token}}  
```