### PR TITLE
fix(test): disable tflint --fix by default

### DIFF
--- a/get-target-config/src/run.ts
+++ b/get-target-config/src/run.ts
@@ -61,7 +61,7 @@ export const run = async (
   outputs.set("enable_tfsec", config?.tfsec?.enabled ?? false);
   outputs.set("enable_tflint", config?.tflint?.enabled ?? true);
   outputs.set("enable_trivy", config?.trivy?.enabled ?? true);
-  outputs.set("tflint_fix", config?.tflint?.fix ?? true);
+  outputs.set("tflint_fix", config?.tflint?.fix ?? false);
 
   outputs.set("terraform_command", "terraform");
 
@@ -152,8 +152,8 @@ export const run = async (
     outputs.set(
       "enable_terraform_docs",
       wdConfig?.terraform_docs?.enabled ??
-        config?.terraform_docs?.enabled ??
-        false,
+      config?.terraform_docs?.enabled ??
+      false,
     );
 
     const m3 = lib.setEnvs(

--- a/get-target-config/src/run.ts
+++ b/get-target-config/src/run.ts
@@ -152,8 +152,8 @@ export const run = async (
     outputs.set(
       "enable_terraform_docs",
       wdConfig?.terraform_docs?.enabled ??
-      config?.terraform_docs?.enabled ??
-      false,
+        config?.terraform_docs?.enabled ??
+        false,
     );
 
     const m3 = lib.setEnvs(


### PR DESCRIPTION
tflint --fix requires tflint v0.48.0 or later.
So this is a breaking change.
To keep the compatibility, we disable this feature by default.

You can enable this feature by tfaction-root.yaml

```yaml
tflint:
  enabled: true
  fix: true
```