### PR TITLE
feat(runs_on): permit using array of string to select specific runner

### DIFF
--- a/check-terraform-skip/dist/index.js
+++ b/check-terraform-skip/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -25000,7 +25000,7 @@ const JobConfig = zod_1.z.object({
     gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     env: zod_1.z.optional(zod_1.z.record(zod_1.z.string())),
     aws_secrets_manager: zod_1.z.optional(zod_1.z.array(AWSSecretsManagerSecret)),
 });
@@ -25013,7 +25013,7 @@ const TargetGroup = zod_1.z.object({
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     gcs_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     secrets: zod_1.z.optional(GitHubSecrets),
     s3_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
     target: zod_1.z.string(),
@@ -25761,8 +25761,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -58225,7 +58225,7 @@ ZodReadonly.create = (type, params) => {
         ...processCreateParams(params),
     });
 };
-const custom = (check, params = {}, 
+const custom = (check, params = {},
 /**
  * @deprecated
  *
@@ -61998,7 +61998,7 @@ module.exports = parseParams
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -62012,7 +62012,7 @@ module.exports = parseParams
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -62021,23 +62021,23 @@ module.exports = parseParams
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
-/******/ 	
+/******/
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
+/******/
 /************************************************************************/
-/******/ 	
+/******/
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
 /******/ 	var __webpack_exports__ = __nccwpck_require__(6144);
 /******/ 	module.exports = __webpack_exports__;
-/******/ 	
+/******/
 /******/ })()
 ;

--- a/create-follow-up-pr/action.yaml
+++ b/create-follow-up-pr/action.yaml
@@ -16,7 +16,7 @@ runs:
     - uses: suzuki-shunsuke/tfaction/get-global-config@main
       id: global-config
 
-    - run: bash ${{ github.action_path }}/skip_create_pr.sh
+    - run: bash "$GITHUB_ACTION_PATH/skip_create_pr.sh"
       shell: bash
       if: "fromJSON(steps.global-config.outputs.skip_create_pr)"
       env:
@@ -24,7 +24,7 @@ runs:
         TFACTION_TARGET_LABEL_PREFIX: ${{ steps.global-config.outputs.label_prefix_target }}
         TFACTION_DRAFT_PR: ${{ steps.global-config.outputs.draft_pr }}
 
-    - run: bash ${{ github.action_path }}/main.sh
+    - run: bash "$GITHUB_ACTION_PATH/main.sh"
       shell: bash
       if: "!fromJSON(steps.global-config.outputs.skip_create_pr)"
       env:

--- a/export-aws-secrets-manager/dist/index.js
+++ b/export-aws-secrets-manager/dist/index.js
@@ -44867,7 +44867,7 @@ const JobConfig = zod_1.z.object({
     gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     env: zod_1.z.optional(zod_1.z.record(zod_1.z.string())),
     aws_secrets_manager: zod_1.z.optional(zod_1.z.array(AWSSecretsManagerSecret)),
 });
@@ -44880,7 +44880,7 @@ const TargetGroup = zod_1.z.object({
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     gcs_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     secrets: zod_1.z.optional(GitHubSecrets),
     s3_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
     target: zod_1.z.string(),

--- a/export-secrets/src/lib.ts
+++ b/export-secrets/src/lib.ts
@@ -19,7 +19,7 @@ export interface TargetConfig {
   gcp_workload_identity_provider: string | undefined;
   environment: object | string | undefined;
   secrets: Array<Secret> | undefined;
-  runs_on: string | undefined;
+  runs_on: string[] | string | undefined;
 
   terraform_plan_config: JobConfig | undefined;
   tfmigrate_plan_config: JobConfig | undefined;
@@ -38,7 +38,7 @@ export interface JobConfig {
   gcp_workload_identity_provider: string | undefined;
   environment: object | string | undefined;
   secrets: Array<Secret> | undefined;
-  runs_on: string | undefined;
+  runs_on: string[] | string | undefined;
 }
 
 export function getConfig(): Config {

--- a/get-global-config/dist/index.js
+++ b/get-global-config/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -25000,7 +25000,7 @@ const JobConfig = zod_1.z.object({
     gcp_access_token_scopes: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     env: zod_1.z.optional(zod_1.z.record(zod_1.z.string())),
     aws_secrets_manager: zod_1.z.optional(zod_1.z.array(AWSSecretsManagerSecret)),
 });
@@ -25013,7 +25013,7 @@ const TargetGroup = zod_1.z.object({
     gcp_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     gcs_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     secrets: zod_1.z.optional(GitHubSecrets),
     s3_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
     target: zod_1.z.string(),
@@ -25761,8 +25761,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -58225,7 +58225,7 @@ ZodReadonly.create = (type, params) => {
         ...processCreateParams(params),
     });
 };
-const custom = (check, params = {}, 
+const custom = (check, params = {},
 /**
  * @deprecated
  *
@@ -61997,7 +61997,7 @@ module.exports = parseParams
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -62011,7 +62011,7 @@ module.exports = parseParams
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -62020,23 +62020,23 @@ module.exports = parseParams
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
-/******/ 	
+/******/
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
+/******/
 /************************************************************************/
-/******/ 	
+/******/
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
 /******/ 	var __webpack_exports__ = __nccwpck_require__(6144);
 /******/ 	module.exports = __webpack_exports__;
-/******/ 	
+/******/
 /******/ })()
 ;

--- a/get-target-config/dist/index.js
+++ b/get-target-config/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -25002,7 +25002,7 @@ const JobConfig = zod_1.z.object({
     gcp_remote_backend_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     env: zod_1.z.optional(zod_1.z.record(zod_1.z.string())),
     aws_secrets_manager: zod_1.z.optional(zod_1.z.array(AWSSecretsManagerSecret)),
 });
@@ -25017,7 +25017,7 @@ const TargetGroup = zod_1.z.object({
     gcp_remote_backend_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_remote_backend_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     gcs_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     secrets: zod_1.z.optional(GitHubSecrets),
     s3_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
     target: zod_1.z.string(),
@@ -25765,8 +25765,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -58229,7 +58229,7 @@ ZodReadonly.create = (type, params) => {
         ...processCreateParams(params),
     });
 };
-const custom = (check, params = {}, 
+const custom = (check, params = {},
 /**
  * @deprecated
  *
@@ -62059,7 +62059,7 @@ module.exports = parseParams
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -62073,7 +62073,7 @@ module.exports = parseParams
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -62082,23 +62082,23 @@ module.exports = parseParams
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
-/******/ 	
+/******/
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
+/******/
 /************************************************************************/
-/******/ 	
+/******/
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
 /******/ 	var __webpack_exports__ = __nccwpck_require__(6144);
 /******/ 	module.exports = __webpack_exports__;
-/******/ 	
+/******/
 /******/ })()
 ;

--- a/lib/dist/index.d.ts
+++ b/lib/dist/index.d.ts
@@ -121,7 +121,7 @@ declare const JobConfig: z.ZodObject<{
         env_name: string;
         secret_name: string;
     }>, "many">>;
-    runs_on: z.ZodOptional<z.ZodString>;
+    runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
     env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
     aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
         envs: z.ZodArray<z.ZodObject<{
@@ -158,6 +158,7 @@ declare const JobConfig: z.ZodObject<{
         aws_region?: string | undefined;
     }>, "many">>;
 }, "strip", z.ZodTypeAny, {
+    runs_on: (string | string[]) & (string | string[] | undefined);
     aws_assume_role_arn?: string | undefined;
     gcp_service_account?: string | undefined;
     gcp_workload_identity_provider?: string | undefined;
@@ -172,7 +173,6 @@ declare const JobConfig: z.ZodObject<{
         env_name: string;
         secret_name: string;
     }[] | undefined;
-    runs_on?: string | undefined;
     env?: Record<string, string> | undefined;
     aws_secrets_manager?: {
         envs: {
@@ -185,6 +185,7 @@ declare const JobConfig: z.ZodObject<{
         aws_region?: string | undefined;
     }[] | undefined;
 }, {
+    runs_on: (string | string[]) & (string | string[] | undefined);
     aws_assume_role_arn?: string | undefined;
     gcp_service_account?: string | undefined;
     gcp_workload_identity_provider?: string | undefined;
@@ -199,7 +200,6 @@ declare const JobConfig: z.ZodObject<{
         env_name: string;
         secret_name: string;
     }[] | undefined;
-    runs_on?: string | undefined;
     env?: Record<string, string> | undefined;
     aws_secrets_manager?: {
         envs: {
@@ -233,7 +233,7 @@ declare const TargetGroup: z.ZodObject<{
     gcp_remote_backend_service_account: z.ZodOptional<z.ZodString>;
     gcp_remote_backend_workload_identity_provider: z.ZodOptional<z.ZodString>;
     gcs_bucket_name_tfmigrate_history: z.ZodOptional<z.ZodString>;
-    runs_on: z.ZodOptional<z.ZodString>;
+    runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
     secrets: z.ZodOptional<z.ZodArray<z.ZodObject<{
         env_name: z.ZodString;
         secret_name: z.ZodString;
@@ -274,7 +274,7 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -311,6 +311,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -325,7 +326,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -338,6 +338,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -352,7 +353,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -392,7 +392,7 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -429,6 +429,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -443,7 +444,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -456,6 +456,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -470,7 +471,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -510,7 +510,7 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -547,6 +547,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -561,7 +562,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -574,6 +574,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -588,7 +589,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -628,7 +628,7 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -665,6 +665,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -679,7 +680,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -692,6 +692,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -706,7 +707,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -771,7 +771,7 @@ declare const TargetGroup: z.ZodObject<{
     gcp_remote_backend_service_account?: string | undefined;
     gcp_remote_backend_workload_identity_provider?: string | undefined;
     gcs_bucket_name_tfmigrate_history?: string | undefined;
-    runs_on?: string | undefined;
+    runs_on?: string | string[] | undefined;
     secrets?: {
         env_name: string;
         secret_name: string;
@@ -779,6 +779,7 @@ declare const TargetGroup: z.ZodObject<{
     s3_bucket_name_tfmigrate_history?: string | undefined;
     template_dir?: string | undefined;
     terraform_apply_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -793,7 +794,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -807,6 +807,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     terraform_plan_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -821,7 +822,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -835,6 +835,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_apply_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -849,7 +850,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -863,6 +863,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_plan_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -877,7 +878,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -917,7 +917,7 @@ declare const TargetGroup: z.ZodObject<{
     gcp_remote_backend_service_account?: string | undefined;
     gcp_remote_backend_workload_identity_provider?: string | undefined;
     gcs_bucket_name_tfmigrate_history?: string | undefined;
-    runs_on?: string | undefined;
+    runs_on?: string | string[] | undefined;
     secrets?: {
         env_name: string;
         secret_name: string;
@@ -925,6 +925,7 @@ declare const TargetGroup: z.ZodObject<{
     s3_bucket_name_tfmigrate_history?: string | undefined;
     template_dir?: string | undefined;
     terraform_apply_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -939,7 +940,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -953,6 +953,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     terraform_plan_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -967,7 +968,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -981,6 +981,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_apply_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -995,7 +996,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1009,6 +1009,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_plan_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1023,7 +1024,6 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1103,7 +1103,7 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -1140,6 +1140,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1154,7 +1155,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1167,6 +1167,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1181,7 +1182,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1221,7 +1221,7 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -1258,6 +1258,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1272,7 +1273,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1285,6 +1285,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1299,7 +1300,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1339,7 +1339,7 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -1376,6 +1376,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1390,7 +1391,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1403,6 +1403,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1417,7 +1418,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1457,7 +1457,7 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -1494,6 +1494,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1508,7 +1509,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1521,6 +1521,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1535,7 +1536,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1567,6 +1567,7 @@ declare const TargetConfig: z.ZodObject<{
         secret_name: string;
     }[] | undefined;
     terraform_apply_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1581,7 +1582,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1595,6 +1595,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     terraform_plan_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1609,7 +1610,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1623,6 +1623,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_apply_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1637,7 +1638,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1651,6 +1651,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_plan_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1665,7 +1666,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1697,6 +1697,7 @@ declare const TargetConfig: z.ZodObject<{
         secret_name: string;
     }[] | undefined;
     terraform_apply_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1711,7 +1712,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1725,6 +1725,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     terraform_plan_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1739,7 +1740,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1753,6 +1753,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_apply_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1767,7 +1768,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1781,6 +1781,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_plan_config?: {
+        runs_on: (string | string[]) & (string | string[] | undefined);
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1795,7 +1796,6 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }[] | undefined;
-        runs_on?: string | undefined;
         env?: Record<string, string> | undefined;
         aws_secrets_manager?: {
             envs: {
@@ -1906,7 +1906,7 @@ declare const Config: z.ZodObject<{
         gcp_remote_backend_service_account: z.ZodOptional<z.ZodString>;
         gcp_remote_backend_workload_identity_provider: z.ZodOptional<z.ZodString>;
         gcs_bucket_name_tfmigrate_history: z.ZodOptional<z.ZodString>;
-        runs_on: z.ZodOptional<z.ZodString>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         secrets: z.ZodOptional<z.ZodArray<z.ZodObject<{
             env_name: z.ZodString;
             secret_name: z.ZodString;
@@ -1947,7 +1947,7 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }>, "many">>;
-            runs_on: z.ZodOptional<z.ZodString>;
+            runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
             env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
             aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
                 envs: z.ZodArray<z.ZodObject<{
@@ -1984,6 +1984,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -1998,7 +1999,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2011,6 +2011,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }[] | undefined;
         }, {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2025,7 +2026,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2065,7 +2065,7 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }>, "many">>;
-            runs_on: z.ZodOptional<z.ZodString>;
+            runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
             env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
             aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
                 envs: z.ZodArray<z.ZodObject<{
@@ -2102,6 +2102,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2116,7 +2117,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2129,6 +2129,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }[] | undefined;
         }, {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2143,7 +2144,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2183,7 +2183,7 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }>, "many">>;
-            runs_on: z.ZodOptional<z.ZodString>;
+            runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
             env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
             aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
                 envs: z.ZodArray<z.ZodObject<{
@@ -2220,6 +2220,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2234,7 +2235,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2247,6 +2247,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }[] | undefined;
         }, {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2261,7 +2262,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2301,7 +2301,7 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }>, "many">>;
-            runs_on: z.ZodOptional<z.ZodString>;
+            runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
             env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
             aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
                 envs: z.ZodArray<z.ZodObject<{
@@ -2338,6 +2338,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2352,7 +2353,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2365,6 +2365,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }[] | undefined;
         }, {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2379,7 +2380,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2444,7 +2444,7 @@ declare const Config: z.ZodObject<{
         gcp_remote_backend_service_account?: string | undefined;
         gcp_remote_backend_workload_identity_provider?: string | undefined;
         gcs_bucket_name_tfmigrate_history?: string | undefined;
-        runs_on?: string | undefined;
+        runs_on?: string | string[] | undefined;
         secrets?: {
             env_name: string;
             secret_name: string;
@@ -2452,6 +2452,7 @@ declare const Config: z.ZodObject<{
         s3_bucket_name_tfmigrate_history?: string | undefined;
         template_dir?: string | undefined;
         terraform_apply_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2466,7 +2467,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2480,6 +2480,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         terraform_plan_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2494,7 +2495,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2508,6 +2508,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_apply_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2522,7 +2523,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2536,6 +2536,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_plan_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2550,7 +2551,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2590,7 +2590,7 @@ declare const Config: z.ZodObject<{
         gcp_remote_backend_service_account?: string | undefined;
         gcp_remote_backend_workload_identity_provider?: string | undefined;
         gcs_bucket_name_tfmigrate_history?: string | undefined;
-        runs_on?: string | undefined;
+        runs_on?: string | string[] | undefined;
         secrets?: {
             env_name: string;
             secret_name: string;
@@ -2598,6 +2598,7 @@ declare const Config: z.ZodObject<{
         s3_bucket_name_tfmigrate_history?: string | undefined;
         template_dir?: string | undefined;
         terraform_apply_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2612,7 +2613,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2626,6 +2626,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         terraform_plan_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2640,7 +2641,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2654,6 +2654,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_apply_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2668,7 +2669,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2682,6 +2682,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_plan_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2696,7 +2697,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2776,7 +2776,7 @@ declare const Config: z.ZodObject<{
         gcp_remote_backend_service_account?: string | undefined;
         gcp_remote_backend_workload_identity_provider?: string | undefined;
         gcs_bucket_name_tfmigrate_history?: string | undefined;
-        runs_on?: string | undefined;
+        runs_on?: string | string[] | undefined;
         secrets?: {
             env_name: string;
             secret_name: string;
@@ -2784,6 +2784,7 @@ declare const Config: z.ZodObject<{
         s3_bucket_name_tfmigrate_history?: string | undefined;
         template_dir?: string | undefined;
         terraform_apply_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2798,7 +2799,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2812,6 +2812,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         terraform_plan_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2826,7 +2827,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2840,6 +2840,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_apply_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2854,7 +2855,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2868,6 +2868,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_plan_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2882,7 +2883,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -2973,7 +2973,7 @@ declare const Config: z.ZodObject<{
         gcp_remote_backend_service_account?: string | undefined;
         gcp_remote_backend_workload_identity_provider?: string | undefined;
         gcs_bucket_name_tfmigrate_history?: string | undefined;
-        runs_on?: string | undefined;
+        runs_on?: string | string[] | undefined;
         secrets?: {
             env_name: string;
             secret_name: string;
@@ -2981,6 +2981,7 @@ declare const Config: z.ZodObject<{
         s3_bucket_name_tfmigrate_history?: string | undefined;
         template_dir?: string | undefined;
         terraform_apply_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2995,7 +2996,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -3009,6 +3009,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         terraform_plan_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -3023,7 +3024,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -3037,6 +3037,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_apply_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -3051,7 +3052,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {
@@ -3065,6 +3065,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_plan_config?: {
+            runs_on: (string | string[]) & (string | string[] | undefined);
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -3079,7 +3080,6 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }[] | undefined;
-            runs_on?: string | undefined;
             env?: Record<string, string> | undefined;
             aws_secrets_manager?: {
                 envs: {

--- a/lib/dist/index.d.ts
+++ b/lib/dist/index.d.ts
@@ -121,7 +121,7 @@ declare const JobConfig: z.ZodObject<{
         env_name: string;
         secret_name: string;
     }>, "many">>;
-    runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+    runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
     env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
     aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
         envs: z.ZodArray<z.ZodObject<{
@@ -158,7 +158,7 @@ declare const JobConfig: z.ZodObject<{
         aws_region?: string | undefined;
     }>, "many">>;
 }, "strip", z.ZodTypeAny, {
-    runs_on: (string | string[]) & (string | string[] | undefined);
+    runs_on: string | string[] | undefined;
     aws_assume_role_arn?: string | undefined;
     gcp_service_account?: string | undefined;
     gcp_workload_identity_provider?: string | undefined;
@@ -185,7 +185,7 @@ declare const JobConfig: z.ZodObject<{
         aws_region?: string | undefined;
     }[] | undefined;
 }, {
-    runs_on: (string | string[]) & (string | string[] | undefined);
+    runs_on: string | string[] | undefined;
     aws_assume_role_arn?: string | undefined;
     gcp_service_account?: string | undefined;
     gcp_workload_identity_provider?: string | undefined;
@@ -274,7 +274,7 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -311,7 +311,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -338,7 +338,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -392,7 +392,7 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -429,7 +429,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -456,7 +456,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -510,7 +510,7 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -547,7 +547,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -574,7 +574,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -628,7 +628,7 @@ declare const TargetGroup: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -665,7 +665,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -692,7 +692,7 @@ declare const TargetGroup: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -779,7 +779,7 @@ declare const TargetGroup: z.ZodObject<{
     s3_bucket_name_tfmigrate_history?: string | undefined;
     template_dir?: string | undefined;
     terraform_apply_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -807,7 +807,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     terraform_plan_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -835,7 +835,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_apply_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -863,7 +863,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_plan_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -925,7 +925,7 @@ declare const TargetGroup: z.ZodObject<{
     s3_bucket_name_tfmigrate_history?: string | undefined;
     template_dir?: string | undefined;
     terraform_apply_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -953,7 +953,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     terraform_plan_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -981,7 +981,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_apply_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1009,7 +1009,7 @@ declare const TargetGroup: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_plan_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1103,7 +1103,7 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -1140,7 +1140,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1167,7 +1167,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1221,7 +1221,7 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -1258,7 +1258,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1285,7 +1285,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1339,7 +1339,7 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -1376,7 +1376,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1403,7 +1403,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1457,7 +1457,7 @@ declare const TargetConfig: z.ZodObject<{
             env_name: string;
             secret_name: string;
         }>, "many">>;
-        runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
         env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
         aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
             envs: z.ZodArray<z.ZodObject<{
@@ -1494,7 +1494,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1521,7 +1521,7 @@ declare const TargetConfig: z.ZodObject<{
             aws_region?: string | undefined;
         }[] | undefined;
     }, {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1567,7 +1567,7 @@ declare const TargetConfig: z.ZodObject<{
         secret_name: string;
     }[] | undefined;
     terraform_apply_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1595,7 +1595,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     terraform_plan_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1623,7 +1623,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_apply_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1651,7 +1651,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_plan_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1697,7 +1697,7 @@ declare const TargetConfig: z.ZodObject<{
         secret_name: string;
     }[] | undefined;
     terraform_apply_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1725,7 +1725,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     terraform_plan_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1753,7 +1753,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_apply_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1781,7 +1781,7 @@ declare const TargetConfig: z.ZodObject<{
         }[] | undefined;
     } | undefined;
     tfmigrate_plan_config?: {
-        runs_on: (string | string[]) & (string | string[] | undefined);
+        runs_on: string | string[] | undefined;
         aws_assume_role_arn?: string | undefined;
         gcp_service_account?: string | undefined;
         gcp_workload_identity_provider?: string | undefined;
@@ -1947,7 +1947,7 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }>, "many">>;
-            runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+            runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
             env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
             aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
                 envs: z.ZodArray<z.ZodObject<{
@@ -1984,7 +1984,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2011,7 +2011,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }[] | undefined;
         }, {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2065,7 +2065,7 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }>, "many">>;
-            runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+            runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
             env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
             aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
                 envs: z.ZodArray<z.ZodObject<{
@@ -2102,7 +2102,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2129,7 +2129,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }[] | undefined;
         }, {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2183,7 +2183,7 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }>, "many">>;
-            runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+            runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
             env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
             aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
                 envs: z.ZodArray<z.ZodObject<{
@@ -2220,7 +2220,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2247,7 +2247,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }[] | undefined;
         }, {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2301,7 +2301,7 @@ declare const Config: z.ZodObject<{
                 env_name: string;
                 secret_name: string;
             }>, "many">>;
-            runs_on: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+            runs_on: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
             env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
             aws_secrets_manager: z.ZodOptional<z.ZodArray<z.ZodObject<{
                 envs: z.ZodArray<z.ZodObject<{
@@ -2338,7 +2338,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2365,7 +2365,7 @@ declare const Config: z.ZodObject<{
                 aws_region?: string | undefined;
             }[] | undefined;
         }, {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2452,7 +2452,7 @@ declare const Config: z.ZodObject<{
         s3_bucket_name_tfmigrate_history?: string | undefined;
         template_dir?: string | undefined;
         terraform_apply_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2480,7 +2480,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         terraform_plan_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2508,7 +2508,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_apply_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2536,7 +2536,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_plan_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2598,7 +2598,7 @@ declare const Config: z.ZodObject<{
         s3_bucket_name_tfmigrate_history?: string | undefined;
         template_dir?: string | undefined;
         terraform_apply_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2626,7 +2626,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         terraform_plan_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2654,7 +2654,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_apply_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2682,7 +2682,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_plan_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2784,7 +2784,7 @@ declare const Config: z.ZodObject<{
         s3_bucket_name_tfmigrate_history?: string | undefined;
         template_dir?: string | undefined;
         terraform_apply_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2812,7 +2812,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         terraform_plan_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2840,7 +2840,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_apply_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2868,7 +2868,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_plan_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -2981,7 +2981,7 @@ declare const Config: z.ZodObject<{
         s3_bucket_name_tfmigrate_history?: string | undefined;
         template_dir?: string | undefined;
         terraform_apply_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -3009,7 +3009,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         terraform_plan_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -3037,7 +3037,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_apply_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;
@@ -3065,7 +3065,7 @@ declare const Config: z.ZodObject<{
             }[] | undefined;
         } | undefined;
         tfmigrate_plan_config?: {
-            runs_on: (string | string[]) & (string | string[] | undefined);
+            runs_on: string | string[] | undefined;
             aws_assume_role_arn?: string | undefined;
             gcp_service_account?: string | undefined;
             gcp_workload_identity_provider?: string | undefined;

--- a/lib/dist/index.js
+++ b/lib/dist/index.js
@@ -80,7 +80,7 @@ const JobConfig = zod_1.z.object({
     gcp_remote_backend_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     env: zod_1.z.optional(zod_1.z.record(zod_1.z.string())),
     aws_secrets_manager: zod_1.z.optional(zod_1.z.array(AWSSecretsManagerSecret)),
 });
@@ -95,7 +95,7 @@ const TargetGroup = zod_1.z.object({
     gcp_remote_backend_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_remote_backend_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     gcs_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     secrets: zod_1.z.optional(GitHubSecrets),
     s3_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
     target: zod_1.z.string(),

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -83,7 +83,7 @@ const JobConfig = z.object({
   gcp_remote_backend_workload_identity_provider: z.optional(z.string()),
   environment: z.optional(GitHubEnvironment),
   secrets: z.optional(GitHubSecrets),
-  runs_on: z.union([z.string(), z.array(z.string())]),
+  runs_on: z.optional(z.union([z.string(), z.array(z.string())])),
   env: z.optional(z.record(z.string())),
   aws_secrets_manager: z.optional(z.array(AWSSecretsManagerSecret)),
 });

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -83,7 +83,7 @@ const JobConfig = z.object({
   gcp_remote_backend_workload_identity_provider: z.optional(z.string()),
   environment: z.optional(GitHubEnvironment),
   secrets: z.optional(GitHubSecrets),
-  runs_on: z.optional(z.string()),
+  runs_on: z.union([z.string(), z.array(z.string())]),
   env: z.optional(z.record(z.string())),
   aws_secrets_manager: z.optional(z.array(AWSSecretsManagerSecret)),
 });
@@ -101,7 +101,7 @@ const TargetGroup = z.object({
   gcp_remote_backend_service_account: z.optional(z.string()),
   gcp_remote_backend_workload_identity_provider: z.optional(z.string()),
   gcs_bucket_name_tfmigrate_history: z.optional(z.string()),
-  runs_on: z.optional(z.string()),
+  runs_on: z.optional(z.union([z.string(), z.array(z.string())])),
   secrets: z.optional(GitHubSecrets),
   s3_bucket_name_tfmigrate_history: z.optional(z.string()),
   target: z.string(),

--- a/list-targets-with-changed-files/dist/index.js
+++ b/list-targets-with-changed-files/dist/index.js
@@ -87,7 +87,7 @@ const JobConfig = zod_1.z.object({
     gcp_remote_backend_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     environment: zod_1.z.optional(GitHubEnvironment),
     secrets: zod_1.z.optional(GitHubSecrets),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     env: zod_1.z.optional(zod_1.z.record(zod_1.z.string())),
     aws_secrets_manager: zod_1.z.optional(zod_1.z.array(AWSSecretsManagerSecret)),
 });
@@ -102,7 +102,7 @@ const TargetGroup = zod_1.z.object({
     gcp_remote_backend_service_account: zod_1.z.optional(zod_1.z.string()),
     gcp_remote_backend_workload_identity_provider: zod_1.z.optional(zod_1.z.string()),
     gcs_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
-    runs_on: zod_1.z.optional(zod_1.z.string()),
+    runs_on: zod_1.z.optional(zod_1.z.union([zod_1.z.string(), zod_1.z.array(zod_1.z.string())])),
     secrets: zod_1.z.optional(GitHubSecrets),
     s3_bucket_name_tfmigrate_history: zod_1.z.optional(zod_1.z.string()),
     target: zod_1.z.string(),

--- a/list-targets-with-changed-files/src/run.ts
+++ b/list-targets-with-changed-files/src/run.ts
@@ -6,7 +6,7 @@ import * as lib from "lib";
 
 type TargetConfig = {
   target: string;
-  runs_on: string;
+  runs_on: string | string[];
   job_type: string;
   environment?: lib.GitHubEnvironment;
   secrets?: lib.GitHubSecrets;

--- a/scaffold-tfmigrate/action.yaml
+++ b/scaffold-tfmigrate/action.yaml
@@ -48,7 +48,7 @@ runs:
     - name: Create .tfmigrate.hcl (S3)
       run: |
         if [ ! -f ".tfmigrate.hcl" ]; then
-          sed "s|%%TARGET%%|${TFACTION_TARGET}|g" ${{ github.action_path }}/tfmigrate.hcl |
+          sed "s|%%TARGET%%|${TFACTION_TARGET}|g" "$GITHUB_ACTION_PATH/tfmigrate.hcl" |
           sed 's|%%S3_BUCKET_NAME_TFMIGRATE_HISTORY%%|${{steps.target-config.outputs.s3_bucket_name_tfmigrate_history}}|g' > .tfmigrate.hcl
         fi
       if: steps.target-config.outputs.s3_bucket_name_tfmigrate_history != ''
@@ -58,7 +58,7 @@ runs:
     - name: Create .tfmigrate.hcl (GCS)
       run: |
         if [ ! -f ".tfmigrate.hcl" ]; then
-          sed "s|%%TARGET%%|${TFACTION_TARGET}|g" ${{ github.action_path }}/tfmigrate-gcs.hcl |
+          sed "s|%%TARGET%%|${TFACTION_TARGET}|g" "$GITHUB_ACTION_PATH/tfmigrate-gcs.hcl" |
           sed 's|%%GCS_BUCKET_NAME_TFMIGRATE_HISTORY%%|${{steps.target-config.outputs.gcs_bucket_name_tfmigrate_history}}|g' > .tfmigrate.hcl
         fi
       if: steps.target-config.outputs.gcs_bucket_name_tfmigrate_history != ''
@@ -70,7 +70,7 @@ runs:
       working-directory: ${{steps.target-config.outputs.working_directory}}
 
     - name: Create a migration file
-      run: sed "s|%%MIGRATION_NAME%%|${{inputs.migration_name}}|g"  ${{ github.action_path }}/migration.hcl > "tfmigrate/$(date +%Y%m%d%H%M%S)_${{inputs.migration_name}}.hcl"
+      run: sed "s|%%MIGRATION_NAME%%|${{inputs.migration_name}}|g" "$GITHUB_ACTION_PATH/migration.hcl" > "tfmigrate/$(date +%Y%m%d%H%M%S)_${{inputs.migration_name}}.hcl"
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}
 

--- a/scaffold-working-dir/action.yaml
+++ b/scaffold-working-dir/action.yaml
@@ -29,11 +29,11 @@ runs:
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}
 
-    - run: cp ${{ github.action_path }}/tfmigrate.hcl .tfmigrate.hcl
+    - run: cp "$GITHUB_ACTION_PATH/tfmigrate.hcl" .tfmigrate.hcl
       if: steps.target-config.outputs.s3_bucket_name_tfmigrate_history != ''
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}
-    - run: cp ${{ github.action_path }}/tfmigrate-gcs.hcl .tfmigrate.hcl
+    - run: cp "$GITHUB_ACTION_PATH/tfmigrate-gcs.hcl" .tfmigrate.hcl
       if: steps.target-config.outputs.gcs_bucket_name_tfmigrate_history != ''
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}

--- a/schema/tfaction-root.json
+++ b/schema/tfaction-root.json
@@ -61,6 +61,9 @@
           "providers_lock_opts": {
             "$ref": "#/$defs/TerraformProvidersLockOptions"
           },
+          "runs_on": {
+            "$ref": "#/$defs/RunsOn"
+          },
           "s3_bucket_name_tfmigrate_history": {
             "$ref": "#/$defs/S3BucketNameTfmigrateHistory"
           },
@@ -398,12 +401,19 @@
         },
         "envs": {
           "$ref": "#/$defs/Envs"
+        },
+        "runs_on": {
+          "$ref": "#/$defs/RunsOn"
         }
       }
     },
     "Envs": {
       "type": "object",
       "description": "environment variables"
+    },
+    "RunsOn": {
+      "type": ["string", "array"],
+      "description": "The type of runner that the job will run on"
     }
   }
 }

--- a/schema/tfaction-root.json
+++ b/schema/tfaction-root.json
@@ -412,7 +412,17 @@
       "description": "environment variables"
     },
     "RunsOn": {
-      "type": ["string", "array"],
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ],
       "description": "The type of runner that the job will run on"
     }
   }

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -124,7 +124,7 @@ runs:
       with:
         ssh_key: ${{ inputs.ssh_key }}
 
-    - uses: suzuki-shunsuke/github-action-terraform-init@71673ab29266f67c4470773675e087e9a4dda3c5 # v1.1.0
+    - uses: suzuki-shunsuke/github-action-terraform-init@29c2316e647f5785788b0a049d11a12c6d615fda # v1.1.1-1
       with:
         working_directory: ${{ steps.target-config.outputs.working_directory }}
         github_token: ${{ inputs.github_token }}

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -124,7 +124,7 @@ runs:
       with:
         ssh_key: ${{ inputs.ssh_key }}
 
-    - uses: suzuki-shunsuke/github-action-terraform-init@29c2316e647f5785788b0a049d11a12c6d615fda # v1.1.1-1
+    - uses: suzuki-shunsuke/github-action-terraform-init@a0f2e069f49737ab11fbd9b00b2149019703ba99 # v1.1.1
       with:
         working_directory: ${{ steps.target-config.outputs.working_directory }}
         github_token: ${{ inputs.github_token }}

--- a/terraform-apply/action.yaml
+++ b/terraform-apply/action.yaml
@@ -32,7 +32,7 @@ runs:
         pr_author: ${{ env.CI_INFO_PR_AUTHOR }}
         skip_label_prefix: ${{ steps.global-config.outputs.label_prefix_skip }}
 
-    - run: bash ${{ github.action_path }}/main.sh
+    - run: bash "$GITHUB_ACTION_PATH/main.sh"
       id: apply
       working-directory: ${{ steps.target-config.outputs.working_directory }}
       shell: bash

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -23,7 +23,7 @@ runs:
         labels: ${{ env.CI_INFO_TEMP_DIR }}/labels.txt
         pr_author: ${{ env.CI_INFO_PR_AUTHOR }}
         skip_label_prefix: ${{ steps.global-config.outputs.label_prefix_skip }}
-    - run: bash ${{ github.action_path }}/main.sh
+    - run: bash "$GITHUB_ACTION_PATH/main.sh"
       working-directory: ${{ steps.target-config.outputs.working_directory }}
       shell: bash
       if: |

--- a/test-module/action.yaml
+++ b/test-module/action.yaml
@@ -53,7 +53,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: bash "${GITHUB_ACTION_PATH}/terraform-docs.sh"
 
-    - uses: suzuki-shunsuke/github-action-terraform-fmt@388ce9deea65edd9a9a3a60bee140732c3dad7a2 # v0.2.1
+    - uses: suzuki-shunsuke/github-action-terraform-fmt@c7378a5b9d2311278db9a7ef825ee6ad6697078c # v0.2.2-1
       with:
         working_directory: ${{ env.TFACTION_TARGET }}
         github_token: ${{ inputs.github_token }}

--- a/test-module/action.yaml
+++ b/test-module/action.yaml
@@ -53,7 +53,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: bash "${GITHUB_ACTION_PATH}/terraform-docs.sh"
 
-    - uses: suzuki-shunsuke/github-action-terraform-fmt@c7378a5b9d2311278db9a7ef825ee6ad6697078c # v0.2.2-1
+    - uses: suzuki-shunsuke/github-action-terraform-fmt@bdc85c3536e31ae189339cc09c5a0f9768d0ffa7 # v0.2.2
       with:
         working_directory: ${{ env.TFACTION_TARGET }}
         github_token: ${{ inputs.github_token }}

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -50,7 +50,7 @@ runs:
         working_directory: ${{ steps.target-config.outputs.working_directory }}
         github_comment: "true"
 
-    - uses: suzuki-shunsuke/github-action-terraform-fmt@388ce9deea65edd9a9a3a60bee140732c3dad7a2 # v0.2.1
+    - uses: suzuki-shunsuke/github-action-terraform-fmt@c7378a5b9d2311278db9a7ef825ee6ad6697078c # v0.2.2-1
       if: steps.target-config.outputs.destroy != 'true'
       with:
         working_directory: ${{ steps.target-config.outputs.working_directory }}

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -50,7 +50,7 @@ runs:
         working_directory: ${{ steps.target-config.outputs.working_directory }}
         github_comment: "true"
 
-    - uses: suzuki-shunsuke/github-action-terraform-fmt@c7378a5b9d2311278db9a7ef825ee6ad6697078c # v0.2.2-1
+    - uses: suzuki-shunsuke/github-action-terraform-fmt@bdc85c3536e31ae189339cc09c5a0f9768d0ffa7 # v0.2.2
       if: steps.target-config.outputs.destroy != 'true'
       with:
         working_directory: ${{ steps.target-config.outputs.working_directory }}

--- a/tfmigrate-apply/action.yaml
+++ b/tfmigrate-apply/action.yaml
@@ -17,7 +17,7 @@ runs:
     - uses: suzuki-shunsuke/tfaction/get-target-config@main
       id: target-config
 
-    - run: bash ${{ github.action_path }}/main.sh
+    - run: bash "$GITHUB_ACTION_PATH/main.sh"
       id: apply
       working-directory: ${{ steps.target-config.outputs.working_directory }}
       shell: bash

--- a/tfmigrate-plan/action.yaml
+++ b/tfmigrate-plan/action.yaml
@@ -15,7 +15,7 @@ runs:
       id: global-config
     - uses: suzuki-shunsuke/tfaction/get-target-config@main
       id: target-config
-    - run: bash ${{ github.action_path }}/main.sh
+    - run: bash "$GITHUB_ACTION_PATH/main.sh"
       working-directory: ${{ steps.target-config.outputs.working_directory }}
       shell: bash
       env:

--- a/update-drift-issue/action.yaml
+++ b/update-drift-issue/action.yaml
@@ -17,7 +17,7 @@ runs:
     - uses: suzuki-shunsuke/tfaction/get-global-config@main
       id: global-config
     - name: Post a comment
-      run: bash ${{ github.action_path }}/post-comment.sh
+      run: bash "$GITHUB_ACTION_PATH/post-comment.sh"
       shell: bash
       if: |
         inputs.status != 'success' && env.TFACTION_DRIFT_ISSUE_NUMBER


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X ] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [X ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/tfaction/issues/1738
- [X ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ X] Do only one thing in one Pull Request

<!-- Please write the description here -->
Permit using array of string to select GitHub runners on which run jobs.
Necessary to select self hosted runners.
