### PR TITLE
feat: support running conftest on given globs

### DIFF
--- a/conftest/dist/index.js
+++ b/conftest/dist/index.js
@@ -60503,12 +60503,7 @@ const run = (inputs, config) => __awaiter(void 0, void 0, void 0, function* () {
         }
     }
     const policies = [];
-    for (const [key, value] of policyMap) {
-        if (value.enabled !== false) {
-            policies.push(value);
-        }
-    }
-    for (const policy of conftest.policies) {
+    for (const policy of conftest.policies.concat(...policyMap.values())) {
         if (policy.enabled !== false && inputs.plan === !!policy.plan) {
             policies.push(policy);
         }

--- a/conftest/dist/index.js
+++ b/conftest/dist/index.js
@@ -25989,6 +25989,7 @@ const ConftestPolicyConfig = zod_1.z.object({
     tf: zod_1.z.optional(zod_1.z.boolean()),
     combine: zod_1.z.optional(zod_1.z.boolean()),
     enabled: zod_1.z.optional(zod_1.z.boolean()),
+    paths: zod_1.z.optional(zod_1.z.array(zod_1.z.string())),
 });
 const ConftestConfig = zod_1.z.object({
     disable_all: zod_1.z.optional(zod_1.z.boolean()),
@@ -60536,6 +60537,16 @@ const run = (inputs, config) => __awaiter(void 0, void 0, void 0, function* () {
         }
         else if (policy.plan) {
             paths.push("tfplan.json");
+        }
+        else if (policy.paths) {
+            for (const p of policy.paths) {
+                const files = (0, glob_1.globSync)(path.join(workingDir, p), {
+                    ignore: ".terraform/**",
+                });
+                for (const file of files) {
+                    paths.push(path.relative(workingDir, file));
+                }
+            }
         }
         const args = [
             "exec",

--- a/conftest/src/run.ts
+++ b/conftest/src/run.ts
@@ -114,12 +114,7 @@ export const run = async (inputs: Inputs, config: lib.Config) => {
     }
   }
   const policies = [];
-  for (const [key, value] of policyMap) {
-    if (value.enabled !== false) {
-      policies.push(value);
-    }
-  }
-  for (const policy of conftest.policies) {
+  for (const policy of conftest.policies.concat(...policyMap.values())) {
     if (policy.enabled !== false && inputs.plan === !!policy.plan) {
       policies.push(policy);
     }

--- a/conftest/src/run.ts
+++ b/conftest/src/run.ts
@@ -147,6 +147,15 @@ export const run = async (inputs: Inputs, config: lib.Config) => {
       }
     } else if (policy.plan) {
       paths.push("tfplan.json");
+    } else if (policy.paths) {
+      for (const p of policy.paths) {
+        const files = globSync(path.join(workingDir, p), {
+          ignore: ".terraform/**",
+        });
+        for (const file of files) {
+          paths.push(path.relative(workingDir, file));
+        }
+      }
     }
     const args = [
       "exec",

--- a/lib/dist/index.d.ts
+++ b/lib/dist/index.d.ts
@@ -53,6 +53,7 @@ declare const ConftestPolicyConfig: z.ZodObject<{
     tf: z.ZodOptional<z.ZodBoolean>;
     combine: z.ZodOptional<z.ZodBoolean>;
     enabled: z.ZodOptional<z.ZodBoolean>;
+    paths: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
 }, "strip", z.ZodTypeAny, {
     data?: string | undefined;
     id?: string | undefined;
@@ -61,6 +62,7 @@ declare const ConftestPolicyConfig: z.ZodObject<{
     plan?: boolean | undefined;
     tf?: boolean | undefined;
     combine?: boolean | undefined;
+    paths?: string[] | undefined;
 }, {
     data?: string | undefined;
     id?: string | undefined;
@@ -69,6 +71,7 @@ declare const ConftestPolicyConfig: z.ZodObject<{
     plan?: boolean | undefined;
     tf?: boolean | undefined;
     combine?: boolean | undefined;
+    paths?: string[] | undefined;
 }>;
 export type ConftestPolicyConfig = z.infer<typeof ConftestPolicyConfig>;
 declare const ConftestConfig: z.ZodObject<{
@@ -81,6 +84,7 @@ declare const ConftestConfig: z.ZodObject<{
         tf: z.ZodOptional<z.ZodBoolean>;
         combine: z.ZodOptional<z.ZodBoolean>;
         enabled: z.ZodOptional<z.ZodBoolean>;
+        paths: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     }, "strip", z.ZodTypeAny, {
         data?: string | undefined;
         id?: string | undefined;
@@ -89,6 +93,7 @@ declare const ConftestConfig: z.ZodObject<{
         plan?: boolean | undefined;
         tf?: boolean | undefined;
         combine?: boolean | undefined;
+        paths?: string[] | undefined;
     }, {
         data?: string | undefined;
         id?: string | undefined;
@@ -97,6 +102,7 @@ declare const ConftestConfig: z.ZodObject<{
         plan?: boolean | undefined;
         tf?: boolean | undefined;
         combine?: boolean | undefined;
+        paths?: string[] | undefined;
     }>, "many">>;
 }, "strip", z.ZodTypeAny, {
     disable_all?: boolean | undefined;
@@ -108,6 +114,7 @@ declare const ConftestConfig: z.ZodObject<{
         plan?: boolean | undefined;
         tf?: boolean | undefined;
         combine?: boolean | undefined;
+        paths?: string[] | undefined;
     }[] | undefined;
 }, {
     disable_all?: boolean | undefined;
@@ -119,6 +126,7 @@ declare const ConftestConfig: z.ZodObject<{
         plan?: boolean | undefined;
         tf?: boolean | undefined;
         combine?: boolean | undefined;
+        paths?: string[] | undefined;
     }[] | undefined;
 }>;
 export type ConftestConfig = z.infer<typeof ConftestConfig>;
@@ -850,6 +858,7 @@ declare const TargetGroup: z.ZodObject<{
             tf: z.ZodOptional<z.ZodBoolean>;
             combine: z.ZodOptional<z.ZodBoolean>;
             enabled: z.ZodOptional<z.ZodBoolean>;
+            paths: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
         }, "strip", z.ZodTypeAny, {
             data?: string | undefined;
             id?: string | undefined;
@@ -858,6 +867,7 @@ declare const TargetGroup: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }, {
             data?: string | undefined;
             id?: string | undefined;
@@ -866,6 +876,7 @@ declare const TargetGroup: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
         disable_all?: boolean | undefined;
@@ -877,6 +888,7 @@ declare const TargetGroup: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     }, {
         disable_all?: boolean | undefined;
@@ -888,6 +900,7 @@ declare const TargetGroup: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     }>>;
 }, "strip", z.ZodTypeAny, {
@@ -1046,6 +1059,7 @@ declare const TargetGroup: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     } | undefined;
 }, {
@@ -1204,6 +1218,7 @@ declare const TargetGroup: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     } | undefined;
 }>;
@@ -1725,6 +1740,7 @@ declare const TargetConfig: z.ZodObject<{
             tf: z.ZodOptional<z.ZodBoolean>;
             combine: z.ZodOptional<z.ZodBoolean>;
             enabled: z.ZodOptional<z.ZodBoolean>;
+            paths: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
         }, "strip", z.ZodTypeAny, {
             data?: string | undefined;
             id?: string | undefined;
@@ -1733,6 +1749,7 @@ declare const TargetConfig: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }, {
             data?: string | undefined;
             id?: string | undefined;
@@ -1741,6 +1758,7 @@ declare const TargetConfig: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
         disable_all?: boolean | undefined;
@@ -1752,6 +1770,7 @@ declare const TargetConfig: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     }, {
         disable_all?: boolean | undefined;
@@ -1763,6 +1782,7 @@ declare const TargetConfig: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     }>>;
 }, "strip", z.ZodTypeAny, {
@@ -1901,6 +1921,7 @@ declare const TargetConfig: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     } | undefined;
     drift_detection?: {
@@ -2046,6 +2067,7 @@ declare const TargetConfig: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     } | undefined;
     drift_detection?: {
@@ -2097,6 +2119,7 @@ declare const Config: z.ZodObject<{
             tf: z.ZodOptional<z.ZodBoolean>;
             combine: z.ZodOptional<z.ZodBoolean>;
             enabled: z.ZodOptional<z.ZodBoolean>;
+            paths: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
         }, "strip", z.ZodTypeAny, {
             data?: string | undefined;
             id?: string | undefined;
@@ -2105,6 +2128,7 @@ declare const Config: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }, {
             data?: string | undefined;
             id?: string | undefined;
@@ -2113,6 +2137,7 @@ declare const Config: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }>, "many">>;
     }, "strip", z.ZodTypeAny, {
         disable_all?: boolean | undefined;
@@ -2124,6 +2149,7 @@ declare const Config: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     }, {
         disable_all?: boolean | undefined;
@@ -2135,6 +2161,7 @@ declare const Config: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     }>>;
     draft_pr: z.ZodOptional<z.ZodBoolean>;
@@ -2734,6 +2761,7 @@ declare const Config: z.ZodObject<{
                 tf: z.ZodOptional<z.ZodBoolean>;
                 combine: z.ZodOptional<z.ZodBoolean>;
                 enabled: z.ZodOptional<z.ZodBoolean>;
+                paths: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
             }, "strip", z.ZodTypeAny, {
                 data?: string | undefined;
                 id?: string | undefined;
@@ -2742,6 +2770,7 @@ declare const Config: z.ZodObject<{
                 plan?: boolean | undefined;
                 tf?: boolean | undefined;
                 combine?: boolean | undefined;
+                paths?: string[] | undefined;
             }, {
                 data?: string | undefined;
                 id?: string | undefined;
@@ -2750,6 +2779,7 @@ declare const Config: z.ZodObject<{
                 plan?: boolean | undefined;
                 tf?: boolean | undefined;
                 combine?: boolean | undefined;
+                paths?: string[] | undefined;
             }>, "many">>;
         }, "strip", z.ZodTypeAny, {
             disable_all?: boolean | undefined;
@@ -2761,6 +2791,7 @@ declare const Config: z.ZodObject<{
                 plan?: boolean | undefined;
                 tf?: boolean | undefined;
                 combine?: boolean | undefined;
+                paths?: string[] | undefined;
             }[] | undefined;
         }, {
             disable_all?: boolean | undefined;
@@ -2772,6 +2803,7 @@ declare const Config: z.ZodObject<{
                 plan?: boolean | undefined;
                 tf?: boolean | undefined;
                 combine?: boolean | undefined;
+                paths?: string[] | undefined;
             }[] | undefined;
         }>>;
     }, "strip", z.ZodTypeAny, {
@@ -2930,6 +2962,7 @@ declare const Config: z.ZodObject<{
                 plan?: boolean | undefined;
                 tf?: boolean | undefined;
                 combine?: boolean | undefined;
+                paths?: string[] | undefined;
             }[] | undefined;
         } | undefined;
     }, {
@@ -3088,6 +3121,7 @@ declare const Config: z.ZodObject<{
                 plan?: boolean | undefined;
                 tf?: boolean | undefined;
                 combine?: boolean | undefined;
+                paths?: string[] | undefined;
             }[] | undefined;
         } | undefined;
     }>, "many">;
@@ -3293,6 +3327,7 @@ declare const Config: z.ZodObject<{
                 plan?: boolean | undefined;
                 tf?: boolean | undefined;
                 combine?: boolean | undefined;
+                paths?: string[] | undefined;
             }[] | undefined;
         } | undefined;
     }[];
@@ -3308,6 +3343,7 @@ declare const Config: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     } | undefined;
     drift_detection?: {
@@ -3517,6 +3553,7 @@ declare const Config: z.ZodObject<{
                 plan?: boolean | undefined;
                 tf?: boolean | undefined;
                 combine?: boolean | undefined;
+                paths?: string[] | undefined;
             }[] | undefined;
         } | undefined;
     }[];
@@ -3532,6 +3569,7 @@ declare const Config: z.ZodObject<{
             plan?: boolean | undefined;
             tf?: boolean | undefined;
             combine?: boolean | undefined;
+            paths?: string[] | undefined;
         }[] | undefined;
     } | undefined;
     drift_detection?: {

--- a/lib/dist/index.js
+++ b/lib/dist/index.js
@@ -68,6 +68,7 @@ const ConftestPolicyConfig = zod_1.z.object({
     tf: zod_1.z.optional(zod_1.z.boolean()),
     combine: zod_1.z.optional(zod_1.z.boolean()),
     enabled: zod_1.z.optional(zod_1.z.boolean()),
+    paths: zod_1.z.optional(zod_1.z.array(zod_1.z.string())),
 });
 const ConftestConfig = zod_1.z.object({
     disable_all: zod_1.z.optional(zod_1.z.boolean()),

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -60,6 +60,7 @@ const ConftestPolicyConfig = z.object({
   tf: z.optional(z.boolean()),
   combine: z.optional(z.boolean()),
   enabled: z.optional(z.boolean()),
+  paths: z.optional(z.array(z.string())),
 });
 
 export type ConftestPolicyConfig = z.infer<typeof ConftestPolicyConfig>;


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/tfaction/pull/1893

```yaml
conftest:
  policies:
    - policy: policy/tfaction
      paths:
        - tfaction.yaml # glob is available https://www.npmjs.com/package/glob
```

glob is available.

https://www.npmjs.com/package/glob