### PR TITLE
refactor(pick-out-drift-issues): extract pure logic to run.ts

### DIFF
--- a/src/pick-out-drift-issues/index.ts
+++ b/src/pick-out-drift-issues/index.ts
@@ -5,120 +5,7 @@ import * as path from "path";
 import * as lib from "../lib";
 import * as env from "../lib/env";
 import * as input from "../lib/input";
-
-type Issue = {
-  number: number;
-  title: string;
-  target: string;
-  state: string;
-  runs_on: string;
-};
-
-const titlePattern = /^Terraform Drift \((\S+)\)$/;
-
-// Calculate deadline (minimum_detection_interval hours ago)
-const getDeadline = (now: Date, durationHours: number): string => {
-  if (durationHours === 0) {
-    return "";
-  }
-  const deadline = new Date(now.getTime() - durationHours * 60 * 60 * 1000);
-  return deadline.toISOString().replace(/\.\d{3}Z$/, "+00:00");
-};
-
-// List least recently updated drift issues using GraphQL
-const listLeastRecentlyUpdatedIssues = async (
-  octokit: ReturnType<typeof github.getOctokit>,
-  repoOwner: string,
-  repoName: string,
-  numOfIssues: number,
-  deadline: string,
-): Promise<Issue[]> => {
-  const query = `
-    query($searchQuery: String!, $cursor: String) {
-      search(first: 100, after: $cursor, query: $searchQuery, type: ISSUE) {
-        nodes {
-          ... on Issue {
-            number
-            title
-            state
-          }
-        }
-        pageInfo {
-          endCursor
-          hasNextPage
-        }
-      }
-    }
-  `;
-
-  let searchQuery = `repo:${repoOwner}/${repoName} "Terraform Drift" in:title sort:updated-asc`;
-  if (deadline) {
-    searchQuery += ` updated:<${deadline}`;
-  }
-  const issues: Issue[] = [];
-  let cursor: string | null = null;
-
-  while (true) {
-    const result: {
-      search: {
-        nodes: Array<{
-          number: number;
-          title: string;
-          state: string;
-        }>;
-        pageInfo: {
-          endCursor: string;
-          hasNextPage: boolean;
-        };
-      };
-    } = await octokit.graphql(query, {
-      searchQuery,
-      cursor,
-    });
-
-    for (const node of result.search.nodes) {
-      const match = titlePattern.exec(node.title);
-      if (!match) {
-        continue;
-      }
-      issues.push({
-        number: node.number,
-        title: node.title,
-        target: match[1],
-        state: node.state.toLowerCase(),
-        runs_on: "",
-      });
-      if (issues.length >= numOfIssues) {
-        return issues;
-      }
-    }
-
-    if (!result.search.pageInfo.hasNextPage) {
-      break;
-    }
-    cursor = result.search.pageInfo.endCursor;
-  }
-
-  return issues;
-};
-
-// Archive issue (close & rename)
-const archiveIssue = async (
-  octokit: ReturnType<typeof github.getOctokit>,
-  owner: string,
-  repo: string,
-  issueNumber: number,
-  title: string,
-): Promise<void> => {
-  await octokit.rest.issues.update({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    state: "closed",
-    title,
-  });
-  core.info(`Archived issue #${issueNumber}`);
-};
+import { run } from "./run";
 
 // Check if drift detection is enabled
 const checkEnabled = (
@@ -234,75 +121,40 @@ const listTargets = async (
   return targets;
 };
 
-/**
- *
- * @returns
- */
 export const main = async () => {
   const githubToken = input.getRequiredGitHubToken();
   const config = await lib.getConfig();
 
-  // If drift_detection is not configured, output empty
-  if (!config.drift_detection) {
-    core.setOutput("has_issues", "false");
-    core.setOutput("issues", "[]");
-    return;
-  }
-
   const repoOwner =
-    config.drift_detection.issue_repo_owner || github.context.repo.owner;
+    config.drift_detection?.issue_repo_owner || github.context.repo.owner;
   const repoName =
-    config.drift_detection.issue_repo_name || github.context.repo.repo;
+    config.drift_detection?.issue_repo_name || github.context.repo.repo;
 
   // List targets with runs_on
   const targets = await listTargets(config);
   core.debug(`Found ${targets.size} targets with drift detection enabled`);
 
-  // Calculate deadline
-  const deadline = getDeadline(
-    new Date(),
-    config.drift_detection.minimum_detection_interval,
-  );
-  if (deadline) {
-    core.info(`Deadline: ${deadline}`);
-  } else {
-    core.info(`No Deadline`);
-  }
-
-  // List least recently updated drift issues
+  // Create octokit
   const octokit = github.getOctokit(githubToken);
-  const issues = await listLeastRecentlyUpdatedIssues(
+
+  // Run the main logic
+  const result = await run({
+    driftDetection: config.drift_detection,
     octokit,
+    targets,
     repoOwner,
     repoName,
-    config.drift_detection.num_of_issues ?? 1,
-    deadline,
-  );
-  core.debug(`Found ${issues.length} drift issues`);
-
-  // Filter issues and archive orphaned ones
-  const result: Issue[] = [];
-  for (const issue of issues) {
-    const runsOn = targets.get(issue.target);
-    if (runsOn !== undefined) {
-      result.push({ ...issue, runs_on: runsOn });
-    } else {
-      // If there is no target associated with the issue, archive the issue.
-      core.notice(
-        `Target ${issue.target} not found, archiving issue ${github.context.serverUrl}/${repoOwner}/${repoName}/issues/${issue.number}`,
-      );
-      await archiveIssue(
-        octokit,
-        repoOwner,
-        repoName,
-        issue.number,
-        "Archived " + issue.title,
-      );
-    }
-  }
+    now: new Date(),
+    serverUrl: github.context.serverUrl,
+    logger: {
+      info: core.info,
+      debug: core.debug,
+      notice: core.notice,
+    },
+  });
 
   // Set outputs
-  core.setOutput("has_issues", result.length > 0 ? "true" : "false");
-  core.setOutput("issues", JSON.stringify(result));
-  core.info(`Output ${result.length} issues`);
+  core.setOutput("has_issues", result.hasIssues ? "true" : "false");
+  core.setOutput("issues", JSON.stringify(result.issues));
+  core.info(`Output ${result.issues.length} issues`);
 };

--- a/src/pick-out-drift-issues/run.test.ts
+++ b/src/pick-out-drift-issues/run.test.ts
@@ -1,0 +1,507 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getDeadline,
+  run,
+  titlePattern,
+  type RunInput,
+  type Logger,
+} from "./run";
+
+describe("getDeadline", () => {
+  it("returns empty string when durationHours is 0", () => {
+    const now = new Date("2024-01-15T10:00:00Z");
+    expect(getDeadline(now, 0)).toBe("");
+  });
+
+  it("calculates deadline 24 hours ago", () => {
+    const now = new Date("2024-01-15T10:00:00Z");
+    const result = getDeadline(now, 24);
+    expect(result).toBe("2024-01-14T10:00:00+00:00");
+  });
+
+  it("calculates deadline 48 hours ago", () => {
+    const now = new Date("2024-01-15T12:30:45Z");
+    const result = getDeadline(now, 48);
+    expect(result).toBe("2024-01-13T12:30:45+00:00");
+  });
+
+  it("handles fractional hours", () => {
+    const now = new Date("2024-01-15T12:00:00Z");
+    const result = getDeadline(now, 1.5); // 1.5 hours = 90 minutes
+    expect(result).toBe("2024-01-15T10:30:00+00:00");
+  });
+});
+
+describe("titlePattern", () => {
+  it("matches valid drift issue titles", () => {
+    const match = titlePattern.exec("Terraform Drift (aws/foo/dev)");
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe("aws/foo/dev");
+  });
+
+  it("extracts target from title", () => {
+    const match = titlePattern.exec("Terraform Drift (gcp/prod/service)");
+    expect(match?.[1]).toBe("gcp/prod/service");
+  });
+
+  it("does not match non-drift titles", () => {
+    expect(titlePattern.exec("Some other issue")).toBeNull();
+    expect(titlePattern.exec("Terraform Plan (aws/foo)")).toBeNull();
+  });
+
+  it("does not match partial drift titles", () => {
+    expect(titlePattern.exec("Terraform Drift aws/foo")).toBeNull();
+    expect(titlePattern.exec("Terraform Drift (aws/foo")).toBeNull();
+  });
+
+  it("matches targets with various characters", () => {
+    const match = titlePattern.exec("Terraform Drift (aws-prod/foo_bar/123)");
+    expect(match?.[1]).toBe("aws-prod/foo_bar/123");
+  });
+});
+
+describe("run", () => {
+  const createMockOctokit = () => ({
+    graphql: vi.fn(),
+    rest: {
+      issues: {
+        update: vi.fn(),
+      },
+    },
+  });
+
+  const createMockLogger = (): Logger => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    notice: vi.fn(),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty result when drift_detection is not configured", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    const input: RunInput = {
+      driftDetection: undefined,
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets: new Map(),
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date(),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    const result = await run(input);
+
+    expect(result.hasIssues).toBe(false);
+    expect(result.issues).toEqual([]);
+    expect(octokit.graphql).not.toHaveBeenCalled();
+  });
+
+  it("returns empty result when no issues found", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    octokit.graphql.mockResolvedValue({
+      search: {
+        nodes: [],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+      },
+    });
+
+    const input: RunInput = {
+      driftDetection: {
+        minimum_detection_interval: 24,
+        num_of_issues: 5,
+      },
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets: new Map([["aws/foo/dev", "ubuntu-latest"]]),
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date("2024-01-15T10:00:00Z"),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    const result = await run(input);
+
+    expect(result.hasIssues).toBe(false);
+    expect(result.issues).toEqual([]);
+  });
+
+  it("returns issues with runs_on when target exists", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    octokit.graphql.mockResolvedValue({
+      search: {
+        nodes: [
+          {
+            number: 123,
+            title: "Terraform Drift (aws/foo/dev)",
+            state: "OPEN",
+          },
+          {
+            number: 456,
+            title: "Terraform Drift (gcp/bar/prod)",
+            state: "OPEN",
+          },
+        ],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+      },
+    });
+
+    const targets = new Map([
+      ["aws/foo/dev", "ubuntu-latest"],
+      ["gcp/bar/prod", '["self-hosted", "linux"]'],
+    ]);
+
+    const input: RunInput = {
+      driftDetection: {
+        minimum_detection_interval: 24,
+        num_of_issues: 10,
+      },
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets,
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date("2024-01-15T10:00:00Z"),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    const result = await run(input);
+
+    expect(result.hasIssues).toBe(true);
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[0]).toEqual({
+      number: 123,
+      title: "Terraform Drift (aws/foo/dev)",
+      target: "aws/foo/dev",
+      state: "open",
+      runs_on: "ubuntu-latest",
+    });
+    expect(result.issues[1]).toEqual({
+      number: 456,
+      title: "Terraform Drift (gcp/bar/prod)",
+      target: "gcp/bar/prod",
+      state: "open",
+      runs_on: '["self-hosted", "linux"]',
+    });
+  });
+
+  it("archives issues when target does not exist", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    octokit.graphql.mockResolvedValue({
+      search: {
+        nodes: [
+          {
+            number: 789,
+            title: "Terraform Drift (deleted/target)",
+            state: "OPEN",
+          },
+        ],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+      },
+    });
+    octokit.rest.issues.update.mockResolvedValue({});
+
+    const input: RunInput = {
+      driftDetection: {
+        minimum_detection_interval: 24,
+        num_of_issues: 10,
+      },
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets: new Map(), // No targets
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date("2024-01-15T10:00:00Z"),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    const result = await run(input);
+
+    expect(result.hasIssues).toBe(false);
+    expect(result.issues).toEqual([]);
+    expect(octokit.rest.issues.update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 789,
+      state: "closed",
+      title: "Archived Terraform Drift (deleted/target)",
+    });
+  });
+
+  it("handles mixed issues (some with targets, some without)", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    octokit.graphql.mockResolvedValue({
+      search: {
+        nodes: [
+          {
+            number: 1,
+            title: "Terraform Drift (aws/foo/dev)",
+            state: "OPEN",
+          },
+          {
+            number: 2,
+            title: "Terraform Drift (deleted/target)",
+            state: "OPEN",
+          },
+          {
+            number: 3,
+            title: "Terraform Drift (gcp/bar/prod)",
+            state: "CLOSED",
+          },
+        ],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+      },
+    });
+    octokit.rest.issues.update.mockResolvedValue({});
+
+    const targets = new Map([
+      ["aws/foo/dev", "ubuntu-latest"],
+      ["gcp/bar/prod", "self-hosted"],
+    ]);
+
+    const input: RunInput = {
+      driftDetection: {
+        minimum_detection_interval: 24,
+        num_of_issues: 10,
+      },
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets,
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date("2024-01-15T10:00:00Z"),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    const result = await run(input);
+
+    expect(result.hasIssues).toBe(true);
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues.map((i) => i.number)).toEqual([1, 3]);
+    expect(octokit.rest.issues.update).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.issues.update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 2,
+      state: "closed",
+      title: "Archived Terraform Drift (deleted/target)",
+    });
+  });
+
+  it("uses num_of_issues default of 1 when not specified", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    octokit.graphql.mockResolvedValue({
+      search: {
+        nodes: [
+          {
+            number: 1,
+            title: "Terraform Drift (aws/foo/dev)",
+            state: "OPEN",
+          },
+          {
+            number: 2,
+            title: "Terraform Drift (aws/bar/prod)",
+            state: "OPEN",
+          },
+        ],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+      },
+    });
+
+    const targets = new Map([
+      ["aws/foo/dev", "ubuntu-latest"],
+      ["aws/bar/prod", "ubuntu-latest"],
+    ]);
+
+    const input: RunInput = {
+      driftDetection: {
+        minimum_detection_interval: 24,
+        // num_of_issues not specified
+      },
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets,
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date("2024-01-15T10:00:00Z"),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    const result = await run(input);
+
+    // Should only return 1 issue (the default)
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].number).toBe(1);
+  });
+
+  it("skips issues with non-matching title pattern", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    octokit.graphql.mockResolvedValue({
+      search: {
+        nodes: [
+          {
+            number: 1,
+            title: "Terraform Drift (aws/foo/dev)",
+            state: "OPEN",
+          },
+          {
+            number: 2,
+            title: "Some other issue mentioning Terraform Drift",
+            state: "OPEN",
+          },
+        ],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+      },
+    });
+
+    const targets = new Map([["aws/foo/dev", "ubuntu-latest"]]);
+
+    const input: RunInput = {
+      driftDetection: {
+        minimum_detection_interval: 24,
+        num_of_issues: 10,
+      },
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets,
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date("2024-01-15T10:00:00Z"),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    const result = await run(input);
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].number).toBe(1);
+  });
+
+  it("handles no deadline when minimum_detection_interval is 0", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    octokit.graphql.mockResolvedValue({
+      search: {
+        nodes: [],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+      },
+    });
+
+    const input: RunInput = {
+      driftDetection: {
+        minimum_detection_interval: 0,
+        num_of_issues: 10,
+      },
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets: new Map(),
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date("2024-01-15T10:00:00Z"),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    await run(input);
+
+    // Verify graphql was called with search query without deadline filter
+    expect(octokit.graphql).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        searchQuery: expect.not.stringContaining("updated:<"),
+      }),
+    );
+  });
+
+  it("handles pagination in GraphQL results", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+
+    // First page
+    octokit.graphql.mockResolvedValueOnce({
+      search: {
+        nodes: [
+          {
+            number: 1,
+            title: "Terraform Drift (aws/foo/dev)",
+            state: "OPEN",
+          },
+        ],
+        pageInfo: {
+          endCursor: "cursor1",
+          hasNextPage: true,
+        },
+      },
+    });
+
+    // Second page
+    octokit.graphql.mockResolvedValueOnce({
+      search: {
+        nodes: [
+          {
+            number: 2,
+            title: "Terraform Drift (aws/bar/prod)",
+            state: "OPEN",
+          },
+        ],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+      },
+    });
+
+    const targets = new Map([
+      ["aws/foo/dev", "ubuntu-latest"],
+      ["aws/bar/prod", "ubuntu-latest"],
+    ]);
+
+    const input: RunInput = {
+      driftDetection: {
+        minimum_detection_interval: 24,
+        num_of_issues: 10,
+      },
+      octokit: octokit as unknown as RunInput["octokit"],
+      targets,
+      repoOwner: "owner",
+      repoName: "repo",
+      now: new Date("2024-01-15T10:00:00Z"),
+      serverUrl: "https://github.com",
+      logger,
+    };
+
+    const result = await run(input);
+
+    expect(octokit.graphql).toHaveBeenCalledTimes(2);
+    expect(result.issues).toHaveLength(2);
+  });
+});

--- a/src/pick-out-drift-issues/run.ts
+++ b/src/pick-out-drift-issues/run.ts
@@ -1,0 +1,204 @@
+import * as github from "@actions/github";
+
+export type Issue = {
+  number: number;
+  title: string;
+  target: string;
+  state: string;
+  runs_on: string;
+};
+
+export type Logger = {
+  info: (message: string) => void;
+  debug: (message: string) => void;
+  notice: (message: string) => void;
+};
+
+export type DriftDetectionConfig = {
+  minimum_detection_interval: number;
+  num_of_issues?: number;
+};
+
+export type RunInput = {
+  driftDetection?: DriftDetectionConfig;
+  octokit: ReturnType<typeof github.getOctokit>;
+  targets: Map<string, string>; // target -> runs_on
+  repoOwner: string;
+  repoName: string;
+  now: Date;
+  serverUrl: string;
+  logger: Logger;
+};
+
+export type RunResult = {
+  hasIssues: boolean;
+  issues: Issue[];
+};
+
+export const titlePattern = /^Terraform Drift \((\S+)\)$/;
+
+// Calculate deadline (minimum_detection_interval hours ago)
+export const getDeadline = (now: Date, durationHours: number): string => {
+  if (durationHours === 0) {
+    return "";
+  }
+  const deadline = new Date(now.getTime() - durationHours * 60 * 60 * 1000);
+  return deadline.toISOString().replace(/\.\d{3}Z$/, "+00:00");
+};
+
+// List least recently updated drift issues using GraphQL
+export const listLeastRecentlyUpdatedIssues = async (
+  octokit: ReturnType<typeof github.getOctokit>,
+  repoOwner: string,
+  repoName: string,
+  numOfIssues: number,
+  deadline: string,
+): Promise<Issue[]> => {
+  const query = `
+    query($searchQuery: String!, $cursor: String) {
+      search(first: 100, after: $cursor, query: $searchQuery, type: ISSUE) {
+        nodes {
+          ... on Issue {
+            number
+            title
+            state
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  `;
+
+  let searchQuery = `repo:${repoOwner}/${repoName} "Terraform Drift" in:title sort:updated-asc`;
+  if (deadline) {
+    searchQuery += ` updated:<${deadline}`;
+  }
+  const issues: Issue[] = [];
+  let cursor: string | null = null;
+
+  while (true) {
+    const result: {
+      search: {
+        nodes: Array<{
+          number: number;
+          title: string;
+          state: string;
+        }>;
+        pageInfo: {
+          endCursor: string;
+          hasNextPage: boolean;
+        };
+      };
+    } = await octokit.graphql(query, {
+      searchQuery,
+      cursor,
+    });
+
+    for (const node of result.search.nodes) {
+      const match = titlePattern.exec(node.title);
+      if (!match) {
+        continue;
+      }
+      issues.push({
+        number: node.number,
+        title: node.title,
+        target: match[1],
+        state: node.state.toLowerCase(),
+        runs_on: "",
+      });
+      if (issues.length >= numOfIssues) {
+        return issues;
+      }
+    }
+
+    if (!result.search.pageInfo.hasNextPage) {
+      break;
+    }
+    cursor = result.search.pageInfo.endCursor;
+  }
+
+  return issues;
+};
+
+// Archive issue (close & rename)
+export const archiveIssue = async (
+  octokit: ReturnType<typeof github.getOctokit>,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  title: string,
+  logger: Logger,
+): Promise<void> => {
+  await octokit.rest.issues.update({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    state: "closed",
+    title,
+  });
+  logger.info(`Archived issue #${issueNumber}`);
+};
+
+// Testable run function that takes dependencies as input
+export const run = async (input: RunInput): Promise<RunResult> => {
+  const {
+    driftDetection,
+    octokit,
+    targets,
+    repoOwner,
+    repoName,
+    now,
+    serverUrl,
+    logger,
+  } = input;
+
+  // If drift_detection is not configured, return empty
+  if (!driftDetection) {
+    return { hasIssues: false, issues: [] };
+  }
+
+  // Calculate deadline
+  const deadline = getDeadline(now, driftDetection.minimum_detection_interval);
+  if (deadline) {
+    logger.info(`Deadline: ${deadline}`);
+  } else {
+    logger.info(`No Deadline`);
+  }
+
+  // List least recently updated drift issues
+  const issues = await listLeastRecentlyUpdatedIssues(
+    octokit,
+    repoOwner,
+    repoName,
+    driftDetection.num_of_issues ?? 1,
+    deadline,
+  );
+  logger.debug(`Found ${issues.length} drift issues`);
+
+  // Filter issues and archive orphaned ones
+  const result: Issue[] = [];
+  for (const issue of issues) {
+    const runsOn = targets.get(issue.target);
+    if (runsOn !== undefined) {
+      result.push({ ...issue, runs_on: runsOn });
+    } else {
+      // If there is no target associated with the issue, archive the issue.
+      logger.notice(
+        `Target ${issue.target} not found, archiving issue ${serverUrl}/${repoOwner}/${repoName}/issues/${issue.number}`,
+      );
+      await archiveIssue(
+        octokit,
+        repoOwner,
+        repoName,
+        issue.number,
+        "Archived " + issue.title,
+        logger,
+      );
+    }
+  }
+
+  return { hasIssues: result.length > 0, issues: result };
+};


### PR DESCRIPTION
## Summary
- Extract pure logic (`run()`, `getDeadline()`, types, etc.) from `index.ts` to `run.ts`
- Remove `@actions/core` mock from tests by injecting a `Logger` interface
- Rename `index.test.ts` to `run.test.ts` to test the pure module directly

## Test plan
- [x] `npm t` - All 79 tests pass
- [x] `npm run build` - Build succeeds
- [x] `npx eslint` - No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)