### PR TITLE
feat(setup): support setting `google-github-actions/auth`'s `access_token_scopes`

### DIFF
--- a/check-terraform-skip/dist/index.js
+++ b/check-terraform-skip/dist/index.js
@@ -24783,6 +24783,7 @@ const JobConfig = zod_1.z.object({
     aws_assume_role_arn: zod_1.z.optional(zod_1.z.string()),
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
+    gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
     runs_on: zod_1.z.optional(zod_1.z.string()),

--- a/export-aws-secrets-manager/dist/index.js
+++ b/export-aws-secrets-manager/dist/index.js
@@ -44847,6 +44847,7 @@ const JobConfig = zod_1.z.object({
     aws_assume_role_arn: zod_1.z.optional(zod_1.z.string()),
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
+    gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
     runs_on: zod_1.z.optional(zod_1.z.string()),

--- a/get-global-config/dist/index.js
+++ b/get-global-config/dist/index.js
@@ -24783,6 +24783,7 @@ const JobConfig = zod_1.z.object({
     aws_assume_role_arn: zod_1.z.optional(zod_1.z.string()),
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
+    gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
     runs_on: zod_1.z.optional(zod_1.z.string()),

--- a/get-target-config/action.yaml
+++ b/get-target-config/action.yaml
@@ -13,6 +13,8 @@ outputs:
     description: Google Cloud Platform Service Account for GCP Workload Identity Federation
   gcp_workload_identity_provider:
     description: Google Cloud Platform Identity Provider for GCP Workload Identity Federation
+  gcp_access_token_scopes:
+    description: List of OAuth 2.0 access scopes to be included in the generated token for authenticating to Google Cloud
 
   s3_bucket_name_tfmigrate_history:
     description: S3 Bucket name for tfmigrate history files

--- a/get-target-config/dist/index.js
+++ b/get-target-config/dist/index.js
@@ -24783,6 +24783,7 @@ const JobConfig = zod_1.z.object({
     aws_assume_role_arn: zod_1.z.optional(zod_1.z.string()),
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
+    gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
     runs_on: zod_1.z.optional(zod_1.z.string()),
@@ -58099,6 +58100,7 @@ const run = (inputs, config) => {
             "aws_assume_role_arn",
             "gcp_service_account",
             "gcp_workload_identity_provider",
+            "gcp_access_token_scopes",
         ], [targetConfig]);
         for (const [key, value] of m) {
             outputs.set(key, value);
@@ -58122,6 +58124,7 @@ const run = (inputs, config) => {
             "aws_assume_role_arn",
             "gcp_service_account",
             "gcp_workload_identity_provider",
+            "gcp_access_token_scopes",
         ], [jobConfig, wdConfig, rootJobConfig, targetConfig, config]);
         for (const [key, value] of m2) {
             outputs.set(key, value);

--- a/get-target-config/src/run.ts
+++ b/get-target-config/src/run.ts
@@ -94,6 +94,7 @@ export const run = (inputs: Inputs, config: lib.Config): Result => {
         "aws_assume_role_arn",
         "gcp_service_account",
         "gcp_workload_identity_provider",
+        "gcp_access_token_scopes",
       ],
       [targetConfig],
     );
@@ -135,6 +136,7 @@ export const run = (inputs: Inputs, config: lib.Config): Result => {
         "aws_assume_role_arn",
         "gcp_service_account",
         "gcp_workload_identity_provider",
+        "gcp_access_token_scopes",
       ],
       [jobConfig, wdConfig, rootJobConfig, targetConfig, config],
     );

--- a/lib/dist/index.d.ts
+++ b/lib/dist/index.d.ts
@@ -98,6 +98,7 @@ declare const JobConfig: z.ZodObject<{
     aws_assume_role_arn: z.ZodOptional<z.ZodString>;
     gcp_service_account: z.ZodOptional<z.ZodString>;
     gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+    gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
     environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
         name: z.ZodString;
         url: z.ZodString;
@@ -158,6 +159,7 @@ declare const JobConfig: z.ZodObject<{
     aws_assume_role_arn?: string | undefined;
     gcp_service_account?: string | undefined;
     gcp_workload_identity_provider?: string | undefined;
+    gcp_access_token_scopes?: string | undefined;
     environment?: string | {
         url: string;
         name: string;
@@ -182,6 +184,7 @@ declare const JobConfig: z.ZodObject<{
     aws_assume_role_arn?: string | undefined;
     gcp_service_account?: string | undefined;
     gcp_workload_identity_provider?: string | undefined;
+    gcp_access_token_scopes?: string | undefined;
     environment?: string | {
         url: string;
         name: string;
@@ -240,6 +243,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn: z.ZodOptional<z.ZodString>;
         gcp_service_account: z.ZodOptional<z.ZodString>;
         gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+        gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
         environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
             name: z.ZodString;
             url: z.ZodString;
@@ -300,6 +304,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -324,6 +329,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -349,6 +355,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn: z.ZodOptional<z.ZodString>;
         gcp_service_account: z.ZodOptional<z.ZodString>;
         gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+        gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
         environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
             name: z.ZodString;
             url: z.ZodString;
@@ -409,6 +416,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -433,6 +441,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -458,6 +467,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn: z.ZodOptional<z.ZodString>;
         gcp_service_account: z.ZodOptional<z.ZodString>;
         gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+        gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
         environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
             name: z.ZodString;
             url: z.ZodString;
@@ -518,6 +528,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -542,6 +553,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -567,6 +579,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn: z.ZodOptional<z.ZodString>;
         gcp_service_account: z.ZodOptional<z.ZodString>;
         gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+        gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
         environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
             name: z.ZodString;
             url: z.ZodString;
@@ -627,6 +640,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -651,6 +665,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -733,6 +748,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -758,6 +774,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -783,6 +800,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -808,6 +826,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -865,6 +884,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -890,6 +910,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -915,6 +936,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -940,6 +962,7 @@ declare const TargetGroup: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1005,6 +1028,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn: z.ZodOptional<z.ZodString>;
         gcp_service_account: z.ZodOptional<z.ZodString>;
         gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+        gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
         environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
             name: z.ZodString;
             url: z.ZodString;
@@ -1065,6 +1089,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1089,6 +1114,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1114,6 +1140,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn: z.ZodOptional<z.ZodString>;
         gcp_service_account: z.ZodOptional<z.ZodString>;
         gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+        gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
         environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
             name: z.ZodString;
             url: z.ZodString;
@@ -1174,6 +1201,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1198,6 +1226,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1223,6 +1252,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn: z.ZodOptional<z.ZodString>;
         gcp_service_account: z.ZodOptional<z.ZodString>;
         gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+        gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
         environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
             name: z.ZodString;
             url: z.ZodString;
@@ -1283,6 +1313,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1307,6 +1338,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1332,6 +1364,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn: z.ZodOptional<z.ZodString>;
         gcp_service_account: z.ZodOptional<z.ZodString>;
         gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+        gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
         environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
             name: z.ZodString;
             url: z.ZodString;
@@ -1392,6 +1425,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1416,6 +1450,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1459,6 +1494,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1484,6 +1520,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1509,6 +1546,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1534,6 +1572,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1577,6 +1616,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1602,6 +1642,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1627,6 +1668,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1652,6 +1694,7 @@ declare const TargetConfig: z.ZodObject<{
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
+        gcp_access_token_scopes?: string | undefined;
         environment?: string | {
             url: string;
             name: string;
@@ -1787,6 +1830,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn: z.ZodOptional<z.ZodString>;
             gcp_service_account: z.ZodOptional<z.ZodString>;
             gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+            gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
             environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
                 name: z.ZodString;
                 url: z.ZodString;
@@ -1847,6 +1891,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -1871,6 +1916,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -1896,6 +1942,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn: z.ZodOptional<z.ZodString>;
             gcp_service_account: z.ZodOptional<z.ZodString>;
             gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+            gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
             environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
                 name: z.ZodString;
                 url: z.ZodString;
@@ -1956,6 +2003,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -1980,6 +2028,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2005,6 +2054,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn: z.ZodOptional<z.ZodString>;
             gcp_service_account: z.ZodOptional<z.ZodString>;
             gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+            gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
             environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
                 name: z.ZodString;
                 url: z.ZodString;
@@ -2065,6 +2115,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2089,6 +2140,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2114,6 +2166,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn: z.ZodOptional<z.ZodString>;
             gcp_service_account: z.ZodOptional<z.ZodString>;
             gcp_workload_identity_provider: z.ZodOptional<z.ZodString>;
+            gcp_access_token_scopes: z.ZodOptional<z.ZodString>;
             environment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
                 name: z.ZodString;
                 url: z.ZodString;
@@ -2174,6 +2227,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2198,6 +2252,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2280,6 +2335,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2305,6 +2361,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2330,6 +2387,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2355,6 +2413,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2412,6 +2471,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2437,6 +2497,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2462,6 +2523,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2487,6 +2549,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2584,6 +2647,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2609,6 +2673,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2634,6 +2699,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2659,6 +2725,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2767,6 +2834,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2792,6 +2860,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2817,6 +2886,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;
@@ -2842,6 +2912,7 @@ declare const Config: z.ZodObject<{
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
+            gcp_access_token_scopes?: string | undefined;
             environment?: string | {
                 url: string;
                 name: string;

--- a/lib/dist/index.js
+++ b/lib/dist/index.js
@@ -75,6 +75,7 @@ const JobConfig = zod_1.z.object({
     aws_assume_role_arn: zod_1.z.optional(zod_1.z.string()),
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
+    gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
     runs_on: zod_1.z.optional(zod_1.z.string()),

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -78,6 +78,7 @@ const JobConfig = z.object({
   aws_assume_role_arn: z.optional(z.string()),
   gcp_service_account: z.optional(z.string()),
   gcp_workload_identity_provider: z.optional(z.string()),
+  gcp_access_token_scopes: z.optional(z.string()),
   environment: z.optional(GitHubEnvironment),
   secrets: z.optional(GitHubSecrets),
   runs_on: z.optional(z.string()),

--- a/list-targets-with-changed-files/dist/index.js
+++ b/list-targets-with-changed-files/dist/index.js
@@ -82,6 +82,7 @@ const JobConfig = zod_1.z.object({
     aws_assume_role_arn: zod_1.z.optional(zod_1.z.string()),
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
+    gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
     runs_on: zod_1.z.optional(zod_1.z.string()),

--- a/schema/tfaction-root.json
+++ b/schema/tfaction-root.json
@@ -52,6 +52,9 @@
           "gcp_workload_identity_provider": {
             "$ref": "#/$defs/GCPWorkloadIdentityProvider"
           },
+          "gcp_access_token_scopes": {
+            "$ref": "#/$defs/GCPAccessTokenScopes"
+          },
           "gcs_bucket_name_tfmigrate_history": {
             "$ref": "#/$defs/GCSBucketNameTfmigrateHistory"
           },
@@ -289,6 +292,10 @@
       "type": "string",
       "description": "GCP Workload Identity Provider"
     },
+    "GCPAccessTokenScopes": {
+      "type": "string",
+      "description": "List of OAuth 2.0 access scopes to be included in the generated token for authenticating to Google Cloud"
+    },
     "GCSBucketNamePlanFile": {
       "type": "string",
       "description": "GCS Bucket Name to store Terraform Plan files"
@@ -379,6 +386,9 @@
         },
         "gcp_workload_identity_provider": {
           "$ref": "#/$defs/GCPWorkloadIdentityProvider"
+        },
+        "gcp_access_token_scopes": {
+          "$ref": "#/$defs/GCPAccessTokenScopes"
         },
         "secrets": {
           "$ref": "#/$defs/Secrets"

--- a/schema/tfaction.json
+++ b/schema/tfaction.json
@@ -15,7 +15,6 @@
     "aws_secrets_manager": {
       "$ref": "#/$defs/AWSSecretsManager"
     },
-
     "drift_detection": {
       "type": "object",
       "required": [],
@@ -27,30 +26,27 @@
         }
       }
     },
-
     "envs": {
       "$ref": "#/$defs/Envs"
     },
-
     "gcp_workload_identity_provider": {
       "$ref": "#/$defs/GCPWorkloadIdentityProvider"
+    },
+    "gcp_access_token_scopes": {
+      "$ref": "#/$defs/GCPAccessTokenScopes"
     },
     "gcs_bucket_name_tfmigrate_history": {
       "$ref": "#/$defs/GCSBucketNameTfmigrateHistory"
     },
-
     "providers_lock_opts": {
       "$ref": "#/$defs/TerraformProvidersLockOptions"
     },
-
     "s3_bucket_name_tfmigrate_history": {
       "$ref": "#/$defs/S3BucketNameTfmigrateHistory"
     },
-
     "secrets": {
       "$ref": "#/$defs/Secrets"
     },
-
     "terraform_plan_config": {
       "$ref": "#/$defs/JobConfig",
       "description": "configuration which is used in the job for 'terraform plan'"
@@ -89,6 +85,10 @@
     "GCPWorkloadIdentityProvider": {
       "type": "string",
       "description": "GCP Workload Identity Provider"
+    },
+    "GCPAccessTokenScopes": {
+      "type": "string",
+      "description": "List of OAuth 2.0 access scopes to be included in the generated token for authenticating to Google Cloud"
     },
     "GCSBucketNamePlanFile": {
       "type": "string",
@@ -180,6 +180,9 @@
         },
         "gcp_workload_identity_provider": {
           "$ref": "#/$defs/GCPWorkloadIdentityProvider"
+        },
+        "gcp_access_token_scopes": {
+          "$ref": "#/$defs/GCPAccessTokenScopes"
         },
         "secrets": {
           "$ref": "#/$defs/Secrets"

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -101,7 +101,7 @@ runs:
         workload_identity_provider: ${{ steps.target-config.outputs.gcp_workload_identity_provider }}
         service_account: ${{ steps.target-config.outputs.gcp_service_account }}
         access_token_scopes: ${{ steps.target-config.outputs.gcp_access_token_scopes }}
-        token_format: ${{ steps.target-config.outputs.gcp_access_token_scopes == '' && '' || 'access_token' }}
+        token_format: ${{ steps.target-config.outputs.gcp_access_token_scopes != '' && 'access_token' || '' }}
 
     - uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
       if: steps.target-config.outputs.gcp_service_account != ''

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -100,6 +100,8 @@ runs:
       with:
         workload_identity_provider: ${{ steps.target-config.outputs.gcp_workload_identity_provider }}
         service_account: ${{ steps.target-config.outputs.gcp_service_account }}
+        access_token_scopes: ${{ steps.target-config.outputs.gcp_access_token_scopes }}
+        token_format: ${{ steps.target-config.outputs.gcp_access_token_scopes == '' && '' || 'access_token' }}
 
     - uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
       if: steps.target-config.outputs.gcp_service_account != ''


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/tfaction/discussions/1325
- https://github.com/google-github-actions/auth

This pull request adds the setting `gcp_access_token_scopes` to enable tfaction to set `google-github-actions/auth`'s `access_token_scopes`.

The format is same with `google-github-actions/auth`'s `access_token_scopes`.

tfaction-root.yaml

e.g.

```yaml
targets:
- working_directory: gcp/
  target: gcp/
  terraform_plan_config:
    gcp_access_token_scopes: 'https://www.googleapis.com/auth/cloud-platform, https://www.googleapis.com/auth/userinfo.email, https://www.googleapis.com/auth/apps.groups.settings, https://www.googleapis.com/auth/admin.directory.group'
```

tfaction.yaml

```yaml
terraform_plan_config:
  gcp_access_token_scopes: 'https://www.googleapis.com/auth/cloud-platform, https://www.googleapis.com/auth/userinfo.email, https://www.googleapis.com/auth/apps.groups.settings, https://www.googleapis.com/auth/admin.directory.group'
```