### PR TITLE
fix: run terragrunt render-json on the directory where terragrunt.hcl exists

### DIFF
--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -356,9 +356,29 @@
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.296.0/registry.yaml",
-      "checksum": "A5EE510BFF6686A7991A01176551D2ACC61B3089C2E2B7D4366AC7C4DD7C487AADD11FEE65714C29A332B166C992E3B310C0DE93F16048B9A327949AF5319DEA",
-      "algorithm": "sha512"
+      "id": "http/releases.hashicorp.com/terraform/1.10.4/terraform_1.10.4_darwin_amd64.zip",
+      "checksum": "3E3D54A96B62B205636CE0FA9B64B85C23CB7E8AD0D63EB74D70080FF1EBFA3E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/releases.hashicorp.com/terraform/1.10.4/terraform_1.10.4_darwin_arm64.zip",
+      "checksum": "3264FE6A903665EF91D18EEBD99C494976F9D96F5DAC603E4F1E283682404009",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/releases.hashicorp.com/terraform/1.10.4/terraform_1.10.4_linux_amd64.zip",
+      "checksum": "64B7B60F35EB92E94A046B6C932CE53F632A9EB528E9D0097857F9F27420BE3E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/releases.hashicorp.com/terraform/1.10.4/terraform_1.10.4_linux_arm64.zip",
+      "checksum": "3C554A8B9BA2B2B03CDFE2B7CFA9B3CC40E98AF99E4A52E21E365B97AF2B3669",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/releases.hashicorp.com/terraform/1.10.4/terraform_1.10.4_windows_amd64.zip",
+      "checksum": "2E08193E7073FAC1E7D3E892D2394E578A10BAFFFEDEAF9E1EBF976FE9FAB979",
+      "algorithm": "sha256"
     },
     {
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.297.0/registry.yaml",

--- a/aqua/terraform.yaml
+++ b/aqua/terraform.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: hashicorp/terraform@v1.10.4

--- a/js/src/list-module-callers/index.ts
+++ b/js/src/list-module-callers/index.ts
@@ -31,11 +31,8 @@ export const main = async () => {
         cwd: tfDir,
       },
     );
-    let source = JSON.parse(fs.readFileSync(tmpobj.name, "utf8")).terraform
+    const source = JSON.parse(fs.readFileSync(tmpobj.name, "utf8")).terraform
       ?.source;
-    if (source) {
-      source = path.join(tfDir, source);
-    }
     if (
       source.startsWith("." + path.sep) ||
       source.startsWith(".." + path.sep)

--- a/js/src/list-module-callers/index.ts
+++ b/js/src/list-module-callers/index.ts
@@ -24,13 +24,13 @@ export const main = async () => {
       continue;
     }
     const tmpobj = tmp.fileSync();
-    await exec.exec("terragrunt", [
-      "render-json",
-      "--terragrunt-json-out",
-      tmpobj.name,
-    ], {
-      cwd: tfDir,
-    });
+    await exec.exec(
+      "terragrunt",
+      ["render-json", "--terragrunt-json-out", tmpobj.name],
+      {
+        cwd: tfDir,
+      },
+    );
     let source = JSON.parse(fs.readFileSync(tmpobj.name, "utf8")).terraform
       ?.source;
     if (source) {

--- a/js/src/list-module-callers/index.ts
+++ b/js/src/list-module-callers/index.ts
@@ -28,11 +28,14 @@ export const main = async () => {
       "render-json",
       "--terragrunt-json-out",
       tmpobj.name,
-      "--terragrunt-working-dir",
-      tfDir,
-    ]);
-    const source = JSON.parse(fs.readFileSync(tmpobj.name, "utf8")).terraform
+    ], {
+      cwd: tfDir,
+    });
+    let source = JSON.parse(fs.readFileSync(tmpobj.name, "utf8")).terraform
       ?.source;
+    if (source) {
+      source = path.join(tfDir, source);
+    }
     if (
       source.startsWith("." + path.sep) ||
       source.startsWith(".." + path.sep)


### PR DESCRIPTION
Fix a bug list-targets fails if `terragrunt.hcl` exists in the repository but terragrunt and terraform aren't found in the repository root directory.