### PR TITLE
fix(apply): specify github-comment config

### DIFF
--- a/terraform-apply/download_plan_file.sh
+++ b/terraform-apply/download_plan_file.sh
@@ -16,7 +16,7 @@ run_id=$(echo "$body" | jq -r ".databaseId")
 head_sha=$(echo "$body" | jq -r ".headSha")
 
 if [ "$head_sha" != "$pr_head_sha" ]; then
-	echo "::error::workflow run's headSha is different from the associated pull request's head sha"
+	echo "::error::workflow run's headSha ($head_sha) is different from the associated pull request's head sha ($pr_head_sha)"
 	github-comment post \
 		-config "${GITHUB_ACTION_PATH}/github-comment.yaml" \
 		-k invalid-workflow-sha \

--- a/terraform-apply/download_plan_file.sh
+++ b/terraform-apply/download_plan_file.sh
@@ -10,7 +10,9 @@ workflow=$PLAN_WORKFLOW_NAME
 pr_head_sha=$(jq -r ".head.sha" "$CI_INFO_TEMP_DIR/pr.json")
 
 # https://github.com/suzuki-shunsuke/tfaction/pull/1570#issuecomment-1987382651
-# We don't use gh run list's -c option because this requires GitHub CLI v2.40.0 or newer.
+# We don't use gh run list's -c option because 
+# 1. this requires GitHub CLI v2.40.0 or newer
+# 2. we should check the latest workflow run
 body=$(gh run list -w "$workflow" -b "$branch" -L 1 --json headSha,databaseId --jq '.[0]')
 run_id=$(echo "$body" | jq -r ".databaseId")
 head_sha=$(echo "$body" | jq -r ".headSha")

--- a/terraform-apply/download_plan_file.sh
+++ b/terraform-apply/download_plan_file.sh
@@ -9,14 +9,19 @@ workflow=$PLAN_WORKFLOW_NAME
 
 pr_head_sha=$(jq -r ".head.sha" "$CI_INFO_TEMP_DIR/pr.json")
 
+# https://github.com/suzuki-shunsuke/tfaction/pull/1570#issuecomment-1987382651
+# We don't use gh run list's -c option because this requires GitHub CLI v2.40.0 or newer.
 body=$(gh run list -w "$workflow" -b "$branch" -L 1 --json headSha,databaseId --jq '.[0]')
 run_id=$(echo "$body" | jq -r ".databaseId")
 head_sha=$(echo "$body" | jq -r ".headSha")
 
 if [ "$head_sha" != "$pr_head_sha" ]; then
 	echo "::error::workflow run's headSha is different from the associated pull request's head sha"
-	github-comment post -k invalid-workflow-sha \
-		-var "wf_sha:$head_sha" -var "pr_sha:$pr_head_sha"
+	github-comment post \
+		-config "${GITHUB_ACTION_PATH}/github-comment.yaml" \
+		-k invalid-workflow-sha \
+		-var "wf_sha:$head_sha" \
+		-var "pr_sha:$pr_head_sha"
 	exit 1
 fi
 


### PR DESCRIPTION
This pr fixes a bug `the template invalid-workflow-sha isn't found`.