### PR TITLE
trim trailing whitespace in follow-up comments

### DIFF
--- a/list-targets-with-changed-files/dist/index.js
+++ b/list-targets-with-changed-files/dist/index.js
@@ -62814,6 +62814,7 @@ const run = (input) => {
     if (prBody.startsWith(followupPRBodyPrefix)) {
         followupTarget = prBody
             .split("\n")[0]
+            .trim()
             .slice(followupPRBodyPrefix.length, -" -->".length);
     }
     const terraformTargets = new Set();

--- a/list-targets-with-changed-files/src/run.ts
+++ b/list-targets-with-changed-files/src/run.ts
@@ -99,6 +99,7 @@ export const run = (input: Input): TargetConfig[] => {
   if (prBody.startsWith(followupPRBodyPrefix)) {
     followupTarget = prBody
       .split("\n")[0]
+      .trim()
       .slice(followupPRBodyPrefix.length, -" -->".length);
   }
 


### PR DESCRIPTION
It has been found that `\r\n` instead of `\n` is sometimes used as a line break code in prBody. If `\r\n` is used as a newline code, the detected target will contain extra spaces at the end.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/tfaction/issues/1661
- [x] [All commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
