### PR TITLE
fix: remove the field `target` from target_groups in tfaction-root.yaml

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -165,7 +165,6 @@ const TargetGroup = z.object({
   runs_on: z.optional(z.union([z.string(), z.array(z.string())])),
   secrets: z.optional(GitHubSecrets),
   s3_bucket_name_tfmigrate_history: z.optional(z.string()),
-  target: z.optional(z.string()),
   template_dir: z.optional(z.string()),
   terraform_apply_config: z.optional(JobConfig),
   terraform_plan_config: z.optional(JobConfig),
@@ -416,9 +415,6 @@ export const createWDTargetMap = (
       if (!wd.startsWith(tg.working_directory)) {
         continue;
       }
-      if (tg.target !== undefined) {
-        target = tg.target + wd.slice(tg.working_directory.length);
-      }
       for (const pattern of config.replace?.patterns ?? []) {
         target = target.replace(
           new RegExp(pattern.regexp, pattern.flags),
@@ -551,12 +547,6 @@ export const getTargetGroup = async (
       };
     }
     target = workingDir;
-    if (targetConfig?.target !== undefined) {
-      target = workingDir.replace(
-        targetConfig.working_directory,
-        targetConfig.target,
-      );
-    }
     for (const pattern of config.replace?.patterns ?? []) {
       target = target.replace(new RegExp(pattern.regexp), pattern.replace);
     }
@@ -632,7 +622,7 @@ export const createIssue = async (
   const octokit = github.getOctokit(ghToken);
   const body = `
   This issues was created by [tfaction](https://suzuki-shunsuke.github.io/tfaction/docs/).
-  
+
   About this issue, please see [the document](https://suzuki-shunsuke.github.io/tfaction/docs/feature/drift-detection).
   `;
 

--- a/src/list-targets/list-targets-with-changed-files/index.test.ts
+++ b/src/list-targets/list-targets-with-changed-files/index.test.ts
@@ -8,7 +8,6 @@ test("normal", async () => {
         plan_workflow_name: "plan.yaml",
         target_groups: [
           {
-            target: "foo/",
             working_directory: "foo/",
           },
         ],
@@ -51,7 +50,6 @@ test("job config", async () => {
         plan_workflow_name: "plan.yaml",
         target_groups: [
           {
-            target: "foo/",
             working_directory: "foo/",
             runs_on: "macos-latest",
             secrets: [
@@ -102,9 +100,16 @@ test("job config", async () => {
 
 const prCommentConfig = {
   plan_workflow_name: "plan.yaml",
+  replace: {
+    patterns: [
+      {
+        regexp: "^yoo/services/",
+        replace: "yoo/",
+      },
+    ],
+  },
   target_groups: [
     {
-      target: "foo/",
       working_directory: "foo/",
       runs_on: "macos-latest",
       secrets: [
@@ -116,17 +121,16 @@ const prCommentConfig = {
       environment: "dev",
     },
     {
-      target: "yoo/",
       working_directory: "yoo/services/",
       runs_on: "ubuntu-latest",
       environment: "yoo",
     },
     {
-      target: "zoo/",
       working_directory: "zoo/",
     },
   ],
 };
+
 const prCommentExpected = {
   modules: [],
   targetConfigs: [
@@ -209,7 +213,6 @@ test("module callers", async () => {
         plan_workflow_name: "plan.yaml",
         target_groups: [
           {
-            target: "foo/",
             working_directory: "foo/",
           },
         ],
@@ -275,7 +278,6 @@ test("nest", async () => {
         plan_workflow_name: "plan.yaml",
         target_groups: [
           {
-            target: "foo/",
             working_directory: "foo/",
           },
         ],

--- a/src/pick-out-drift-issues/index.ts
+++ b/src/pick-out-drift-issues/index.ts
@@ -168,12 +168,12 @@ const getRunsOn = (
 // Get target name from working directory path
 const getTargetByWorkingDirectory = (
   workingDirectoryPath: string,
-  targetGroup: lib.TargetGroup,
+  config: lib.Config,
 ): string => {
-  if (targetGroup.target !== undefined) {
-    return (
-      targetGroup.target +
-      workingDirectoryPath.slice(targetGroup.working_directory.length)
+  for (const pattern of config.replace?.patterns ?? []) {
+    workingDirectoryPath = workingDirectoryPath.replace(
+      new RegExp(pattern.regexp),
+      pattern.replace,
     );
   }
   return workingDirectoryPath;
@@ -238,10 +238,7 @@ const listTargets = async (
     }
 
     // Get target and runs_on
-    const target = getTargetByWorkingDirectory(
-      workingDirectoryPath,
-      targetGroup,
-    );
+    const target = getTargetByWorkingDirectory(workingDirectoryPath, config);
     const runsOn = getRunsOn(config, targetGroup, wdConfig);
 
     targets.set(target, runsOn);


### PR DESCRIPTION
## ⚠️ Breaking Changes

The field `target` is removed from `target_groups` in tfaction-root.yaml.

### How To Migrate

Use the setting `replace` instead.

e.g.

Before:

```yaml
target_groups:
  - working_directory: github/services/
    target: github/ # Remove `/services` from `github/services/...
    # ...
```

After:

```yaml
replace:
  patterns:
    - regexp: "^github/services/"
      replace: "github/"

target_groups:
  - working_directory: github/services/
    # ...
```