### PR TITLE
refactor: rename `replace` to `replace_target` in tfaction-root.yaml

### DIFF
--- a/src/create-drift-issues/index.ts
+++ b/src/create-drift-issues/index.ts
@@ -82,7 +82,7 @@ const run = async (inputs: Inputs): Promise<Result | undefined> => {
   }
 
   // map working directories and targets
-  const m = lib.createWDTargetMap(dirs, cfg.target_groups, cfg.replace);
+  const m = lib.createWDTargetMap(dirs, cfg.target_groups, cfg.replace_target);
   const targetWDMap = new Map<string, string>();
   for (const [wd, target] of m) {
     const tg = await lib.getTargetGroup(cfg, target, wd);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -321,7 +321,7 @@ const RawConfig = z.object({
     })
     .optional(),
   working_directory_file: z.string().optional(),
-  replace: Replace.optional(),
+  replace_target: Replace.optional(),
   providers_lock_opts: z.string().optional(),
   securefix_action: z
     .object({
@@ -444,7 +444,7 @@ export const getConfig = async (): Promise<Config> => {
 export const createWDTargetMap = (
   wds: string[],
   targetGroups: TargetGroup[],
-  replace: Replace | undefined,
+  replaceTarget: Replace | undefined,
 ): Map<string, string> => {
   const m = new Map<string, string>();
   for (const wd of wds) {
@@ -455,7 +455,7 @@ export const createWDTargetMap = (
       if (rel.startsWith("..") || path.isAbsolute(rel)) {
         continue;
       }
-      for (const pattern of replace?.patterns ?? []) {
+      for (const pattern of replaceTarget?.patterns ?? []) {
         target = target.replace(
           new RegExp(pattern.regexp, pattern.flags),
           pattern.replace,
@@ -584,7 +584,7 @@ export const getTargetGroup = async (
     config_path: string;
     working_directory_file: string;
     target_groups: TargetGroup[];
-    replace?: Replace | undefined;
+    replace_target?: Replace | undefined;
   },
   target?: string,
   workingDir?: string,
@@ -602,7 +602,7 @@ export const getTargetGroup = async (
       };
     }
     target = workingDir;
-    for (const pattern of config.replace?.patterns ?? []) {
+    for (const pattern of config.replace_target?.patterns ?? []) {
       target = target.replace(new RegExp(pattern.regexp), pattern.replace);
     }
     return {
@@ -630,7 +630,7 @@ export const getTargetGroup = async (
   for (const file of files) {
     wds.push(path.dirname(file));
   }
-  const m = createWDTargetMap(wds, config.target_groups, config.replace);
+  const m = createWDTargetMap(wds, config.target_groups, config.replace_target);
   for (const [wd, t] of m) {
     if (t === target) {
       workingDir = wd;

--- a/src/list-targets/list-targets-with-changed-files/index.test.ts
+++ b/src/list-targets/list-targets-with-changed-files/index.test.ts
@@ -98,7 +98,7 @@ test("job config", async () => {
 
 const prCommentConfig = {
   plan_workflow_name: "plan.yaml",
-  replace: {
+  replace_target: {
     patterns: [
       {
         regexp: "^yoo/services/",

--- a/src/list-targets/list-targets-with-changed-files/index.ts
+++ b/src/list-targets/list-targets-with-changed-files/index.ts
@@ -86,9 +86,13 @@ type ModuleData = {
 const createTargetMaps = (
   workingDirs: string[],
   targetGroups: lib.TargetGroup[],
-  replace: lib.Replace | undefined,
+  replaceTarget: lib.Replace | undefined,
 ): { wdTargetMap: Map<string, string>; targetWDMap: Map<string, string> } => {
-  const wdTargetMap = lib.createWDTargetMap(workingDirs, targetGroups, replace);
+  const wdTargetMap = lib.createWDTargetMap(
+    workingDirs,
+    targetGroups,
+    replaceTarget,
+  );
   const targetWDMap = new Map<string, string>();
   for (const [wd, t] of wdTargetMap) {
     targetWDMap.set(t, wd);
@@ -265,7 +269,7 @@ export const run = async (input: Input): Promise<Result> => {
   const { wdTargetMap, targetWDMap } = createTargetMaps(
     workingDirs,
     config.target_groups,
-    config.replace,
+    config.replace_target,
   );
 
   const terraformTargets = new Set<string>();
@@ -321,7 +325,7 @@ export const run = async (input: Input): Promise<Result> => {
 type Input = {
   config: {
     target_groups: lib.TargetGroup[];
-    replace?: lib.Replace;
+    replace_target?: lib.Replace;
     label_prefixes?: lib.LabelPrefixes;
   };
   isApply: boolean;

--- a/src/pick-out-drift-issues/index.ts
+++ b/src/pick-out-drift-issues/index.ts
@@ -171,7 +171,7 @@ const getTargetByWorkingDirectory = (
   workingDirectoryPath: string,
   config: lib.Config,
 ): string => {
-  for (const pattern of config.replace?.patterns ?? []) {
+  for (const pattern of config.replace_target?.patterns ?? []) {
     workingDirectoryPath = workingDirectoryPath.replace(
       new RegExp(pattern.regexp),
       pattern.replace,

--- a/tests/opentofu/tfaction-root.yaml
+++ b/tests/opentofu/tfaction-root.yaml
@@ -44,7 +44,7 @@ drift_detection:
   minimum_detection_interval: 1
   num_of_issues: 1
 
-replace:
+replace_target:
   patterns:
     - regexp: /services/
       replace: /

--- a/tests/terragrunt/tfaction-root.yaml
+++ b/tests/terragrunt/tfaction-root.yaml
@@ -44,7 +44,7 @@ drift_detection:
   minimum_detection_interval: 1
   num_of_issues: 1
 
-replace:
+replace_target:
   patterns:
     - regexp: /services/
       replace: /

--- a/tests/tfaction-root.yaml
+++ b/tests/tfaction-root.yaml
@@ -44,7 +44,7 @@ drift_detection:
   minimum_detection_interval: 1
   num_of_issues: 3
 
-replace:
+replace_target:
   patterns:
     - regexp: /services/
       replace: /


### PR DESCRIPTION
Rename the top-level `replace` config field to `replace_target` for clarity, avoiding confusion with the inner `replace` property (the replacement string in pattern objects).