### PR TITLE
fix: fix a bug that TFACTION_TARGET is empty

### DIFF
--- a/generate-config-out/action.yaml
+++ b/generate-config-out/action.yaml
@@ -41,7 +41,6 @@ runs:
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}
       env:
-        TFACTION_TARGET: ${{steps.target-config.outputs.target}}
         FILE: ${{inputs.file}}
       run: |
         tempfile=generated_${GITHUB_RUN_ID}_$(date +%Y%m%d%H%M%S).tf

--- a/scaffold-working-dir/action.yaml
+++ b/scaffold-working-dir/action.yaml
@@ -103,5 +103,3 @@ runs:
     - run: git ls-files --modified --others --exclude-standard | xargs -n 1 sed -i "s|%%TARGET%%|${TFACTION_TARGET}|g"
       shell: bash
       working-directory: ${{steps.target-config.outputs.working_directory}}
-      env:
-        TFACTION_TARGET: ${{steps.target-config.outputs.target}}


### PR DESCRIPTION
Close #2918

get-target-config doesn't output `target`.
Instead, it sets the environment variable `TFACTION_TARGET`.

- https://github.com/suzuki-shunsuke/tfaction/commit/cac6c53bba43bbf419863f6b151183ae41fc408d
- https://github.com/suzuki-shunsuke/tfaction/pull/2785
  - https://github.com/suzuki-shunsuke/tfaction/commit/b811fe329dce029a2d4d95f3b4302c493a32b9df