### PR TITLE
chore: added `secrets` input to tfaction/js

### DIFF
--- a/js/action.yaml
+++ b/js/action.yaml
@@ -52,6 +52,11 @@ inputs:
     required: false
     default: ${{ github.token }}
 
+  # export-secrets
+  secrets:
+    description: "A JSON representing a map whose keys are secret names and values are secret values"
+    required: false
+
 outputs:
   # get-target-config
   working_directory:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

Hi @suzuki-shunsuke

In tfaction v1.13.4, the following warning appeared when using export-secrets in tfaction/js.
```
Warning: Unexpected input(s) 'secrets', valid inputs are ['action', 'labels', 'skip_label_prefix', 'pr_author', 'changed_files', 'config_files', 'config', 'module_files', 'pull_request', 'module_callers', 'plan', 'github_token']
```

Probably, this is because TypeScript refers to inputs that are not defined in `action.yaml`

https://github.com/suzuki-shunsuke/tfaction/blob/952fc2e30a83ae774f0218486e86b6d71b0adb53/js/src/export-secrets/index.ts#L50
