### PR TITLE
feat(test): add test coverage for list-targets-with-changed-files

### DIFF
--- a/src/list-targets/list-targets-with-changed-files/index.test.ts
+++ b/src/list-targets/list-targets-with-changed-files/index.test.ts
@@ -663,7 +663,9 @@ test("tfmigrate label with unknown target throws error", async () => {
       maxChangedWorkingDirectories: 0,
       maxChangedModules: 0,
     }),
-  ).rejects.toThrow("No working directory is found for the target unknown/target");
+  ).rejects.toThrow(
+    "No working directory is found for the target unknown/target",
+  );
 });
 
 test("empty labels and changed files", async () => {


### PR DESCRIPTION
## Summary
- Add 11 new test cases to improve test coverage for `src/list-targets/list-targets-with-changed-files/index.ts`
- Coverage improved from 63.63% to 82.57% (statements/lines)
- Branch coverage improved from 47.94% to 57.53%

## Test cases added
- tfmigrate label processing (`tfmigrate:target` labels)
- tfmigrate label with changed files (precedence over terraform)
- module change detection (files in `moduleFiles`)
- module callers triggered (dependent working directories)
- replace_target configuration (regexp patterns)
- custom label_prefixes for tfmigrate
- skip label parsing
- custom skip label prefix
- tfmigrate label with unknown target (error handling)
- empty labels and changed files (edge case)
- duplicate tfmigrate labels (deduplication)

## Test plan
- [x] All 90 tests pass (`npm test`)
- [x] No lint errors (`npx eslint`)
- [x] Coverage verified (`npm run test:coverage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)