### PR TITLE
fix(ci): set CI_INFO env vars for check-terraform-skip test

### DIFF
--- a/.github/workflows/wc-create-pr-branch.yaml
+++ b/.github/workflows/wc-create-pr-branch.yaml
@@ -117,12 +117,16 @@ jobs:
         env:
           TFACTION_CONFIG: js/test/tfaction-root.yaml
           TFACTION_JOB_TYPE: terraform
+          CI_INFO_TEMP_DIR: js/test/ci-info
+          CI_INFO_PR_AUTHOR: suzuki-shunsuke
       - name: Test check-terraform-skip
         uses: ./check-terraform-skip
         id: check-terraform-skip
         env:
           TFACTION_CONFIG: js/test/tfaction-root.yaml
           TFACTION_JOB_TYPE: terraform
+          CI_INFO_TEMP_DIR: js/test/ci-info
+          CI_INFO_PR_AUTHOR: suzuki-shunsuke
 
       - name: Test js/list-changed-modules
         uses: ./js


### PR DESCRIPTION
The check-terraform-skip test was failing on Renovate bot PRs because CI_INFO_PR_AUTHOR was set to renovate[bot] by the ci-info action. With skip_terraform_by_renovate: true and no terraform label, skip_terraform was returning true instead of expected false.

Set fixed test values for CI_INFO_TEMP_DIR and CI_INFO_PR_AUTHOR to ensure consistent test behavior regardless of actual PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)