### PR TITLE
docs: Fix topotal company name on who-uses-tfaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://suzuki-shunsuke.github.io/tfaction/docs/
 > [!NOTE]
 > If you want to add your company or organization to the list, please send a pull request or send a comment to the [GitHub Discussion](https://github.com/suzuki-shunsuke/tfaction/discussions/1280)!
 
-- [Topotal Inc](https://topotal.com/)
+- [Topotal, Inc.](https://topotal.com/)
 - Recruit Co., Ltd. - [StudySapuri](https://brand.studysapuri.jp/) and [Quipper](https://www.quipper.com/) product team
   - [Terraform の CI を AWS CodeBuild から GitHub Actions + tfaction に移行しました](https://blog.studysapuri.jp/entry/2022/02/04/080000)
   - [Migrate Terraform CI from AWS CodeBuild to GitHub Actions](https://devs.quipper.com/2022/02/25/terraform-github-actions.html)


### PR DESCRIPTION
Hi, I’m @nari-ex from Topotal, Inc.

Thank you for your continuous great products as always. I was testing 1.0.0-2 today :v:

We forgot to add a comma and period when adding our company name to the who-uses list the other day.
So I would appreciate it if you could correct the company name.

If there are any other corrections, I would appreciate it if you could let me know.