### PR TITLE
fix: use regexp to handle follow up pr target

### DIFF
--- a/list-targets-with-changed-files/dist/index.js
+++ b/list-targets-with-changed-files/dist/index.js
@@ -83,6 +83,8 @@ const JobConfig = zod_1.z.object({
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
+    gcp_remote_backend_service_account: zod_1.z.optional(zod_1.z.string()),
+    gcp_remote_backend_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
     runs_on: zod_1.z.optional(zod_1.z.string()),
@@ -97,6 +99,8 @@ const TargetGroup = zod_1.z.object({
     environment: zod_1.z.optional(GitHubEnvironment),
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
+    gcp_remote_backend_service_account: zod_1.z.optional(zod_1.z.string()),
+    gcp_remote_backend_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     gcs_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
     runs_on: zod_1.z.optional(zod_1.z.string()),
     secrets: zod_1.z.optional(GitHubSecrets),
@@ -62807,16 +62811,12 @@ const run = (input) => {
         }
         workingDirs.add(path.dirname(configFile));
     }
+    // Expected followupPRBody include the line:
     // <!-- tfaction follow up pr target=foo -->
-    let followupTarget = "";
-    const followupPRBodyPrefix = "<!-- tfaction follow up pr target=";
+    const followupTargetCommentRegex = new RegExp(/<!-- tfaction follow up pr target=([^\s]+).*-->/, "s");
     const prBody = getPRBody(input.pr, input.payload);
-    if (prBody.startsWith(followupPRBodyPrefix)) {
-        followupTarget = prBody
-            .split("\n")[0]
-            .trim()
-            .slice(followupPRBodyPrefix.length, -" -->".length);
-    }
+    const matchResult = prBody.match(followupTargetCommentRegex);
+    const followupTarget = matchResult ? matchResult[1] : "";
     const terraformTargets = new Set();
     const tfmigrates = new Set();
     const skips = new Set();

--- a/list-targets-with-changed-files/src/run.test.ts
+++ b/list-targets-with-changed-files/src/run.test.ts
@@ -83,36 +83,59 @@ test("job config", () => {
   ]);
 });
 
+const prCommentConfig = {
+  plan_workflow_name: "plan",
+  target_groups: [
+    {
+      target: "foo/",
+      working_directory: "foo/",
+      runs_on: "macos-latest",
+      secrets: [
+        {
+          env_name: "GH_TOKEN",
+          secret_name: "GH_TOKEN",
+        },
+      ],
+      environment: "dev",
+    },
+    {
+      target: "yoo/",
+      working_directory: "yoo/services/",
+      runs_on: "ubuntu-latest",
+      environment: "yoo",
+    },
+    {
+      target: "zoo/",
+      working_directory: "zoo/",
+    },
+  ],
+};
+const prCommnetExpected = [
+  {
+    environment: "dev",
+    job_type: "terraform",
+    runs_on: "macos-latest",
+    secrets: [
+      {
+        env_name: "GH_TOKEN",
+        secret_name: "GH_TOKEN",
+      },
+    ],
+    target: "foo/dev",
+  },
+  {
+    environment: "yoo",
+    job_type: "terraform",
+    runs_on: "ubuntu-latest",
+    secrets: undefined,
+    target: "yoo/dev",
+  },
+];
+
 test("pr comment", () => {
   expect(
     run({
-      config: {
-        plan_workflow_name: "plan",
-        target_groups: [
-          {
-            target: "foo/",
-            working_directory: "foo/",
-            runs_on: "macos-latest",
-            secrets: [
-              {
-                env_name: "GH_TOKEN",
-                secret_name: "GH_TOKEN",
-              },
-            ],
-            environment: "dev",
-          },
-          {
-            target: "yoo/",
-            working_directory: "yoo/services/",
-            runs_on: "ubuntu-latest",
-            environment: "yoo",
-          },
-          {
-            target: "zoo/",
-            working_directory: "zoo/",
-          },
-        ],
-      },
+      config: prCommentConfig,
       isApply: false,
       labels: [],
       changedFiles: ["foo/dev/main.tf"],
@@ -125,27 +148,28 @@ test("pr comment", () => {
       },
       module_callers: {},
     }),
-  ).toStrictEqual([
-    {
-      environment: "dev",
-      job_type: "terraform",
-      runs_on: "macos-latest",
-      secrets: [
-        {
-          env_name: "GH_TOKEN",
-          secret_name: "GH_TOKEN",
+  ).toStrictEqual(prCommnetExpected);
+});
+
+test("pr comment with updated body", () => {
+  expect(
+    run({
+      config: prCommentConfig,
+      isApply: false,
+      labels: [],
+      changedFiles: ["foo/dev/main.tf"],
+      configFiles: ["foo/dev/tfaction.yaml"],
+      pr: "",
+      payload: {
+        pull_request: {
+          body: `first line is added
+<!-- tfaction follow up pr target=yoo/dev
+-->`,
         },
-      ],
-      target: "foo/dev",
-    },
-    {
-      environment: "yoo",
-      job_type: "terraform",
-      runs_on: "ubuntu-latest",
-      secrets: undefined,
-      target: "yoo/dev",
-    },
-  ]);
+      },
+      module_callers: {},
+    }),
+  ).toStrictEqual(prCommnetExpected);
 });
 
 test("module callers", () => {

--- a/list-targets-with-changed-files/src/run.ts
+++ b/list-targets-with-changed-files/src/run.ts
@@ -92,16 +92,15 @@ export const run = (input: Input): TargetConfig[] => {
     workingDirs.add(path.dirname(configFile));
   }
 
+  // Expected followupPRBody include the line:
   // <!-- tfaction follow up pr target=foo -->
-  let followupTarget = "";
-  const followupPRBodyPrefix = "<!-- tfaction follow up pr target=";
+  const followupTargetCommentRegex = new RegExp(
+    /<!-- tfaction follow up pr target=([^\s]+).*-->/,
+    "s",
+  );
   const prBody = getPRBody(input.pr, input.payload);
-  if (prBody.startsWith(followupPRBodyPrefix)) {
-    followupTarget = prBody
-      .split("\n")[0]
-      .trim()
-      .slice(followupPRBodyPrefix.length, -" -->".length);
-  }
+  const matchResult = prBody.match(followupTargetCommentRegex);
+  const followupTarget = matchResult ? matchResult[1] : "";
 
   const terraformTargets = new Set<string>();
   const tfmigrates = new Set<string>();


### PR DESCRIPTION
## Context

- https://github.com/suzuki-shunsuke/tfaction/pull/1660 is improved the problem but still there like adding lines before comment or update the comment line.

## Objective

- Use regexp to handle follow up pr target for robustness
  - I think using PR label or something is robuster than using PR body string but I don't know well about tfaction

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/tfaction/issues/1661
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
