### PR TITLE
fix: fix graphql error

### DIFF
--- a/src/apply/terraform-apply/run.ts
+++ b/src/apply/terraform-apply/run.ts
@@ -36,8 +36,8 @@ export const listRelatedPullRequests = async (
     };
   } = await octokit.graphql(
     `
-    query($query: String!) {
-      search(query: $query, type: ISSUE, first: 100) {
+    query($q: String!) {
+      search(query: $q, type: ISSUE, first: 100) {
         nodes {
           ... on PullRequest {
             number
@@ -46,7 +46,7 @@ export const listRelatedPullRequests = async (
       }
     }
   `,
-    { query },
+    { q: query },
   );
 
   return result.search.nodes.map((pr) => pr.number);


### PR DESCRIPTION
```
Error: [@octokit/graphql] "query" cannot be used as variable name
```

Changed the variable name `query` to `q`.