### PR TITLE
feat(conftest): create a special data file

### DIFF
--- a/conftest/package-lock.json
+++ b/conftest/package-lock.json
@@ -8,7 +8,8 @@
         "@actions/core": "1.11.1",
         "glob": "^11.0.0",
         "js-yaml": "4.1.0",
-        "lib": "file:../lib/dist"
+        "lib": "file:../lib/dist",
+        "tmp": "^0.2.3"
       },
       "devDependencies": {
         "@types/node": "20.16.11",
@@ -1553,6 +1554,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tunnel": {

--- a/conftest/package-lock.json
+++ b/conftest/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "20.16.11",
+        "@types/tmp": "^0.2.6",
         "@vercel/ncc": "0.38.2",
         "typescript": "5.6.3",
         "vitest": "2.1.3"
@@ -718,6 +719,13 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vercel/ncc": {
       "version": "0.38.2",

--- a/conftest/package.json
+++ b/conftest/package.json
@@ -7,7 +7,8 @@
     "@actions/core": "1.11.1",
     "glob": "^11.0.0",
     "js-yaml": "4.1.0",
-    "lib": "file:../lib/dist"
+    "lib": "file:../lib/dist",
+    "tmp": "^0.2.3"
   },
   "devDependencies": {
     "@types/node": "20.16.11",

--- a/conftest/package.json
+++ b/conftest/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@types/node": "20.16.11",
+    "@types/tmp": "^0.2.6",
     "@vercel/ncc": "0.38.2",
     "typescript": "5.6.3",
     "vitest": "2.1.3"

--- a/conftest/src/run.ts
+++ b/conftest/src/run.ts
@@ -3,6 +3,7 @@ import * as exec from "@actions/exec";
 import * as lib from "lib";
 import * as path from "path";
 import fs from "fs";
+import tmp from "tmp";
 import { globSync } from "glob";
 
 type Inputs = {
@@ -175,6 +176,17 @@ export const run = async (inputs: Inputs, config: lib.Config) => {
         }
       }
     }
+
+    // create a special data file
+    tmp.setGracefulCleanup();
+    const tmpobj = tmp.dirSync();
+    const data = {
+      target: t.target,
+      working_directory: t.workingDir,
+    };
+    const tmpFile = path.join(tmpobj.name, "data.json");
+    fs.writeFileSync(tmpFile, JSON.stringify(data));
+    args.push("--data", tmpFile);
 
     if (policy.fail_on_warn) {
       args.push("--fail-on-warn");

--- a/conftest/src/run.ts
+++ b/conftest/src/run.ts
@@ -181,8 +181,10 @@ export const run = async (inputs: Inputs, config: lib.Config) => {
     tmp.setGracefulCleanup();
     const tmpobj = tmp.dirSync();
     const data = {
-      target: t.target,
-      working_directory: t.workingDir,
+      tfaction: {
+        target: t.target,
+        working_directory: t.workingDir,
+      },
     };
     const tmpFile = path.join(tmpobj.name, "data.json");
     fs.writeFileSync(tmpFile, JSON.stringify(data));


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/tfaction/issues/1896#issuecomment-2412399621

You can now refer `target` and `working_directory` in Conftest policies via [--data option](https://www.conftest.dev/options/#-data).
tfaction creates a special data file temporarily and pass it to your policies.

```rego
import data.tfaction

target := tfaction.target
working_directory := tfaction.working_directory
```