### PR TITLE
feat: add assignees of the original PR to follow-up PRs

### DIFF
--- a/js/src/get-follow-up-pr-param/index.ts
+++ b/js/src/get-follow-up-pr-param/index.ts
@@ -1,5 +1,14 @@
 import * as core from "@actions/core";
 import * as fs from "fs";
+import { z } from "zod";
+
+const PRData = z.object({
+  assignees: z.array(
+    z.object({
+      login: z.string(),
+    })
+  ).optional(),
+});
 
 export const main = async () => {
   const prNumber = process.env.CI_INFO_PR_NUMBER;
@@ -35,6 +44,25 @@ Follow up #${prNumber} ([failed workflow](${runURL}))
   }
   if (actor && !actor.endsWith("[bot]") && actor !== prAuthor) {
     assignees.add(actor);
+  }
+
+  // Add assignees from the original PR
+  const ciInfoTempDir = process.env.CI_INFO_TEMP_DIR;
+  if (ciInfoTempDir) {
+    const prJsonPath = `${ciInfoTempDir}/pr.json`;
+    if (fs.existsSync(prJsonPath)) {
+      try {
+        const prDataRaw = JSON.parse(fs.readFileSync(prJsonPath, "utf8"));
+        const prData = PRData.parse(prDataRaw);
+        if (prData.assignees) {
+          for (const assignee of prData.assignees) {
+            assignees.add(assignee.login);
+          }
+        }
+      } catch (error) {
+        console.error("Failed to read or parse pr.json:", error);
+      }
+    }
   }
   core.setOutput("assignees_txt", [...assignees].join("\n"));
   core.setOutput(

--- a/js/src/get-follow-up-pr-param/index.ts
+++ b/js/src/get-follow-up-pr-param/index.ts
@@ -3,11 +3,13 @@ import * as fs from "fs";
 import { z } from "zod";
 
 const PRData = z.object({
-  assignees: z.array(
-    z.object({
-      login: z.string(),
-    })
-  ).optional(),
+  assignees: z
+    .array(
+      z.object({
+        login: z.string(),
+      }),
+    )
+    .optional(),
 });
 
 export const main = async () => {


### PR DESCRIPTION
## Summary
- Add assignees from the original PR to follow-up PRs automatically
- Implement zod validation for pr.json parsing
- Resolves #2946

## Changes
- Read assignees from `$CI_INFO_TEMP_DIR/pr.json`
- Add zod schema validation for type safety
- Include original PR assignees in addition to PR author and actor

## Test plan
- [x] TypeScript build succeeds
- [x] Test with actual PR that has assignees
- [x] Verify follow-up PR gets correct assignees