### PR TITLE
refactor: migrate Config defaults to zod .default()

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -209,7 +209,10 @@ const TargetConfig = z.object({
 });
 export type TargetConfig = z.infer<typeof TargetConfig>;
 
-const labelPrefixesDefaults = { skip: "skip:", tfmigrate: "tfmigrate:" } as const;
+const labelPrefixesDefaults = {
+  skip: "skip:",
+  tfmigrate: "tfmigrate:",
+} as const;
 const LabelPrefixes = z.object({
   skip: z.string().default(labelPrefixesDefaults.skip),
   tfmigrate: z.string().default(labelPrefixesDefaults.tfmigrate),


### PR DESCRIPTION
## Summary
- Move default value handling from `applyConfigDefaults` to zod schema definitions using `.default()`
- Extract default values to constants (`tflintDefaults`, `trivyDefaults`, `labelPrefixesDefaults`) to avoid duplication between field-level and object-level defaults
- Simplify `Config` type to extend `z.output<typeof RawConfig>` instead of manually overriding each field
- Reduce `applyConfigDefaults` to only add dynamic fields (`git_root_dir`, `config_path`, `config_dir`, `workspace`)

## Test plan
- [x] `npm run build` - TypeScript build succeeds
- [x] `npm test` - All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)