### PR TITLE
fix(export-secrets): output secret names for troubleshooting

### DIFF
--- a/export-secrets/dist/index.js
+++ b/export-secrets/dist/index.js
@@ -28844,6 +28844,9 @@ const lib = __importStar(__nccwpck_require__(9730));
 try {
     const config = lib.getConfig();
     const secrets = new Map(Object.entries(JSON.parse(core.getInput("secrets"))));
+    // Log the list of secrets for troubleshooting
+    // https://github.com/suzuki-shunsuke/tfaction/issues/1564
+    core.info(`The list of secret names passed to the action: ${Array.from(secrets.keys()).join(", ")}`);
     const targetS = lib.getTarget();
     const jobType = lib.getJobType();
     const isApply = lib.getIsApply();

--- a/export-secrets/src/index.ts
+++ b/export-secrets/src/index.ts
@@ -9,7 +9,9 @@ try {
 
   // Log the list of secrets for troubleshooting
   // https://github.com/suzuki-shunsuke/tfaction/issues/1564
-  core.info(`The list of secret names passed to the action: ${Array.from(secrets.keys()).join(", ")}`);
+  core.info(
+    `The list of secret names passed to the action: ${Array.from(secrets.keys()).join(", ")}`,
+  );
 
   const targetS = lib.getTarget();
   const jobType = lib.getJobType();

--- a/export-secrets/src/index.ts
+++ b/export-secrets/src/index.ts
@@ -6,6 +6,11 @@ try {
   const secrets = new Map<string, string>(
     Object.entries(JSON.parse(core.getInput("secrets"))),
   );
+
+  // Log the list of secrets for troubleshooting
+  // https://github.com/suzuki-shunsuke/tfaction/issues/1564
+  core.info(`The list of secret names passed to the action: ${Array.from(secrets.keys()).join(", ")}`);
+
   const targetS = lib.getTarget();
   const jobType = lib.getJobType();
   const isApply = lib.getIsApply();


### PR DESCRIPTION
This pull request updates the action `export-secrets` and outputs secret names passed to the action for troubleshooting.
The log is useful to check if secrets are passed to the action properly.

If secrets aren't passed properly, this isn't a bug of tfaction.
You have to check your workflow and the usage of tfaction.

- https://github.com/suzuki-shunsuke/tfaction/issues/1564