### PR TITLE
add(deps): add `skip_setup_gcloud` input

### DIFF
--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -13,6 +13,10 @@ inputs:
   ssh_key:
     description: "SSH Key for Terraform Private Module"
     required: false
+  skip_setup_gcloud:
+    description: "If this value is not `false`, the setup-gcloud step will be skipped."
+    required: false
+    default: "false"
 outputs:
   working_directory:
     description: working directory
@@ -125,7 +129,7 @@ runs:
         token_format: ${{ steps.target-config.outputs.gcp_access_token_scopes != '' && 'access_token' || '' }}
 
     - uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
-      if: steps.target-config.outputs.gcp_service_account != ''
+      if: steps.target-config.outputs.gcp_service_account != '' && inputs.skip_setup_gcloud == 'false'
 
     - uses: suzuki-shunsuke/tfaction/deploy-ssh-key@main
       if: inputs.ssh_key != ''


### PR DESCRIPTION
Closes https://github.com/suzuki-shunsuke/tfaction/issues/2330

This issue introduces a new flag in the setup action that enables users to choose whether to skip the execution of the `google-github-actions/setup-gcloud` step.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/tfaction/issues/2330
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
