### PR TITLE
feat: install dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       update-aqua-checksums: ${{steps.changes.outputs.update-aqua-checksums}}
+      update-aqua-checksums-install: ${{steps.changes.outputs.update-aqua-checksums-install}}
       renovate-config-validator: ${{steps.changes.outputs.renovate-config-validator}}
       ghalint: ${{steps.changes.outputs.ghalint}}
       shellcheck: ${{steps.changes.outputs.shellcheck}}
@@ -23,6 +24,13 @@ jobs:
               - aqua/*.yaml
               - aqua/aqua-checksums.json
               - .github/workflows/test.yaml
+              - .github/workflows/wc-update-aqua-checksums.yaml
+            update-aqua-checksums-install:
+              - install/aqua.yaml
+              - install/aqua/*.yaml
+              - install/aqua-checksums.json
+              - .github/workflows/test.yaml
+              - .github/workflows/wc-update-aqua-checksums-install.yaml
             renovate-config-validator:
               - renovate.json5
               - .github/workflows/test.yaml
@@ -47,6 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - update-aqua-checksums
+      - update-aqua-checksums-install
       - renovate-config-validator
       - ghalint
       - build-schema
@@ -61,6 +70,16 @@ jobs:
     needs: path-filter
     if: needs.path-filter.outputs.update-aqua-checksums == 'true'
     uses: ./.github/workflows/wc-update-aqua-checksums.yaml
+    permissions:
+      contents: read
+    secrets:
+      gh_app_id: ${{secrets.APP_ID}}
+      gh_app_private_key: ${{secrets.APP_PRIVATE_KEY}}
+
+  update-aqua-checksums-install:
+    needs: path-filter
+    if: needs.path-filter.outputs.update-aqua-checksums-install == 'true'
+    uses: ./.github/workflows/wc-update-aqua-checksums-install.yaml
     permissions:
       contents: read
     secrets:

--- a/.github/workflows/wc-update-aqua-checksums-install.yaml
+++ b/.github/workflows/wc-update-aqua-checksums-install.yaml
@@ -1,0 +1,23 @@
+---
+name: update-aqua-checksums
+on:
+  workflow_call:
+    secrets:
+      gh_app_id:
+        required: true
+      gh_app_private_key:
+        required: true
+
+jobs:
+  update-aqua-checksums:
+    # Update aqua-checksums.json and push a commit
+    uses: aquaproj/update-checksum-workflow/.github/workflows/update-checksum.yaml@437067ad2fba9ba8ed8454cf207f2532432d4e28 # v1.0.2
+    permissions:
+      contents: read
+    with:
+      aqua_version: v2.37.1
+      prune: true
+      working_directory: install
+    secrets:
+      gh_app_id: ${{secrets.gh_app_id}}
+      gh_app_private_key: ${{secrets.gh_app_private_key}}

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -246,8 +246,8 @@
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.238.0/registry.yaml",
-      "checksum": "E43D0AE8B755398BB3B3E7E2DBCCAE94F87910EB6009F28BED9B34666283056C",
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.246.0/registry.yaml",
+      "checksum": "153438D21A059F716E695701D3A0E41AF537024C25AB8B6852EE6B996E313C93",
       "algorithm": "sha256"
     }
   ]

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -1,0 +1,26 @@
+name: Install dependencies by aqua
+description: Install dependencies by aqua
+inputs:
+  github_token:
+    description: |
+      GitHub Access Token
+      contents:read - Install registries and packages
+    required: false
+    default: ${{ github.token }}
+outputs:
+  config:
+    description: aqua config paths
+    value: ${{ steps.config.outputs.config }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: config
+      run: echo "config=$GITHUB_ACTION_PATH/aqua.yaml" >> "$GITHUB_OUTPUT"
+    - run: aqua i -l
+      shell: bash
+      env:
+        AQUA_CONFIG: ${{ steps.config.outputs.config }}
+        AQUA_GITHUB_TOKEN: ${{ inputs.github_token }}
+    - shell: bash
+      run: echo "AQUA_GLOBAL_CONFIG=$GITHUB_ACTION_PATH/aqua.yaml:${AQUA_GLOBAL_CONFIG:-}" >> "$GITHUB_ENV"

--- a/install/aqua-checksums.json
+++ b/install/aqua-checksums.json
@@ -1,11 +1,6 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_linux_amd64.tar.gz",
-      "checksum": "DFCD9926DE38A797E88E604C3111ECF9DDF13C524706712B2B0D2E2FC4A6ED7F",
-      "algorithm": "sha256"
-    },
-    {
       "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_linux_arm64.tar.gz",
       "checksum": "A2842ED6D1F9E260043305749383BB1EB77D817BB57E22CF8C01DA0A48CAFF66",
       "algorithm": "sha256"

--- a/install/aqua-checksums.json
+++ b/install/aqua-checksums.json
@@ -1,0 +1,254 @@
+{
+  "checksums": [
+    {
+      "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_linux_amd64.tar.gz",
+      "checksum": "DFCD9926DE38A797E88E604C3111ECF9DDF13C524706712B2B0D2E2FC4A6ED7F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_linux_arm64.tar.gz",
+      "checksum": "A2842ED6D1F9E260043305749383BB1EB77D817BB57E22CF8C01DA0A48CAFF66",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_macOS_amd64.zip",
+      "checksum": "D44C5D0DACD23341293F18A17486A93392A29EF702EFA468FA3636A01637FE95",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_macOS_arm64.zip",
+      "checksum": "1930A3DB9A2D1C420E476D06F3D4A8F02DB8472D2630A1099968C3B82F231F1F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_windows_amd64.zip",
+      "checksum": "2C56F2FE38A62C8135401CFCD6BEC2E8720FF8AE44176F15E90B0CAC8F293C85",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_windows_arm64.zip",
+      "checksum": "5DDB1D4D013A44C2E5DF027867C0D4161383EB7C16E569A86384AF52BFE09A65",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/int128/ghcp/v1.13.4/ghcp_darwin_amd64.zip",
+      "checksum": "F58E47490B3FC8AEF1679C8CC24A0278457C5F02423F38AB35B1F13BE6903CCB",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/int128/ghcp/v1.13.4/ghcp_linux_amd64.zip",
+      "checksum": "5867522FB90C2ACA8907767732E194E498C5A129C61B280EE6F40E6727426685",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/int128/ghcp/v1.13.4/ghcp_windows_amd64.zip",
+      "checksum": "1482935DBB13980A1CCF27BFB54500882C39EA7083FCE08977343E3AF5579006",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/minamijoyo/tfmigrate/v0.3.24/tfmigrate_0.3.24_darwin_amd64.tar.gz",
+      "checksum": "1C5B0FCB714C633C391E368512023C16D81F989FA47BD3A78AB5BEEAF1F8AADE",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/minamijoyo/tfmigrate/v0.3.24/tfmigrate_0.3.24_darwin_arm64.tar.gz",
+      "checksum": "AE1BBDDEBD4EEB9469A60CB4F0A970708CD4E5D59ED673EF2538C335B8FF5C6C",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/minamijoyo/tfmigrate/v0.3.24/tfmigrate_0.3.24_linux_amd64.tar.gz",
+      "checksum": "3E6E4BA2AA80681019DD27BDD18C942CB4EBA0CA2BD77699DE2EF7A0EB060222",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/minamijoyo/tfmigrate/v0.3.24/tfmigrate_0.3.24_linux_arm64.tar.gz",
+      "checksum": "51190DF66A1B1A1DD46DE5674946A226C6AB1915CE305335766B614C337B6072",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/open-policy-agent/conftest/v0.56.0/conftest_0.56.0_Darwin_arm64.tar.gz",
+      "checksum": "F84ECD403BF2F3ECFF508BBEE4F3A4EC7BEF5290A472C0E902501354A2277A59",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/open-policy-agent/conftest/v0.56.0/conftest_0.56.0_Darwin_x86_64.tar.gz",
+      "checksum": "76864DBB51B1A932373375A9514802EBB65F9700470C1E69A692A2EC805CEC50",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/open-policy-agent/conftest/v0.56.0/conftest_0.56.0_Linux_arm64.tar.gz",
+      "checksum": "86334E4CA57B991F0DCA0DD3D011270EDDA50FDFF2B2E208954EA639BB1C99EC",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/open-policy-agent/conftest/v0.56.0/conftest_0.56.0_Linux_x86_64.tar.gz",
+      "checksum": "620F41640D63BBDE1646A108CE2816BA54C980466CEEBB7E754DDA2D508E8CD5",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/open-policy-agent/conftest/v0.56.0/conftest_0.56.0_Windows_arm64.zip",
+      "checksum": "1AF2BE9202507A17B800E6E90923284FADCAF2BA6BEC75B0DA3D69549DCB291F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/open-policy-agent/conftest/v0.56.0/conftest_0.56.0_Windows_x86_64.zip",
+      "checksum": "22806C17BCF7003139885526CD1DF158A6D3A141D9D92EE461F9AD679F0BAAE2",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_darwin_amd64.tar.gz",
+      "checksum": "12CCAC8418415E5F28012E864E1714A84636C3720F2166B9A3B27E15393870C6",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_darwin_arm64.tar.gz",
+      "checksum": "7FEC0B88D213986B16605DD8E64F6230E4B4FC605A0CE4C2FD9698FDC40D3E2D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_linux_amd64.tar.gz",
+      "checksum": "66C78BEBE4C4B0CE28E7AA5CD06FDAB9DB12E9D4116BE9135224DEE55B94CF38",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_linux_arm64.tar.gz",
+      "checksum": "5758EAC473D6BFF381761B2AA88218EE28828666E799C10E856417A89E77928C",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_windows_amd64.tar.gz",
+      "checksum": "417420AB3D5CE24FBB1A8A2BAA568631DF40A8411A719908A1C1416482DDB722",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_windows_arm64.tar.gz",
+      "checksum": "991CD4F64DABBB541BC26BC0E2C7B2CC50E8C4EAFA24DA4F36F2894528651A0C",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/github-comment/v6.3.0/github-comment_6.3.0_darwin_amd64.tar.gz",
+      "checksum": "1D05A6A0AFED660C1E8A9399ECD7FD8FD3AFFEE9D95D2E410E350CC1A3DC71AE",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/github-comment/v6.3.0/github-comment_6.3.0_darwin_arm64.tar.gz",
+      "checksum": "0744E5F79F86F88FEE06C9C1FB2F2304FC5E726A8E615D5039CC96271C50CAAB",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/github-comment/v6.3.0/github-comment_6.3.0_linux_amd64.tar.gz",
+      "checksum": "626077A9C412759D4ECAEFF083EE931248CD7A69EE7FCE178021574025746626",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/github-comment/v6.3.0/github-comment_6.3.0_linux_arm64.tar.gz",
+      "checksum": "1FCC7BB8C66EC128310AD757E398D8B93601DC0625CF7B1753B9FFCE089BE765",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/github-comment/v6.3.0/github-comment_6.3.0_windows_amd64.tar.gz",
+      "checksum": "3461DA9EA91B22D9684E7015133FA46C4B644BBC0D145F18229E69BEA68CA200",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/github-comment/v6.3.0/github-comment_6.3.0_windows_arm64.tar.gz",
+      "checksum": "27BD4EAB0B7D5707AFDCF17381FB7C223D7A3FEC457B07E96B7CB1367E98D2C0",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_darwin_amd64.tar.gz",
+      "checksum": "A8117CEA55EFFFD2468FA81B856A447634F0D1A72FE81254765F08270A282A7D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_darwin_arm64.tar.gz",
+      "checksum": "54383EAACAE249CEBB5587B3B0883DDA8DCE2130982B24BA54DD284D983297DF",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_linux_amd64.tar.gz",
+      "checksum": "AEACB544B8A338E845AED69F0B702DF42994EC932099D90B5BCD7801ADF5DF82",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_linux_arm64.tar.gz",
+      "checksum": "570EFD8E3D5B47B675864A805C03603A5233FE21CB766FE3E065852CB8CA112F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_windows_amd64.tar.gz",
+      "checksum": "903E49D08ECC5ADB86BB143F6F76DEBBDF7A41CADA1FB9AFCAF2D2AC1C9939AE",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_windows_arm64.tar.gz",
+      "checksum": "916C06F5444C84CCE95D7F8CA05E68F657E80224B24CF21B49996B27744448A9",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.0/tfcmt_darwin_amd64.tar.gz",
+      "checksum": "FA35ECFE0EE3D632DE2613314E98AFDFD4C70A37F4BA8BCC30236283FAF54EDE",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.0/tfcmt_darwin_arm64.tar.gz",
+      "checksum": "5789EA2F3165B0448F84A46DF6489B01D0C90802D2C95D3FA4B74DE06177CED7",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.0/tfcmt_linux_amd64.tar.gz",
+      "checksum": "BF0C82A40839647B20629289C9F72FAA6DEE931F45DB26842E0818192C706309",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.0/tfcmt_linux_arm64.tar.gz",
+      "checksum": "B288B7375FBCC6F12F4971CC490C27E3FE023B592421F573B64712C75D72B448",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.0/tfcmt_windows_amd64.tar.gz",
+      "checksum": "F4F5E0664B58A52D8312310F8732EC62FB72E02200751730D9D879EF649FE783",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.0/tfcmt_windows_arm64.tar.gz",
+      "checksum": "BC9EDFED60D3F41C93D45703E8C6830554D5D173E2C85539DE351DF7090F510B",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.19.0/terraform-docs-v0.19.0-darwin-amd64.tar.gz",
+      "checksum": "FC3FA55037E35F1B76D1C7E84ED5A8B412EA6AED8264DF050E1F692FAD1DAE29",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.19.0/terraform-docs-v0.19.0-darwin-arm64.tar.gz",
+      "checksum": "C4E8D863571B8D5102089A22500426A18094855040EB07E4B83E4DFD1816DD23",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.19.0/terraform-docs-v0.19.0-linux-amd64.tar.gz",
+      "checksum": "DD741A0ECE81059A478684B414D95D72B8B74FA58F50AC4036B4E8B56130D64B",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.19.0/terraform-docs-v0.19.0-linux-arm64.tar.gz",
+      "checksum": "EBDA7DDA3A1F678E9E3EF2F091C97B43F34A5A1B52FB9B1D3F44A003F481E8B5",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.19.0/terraform-docs-v0.19.0-windows-amd64.zip",
+      "checksum": "9D6D63B6C57FA82EC4BB61E7CDF504F52470FAE3E46E293A7E9FCCCBADDB1BA7",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.19.0/terraform-docs-v0.19.0-windows-arm64.zip",
+      "checksum": "87BE154D78DC594E01CCEAFBB93033B113F032696ECBC8C39D7A1214429602A6",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.246.0/registry.yaml",
+      "checksum": "153438D21A059F716E695701D3A0E41AF537024C25AB8B6852EE6B996E313C93",
+      "algorithm": "sha256"
+    }
+  ]
+}

--- a/install/aqua-checksums.json
+++ b/install/aqua-checksums.json
@@ -1,6 +1,11 @@
 {
   "checksums": [
     {
+      "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_linux_amd64.tar.gz",
+      "checksum": "DFCD9926DE38A797E88E604C3111ECF9DDF13C524706712B2B0D2E2FC4A6ED7F",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/cli/cli/v2.60.1/gh_2.60.1_linux_arm64.tar.gz",
       "checksum": "A2842ED6D1F9E260043305749383BB1EB77D817BB57E22CF8C01DA0A48CAFF66",
       "algorithm": "sha256"
@@ -91,33 +96,33 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_darwin_amd64.tar.gz",
-      "checksum": "12CCAC8418415E5F28012E864E1714A84636C3720F2166B9A3B27E15393870C6",
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.0/ci-info_2.3.0_darwin_amd64.tar.gz",
+      "checksum": "CE305C6E0DE5A5232A6C161CEC5BE21FBA53C487A223D4453A130DD52CF2BB90",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_darwin_arm64.tar.gz",
-      "checksum": "7FEC0B88D213986B16605DD8E64F6230E4B4FC605A0CE4C2FD9698FDC40D3E2D",
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.0/ci-info_2.3.0_darwin_arm64.tar.gz",
+      "checksum": "F92C13A00241D24500A0039D5C2BEAEBBAC778712FB5437D06A03C2EAE2129AC",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_linux_amd64.tar.gz",
-      "checksum": "66C78BEBE4C4B0CE28E7AA5CD06FDAB9DB12E9D4116BE9135224DEE55B94CF38",
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.0/ci-info_2.3.0_linux_amd64.tar.gz",
+      "checksum": "E09FCEE6FD8F2C1E0FB34505B87BCCBF62DB02BD162ADA632564E7F562701FB7",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_linux_arm64.tar.gz",
-      "checksum": "5758EAC473D6BFF381761B2AA88218EE28828666E799C10E856417A89E77928C",
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.0/ci-info_2.3.0_linux_arm64.tar.gz",
+      "checksum": "7AE845855A65504917C89733580D7207E6BFFD7D721BE322E6E7A78803E96C09",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_windows_amd64.tar.gz",
-      "checksum": "417420AB3D5CE24FBB1A8A2BAA568631DF40A8411A719908A1C1416482DDB722",
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.0/ci-info_2.3.0_windows_amd64.tar.gz",
+      "checksum": "39D5055203CC327C66FCEC0B49DBAA847A89AA206D94D4360A71791165FED17A",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.1/ci-info_2.3.1_windows_arm64.tar.gz",
-      "checksum": "991CD4F64DABBB541BC26BC0E2C7B2CC50E8C4EAFA24DA4F36F2894528651A0C",
+      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.3.0/ci-info_2.3.0_windows_arm64.tar.gz",
+      "checksum": "35B610B35FB7DF32B4A421B7185FD0750BA01615ADC46232487DD402097B5E25",
       "algorithm": "sha256"
     },
     {
@@ -241,9 +246,9 @@
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.246.0/registry.yaml",
-      "checksum": "153438D21A059F716E695701D3A0E41AF537024C25AB8B6852EE6B996E313C93",
-      "algorithm": "sha256"
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.245.0/registry.yaml",
+      "checksum": "206137852AC004C6679748FF866169C6AE88976CBA2B7F5E9E84C7926B3ACC08958279B02157FDE73E6E6D6A1A2369C9D1E63EC118FEF18743F6E81505EBFB0E",
+      "algorithm": "sha512"
     }
   ]
 }

--- a/install/aqua.yaml
+++ b/install/aqua.yaml
@@ -1,0 +1,11 @@
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+checksum:
+  enabled: true
+  require_checksum: true
+registries:
+  - type: standard
+    ref: v4.246.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+  # Split packages per package with `import` to avoid pull requests' conflict
+  - import: aqua/*.yaml

--- a/install/aqua.yaml
+++ b/install/aqua.yaml
@@ -5,7 +5,7 @@ checksum:
   require_checksum: true
 registries:
   - type: standard
-    ref: v4.246.0 # renovate: depName=aquaproj/aqua-registry
+    ref: v4.245.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   # Split packages per package with `import` to avoid pull requests' conflict
   - import: aqua/*.yaml

--- a/install/aqua/ci-info.yaml
+++ b/install/aqua/ci-info.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/ci-info@v2.3.1

--- a/install/aqua/ci-info.yaml
+++ b/install/aqua/ci-info.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/ci-info@v2.3.1
+  - name: suzuki-shunsuke/ci-info@v2.3.0

--- a/install/aqua/conftest.yaml
+++ b/install/aqua/conftest.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: open-policy-agent/conftest@v0.56.0

--- a/install/aqua/gh.yaml
+++ b/install/aqua/gh.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cli/cli@v2.60.1

--- a/install/aqua/ghcp.yaml
+++ b/install/aqua/ghcp.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: int128/ghcp@v1.13.4

--- a/install/aqua/github-comment.yaml
+++ b/install/aqua/github-comment.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/github-comment@v6.3.0

--- a/install/aqua/terraform-config-inspect.yaml
+++ b/install/aqua/terraform-config-inspect.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: hashicorp/terraform-config-inspect
+    version: v0.0.0-20240801114854-6714b46f5fe4

--- a/install/aqua/terraform-docs.yaml
+++ b/install/aqua/terraform-docs.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: terraform-docs/terraform-docs@v0.19.0

--- a/install/aqua/tfaction-go.yaml
+++ b/install/aqua/tfaction-go.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/tfaction-go@v0.2.3

--- a/install/aqua/tfcmt.yaml
+++ b/install/aqua/tfcmt.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/tfcmt@v4.14.0

--- a/install/aqua/tfmigrate.yaml
+++ b/install/aqua/tfmigrate.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: minamijoyo/tfmigrate@v0.3.24

--- a/list-targets/action.yaml
+++ b/list-targets/action.yaml
@@ -26,7 +26,6 @@ runs:
         ! contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        AQUA_CONFIG: ${{steps.install.outputs.config}}
 
     - name: Check if the commit is latest
       shell: bash
@@ -52,8 +51,6 @@ runs:
       with:
         config_files: ${{ steps.list-working-directory-configs.outputs.file }}
         module_files: ${{ steps.list-working-directory-configs.outputs.module_file }}
-      env:
-        AQUA_CONFIG: ${{steps.install.outputs.config}}
     - uses: suzuki-shunsuke/tfaction/list-targets-with-changed-files@main
       id: list-targets
       with:

--- a/list-targets/action.yaml
+++ b/list-targets/action.yaml
@@ -18,12 +18,15 @@ outputs:
 runs:
   using: composite
   steps:
+    - uses: suzuki-shunsuke/tfaction/install@main
+      id: install
     - run: github-comment exec -- ci-info run | sed "s/^export //" >> "$GITHUB_ENV"
       shell: bash
       if: |
         ! contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        AQUA_CONFIG: ${{steps.install.outputs.config}}
 
     - name: Check if the commit is latest
       shell: bash
@@ -49,6 +52,8 @@ runs:
       with:
         config_files: ${{ steps.list-working-directory-configs.outputs.file }}
         module_files: ${{ steps.list-working-directory-configs.outputs.module_file }}
+      env:
+        AQUA_CONFIG: ${{steps.install.outputs.config}}
     - uses: suzuki-shunsuke/tfaction/list-targets-with-changed-files@main
       id: list-targets
       with:

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -31,7 +31,6 @@ runs:
         ! contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        AQUA_CONFIG: ${{steps.install.outputs.config}}
 
     - name: Check if the commit is latest
       shell: bash
@@ -82,7 +81,6 @@ runs:
         working_directory: ${{ steps.target-config.outputs.working_directory }}
       env:
         GITHUB_TOKEN: ${{inputs.github_token}}
-        AQUA_CONFIG: ${{steps.install.outputs.config}}
 
     - run: aqua i -l -a
       shell: bash
@@ -136,5 +134,3 @@ runs:
         providers_lock_opts: ${{ steps.target-config.outputs.providers_lock_opts }}
         skip_push: ${{ github.event_name != 'pull_request' && ! startsWith(github.event_name, 'pull_request_') }}
         terraform_command: ${{ steps.target-config.outputs.terraform_command }}
-      env:
-        AQUA_CONFIG: ${{steps.install.outputs.config}}

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -23,12 +23,15 @@ outputs:
 runs:
   using: composite
   steps:
+    - uses: suzuki-shunsuke/tfaction/install@main
+      id: install
     - run: github-comment exec -- ci-info run | sed "s/^export //" >> "$GITHUB_ENV"
       shell: bash
       if: |
         ! contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        AQUA_CONFIG: ${{steps.install.outputs.config}}
 
     - name: Check if the commit is latest
       shell: bash
@@ -36,7 +39,7 @@ runs:
       run: |
         set -euo pipefail
 
-        latest_head_sha=$(jq -r ".head.sha" $CI_INFO_TEMP_DIR/pr.json)
+        latest_head_sha=$(jq -r ".head.sha" "$CI_INFO_TEMP_DIR/pr.json")
         if [ "$HEAD_SHA" != "$latest_head_sha" ]; then
           echo "::error::The head sha ($HEAD_SHA) isn't latest ($latest_head_sha)."
           exit 1
@@ -48,7 +51,7 @@ runs:
       id: target-config
 
     - run: |
-        curl -X POST "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" \
+        curl -X POST "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$CI_INFO_PR_NUMBER/labels" \
           -H "Authorization: token ${GITHUB_TOKEN}" \
           -H "Accept: application/json" \
           -H "Content-type: application/json" \
@@ -79,6 +82,7 @@ runs:
         working_directory: ${{ steps.target-config.outputs.working_directory }}
       env:
         GITHUB_TOKEN: ${{inputs.github_token}}
+        AQUA_CONFIG: ${{steps.install.outputs.config}}
 
     - run: aqua i -l -a
       shell: bash
@@ -132,3 +136,5 @@ runs:
         providers_lock_opts: ${{ steps.target-config.outputs.providers_lock_opts }}
         skip_push: ${{ github.event_name != 'pull_request' && ! startsWith(github.event_name, 'pull_request_') }}
         terraform_command: ${{ steps.target-config.outputs.terraform_command }}
+      env:
+        AQUA_CONFIG: ${{steps.install.outputs.config}}


### PR DESCRIPTION
`setup` and `list-targets` actions install the following tools via aqua and `AQUA_GLOBAL_CONFIG`.

- ci-info
- conftest
- gh
- ghcp
- github-comment
- terraform-config-inspect
- terraform-docs
- tfaction-go
- tfcmt
- tfmigrate

tfaction install these tools securely via checksum verification.

So you don't need to install these tools yourself anymore, but you can still overwrite these commands by your own aqua.yaml because your own aqua.yaml takes precedence over `$AQUA_GLOBAL_CONFIG`.

On the other hand, you still have to install the following tools yourself.

- tfsec
- tflint
- trivy
- Terraform

And if you want to hide old comments, you still have to install and run github-comment yourself.