### PR TITLE
feat: added `aws_role_sesion_name`

### DIFF
--- a/get-target-config/src/run.test.ts
+++ b/get-target-config/src/run.test.ts
@@ -64,6 +64,7 @@ test("config", async () => {
       ["terraform_command", "tofu"],
       ["destroy", false],
       ["aws_region", "us-east-1"],
+      ["aws_role_session_name", "test"],
     ]),
   };
   expect(
@@ -92,6 +93,7 @@ test("config", async () => {
             working_directory: "tests/aws/",
             template_dir: "templates/aws",
             aws_region: "ap-northeast-1",
+            aws_role_session_name: "test",
           },
         ],
       },

--- a/get-target-config/src/run.ts
+++ b/get-target-config/src/run.ts
@@ -115,6 +115,7 @@ export const run = async (
       [
         "aws_region",
         "aws_assume_role_arn",
+        "aws_role_session_name",
         "gcp_service_account",
         "gcp_workload_identity_provider",
         "gcp_access_token_scopes",

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -120,6 +120,7 @@ export type AWSSecretsManagerSecret = z.infer<typeof AWSSecretsManagerSecret>;
 
 const JobConfig = z.object({
   aws_assume_role_arn: z.optional(z.string()),
+  aws_role_session_name: z.optional(z.string()),
   gcp_service_account: z.optional(z.string()),
   gcp_workload_identity_provider: z.optional(z.string()),
   gcp_access_token_scopes: z.optional(z.string()),
@@ -137,6 +138,7 @@ export type JobConfig = z.infer<typeof JobConfig>;
 const TargetGroup = z.object({
   aws_region: z.optional(z.string()),
   aws_assume_role_arn: z.optional(z.string()),
+  aws_role_session_name: z.optional(z.string()),
   destroy: z.optional(z.boolean()),
   env: z.optional(z.record(z.string())),
   environment: z.optional(GitHubEnvironment),

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -90,7 +90,7 @@ runs:
       if: steps.target-config.outputs.aws_assume_role_arn != ''
       with:
         role-to-assume: ${{ steps.target-config.outputs.aws_assume_role_arn }}
-        role-session-name: samplerolesession
+        role-session-name: ${{ steps.target-config.outputs.aws_role_session_name }}
         aws-region: ${{ steps.target-config.outputs.aws_region }}
 
     - uses: suzuki-shunsuke/tfaction/export-aws-secrets-manager@main


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/tfaction/issues/1930
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

## Summary
[aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) to allow [role-session-name](https://github.com/aws-actions/configure-aws-credentials/blob/2cefa29f8797029f898b1baeff3e21a144128687/action.yml#L49-L51) to be set when execution AssumeRole.

## Why is the feature needed?
Currently, tfaction has a fixed value of `samplerolesession` when execute AssumeRole operation, which is undesirable.
https://github.com/suzuki-shunsuke/tfaction/blob/1f76ed16ff681ff5bff6feaa117f97a39d0b5808/setup/action.yaml#L93

This value is mainly recorded in CloudTrail as the User name. 
![image](https://github.com/user-attachments/assets/060acc63-ec54-447a-afca-30232661949e)

Ideally, different names should be set for different IAM Roles. This makes it easier to track which session performed which operation.