### PR TITLE
ci: enable persist-credentials for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: false
+          persist-credentials: true # This is required to push a commit
       - run: gh pr checkout "$PR"
         if: inputs.pr != ''
         env:

--- a/ghalint.yaml
+++ b/ghalint.yaml
@@ -1,0 +1,4 @@
+excludes:
+  - policy_name: checkout_persist_credentials_should_be_false
+    workflow_file_path: .github/workflows/release.yaml
+    job_name: release


### PR DESCRIPTION
https://github.com/suzuki-shunsuke/tfaction/actions/runs/12490571831/job/34855465121

```
Run git push origin "$TAG"
fatal: could not read Username for 'https://github.com/': No such device or address
```