### PR TITLE
test(list-targets): add unit tests for run.ts

### DIFF
--- a/src/actions/list-targets/run.test.ts
+++ b/src/actions/list-targets/run.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { shouldSkipCiInfo, isPREvent, validateHeadSha } from "./run";
+
+describe("shouldSkipCiInfo", () => {
+  it("returns true for workflow_dispatch", () => {
+    expect(shouldSkipCiInfo("workflow_dispatch")).toBe(true);
+  });
+
+  it("returns true for schedule", () => {
+    expect(shouldSkipCiInfo("schedule")).toBe(true);
+  });
+
+  it("returns false for pull_request", () => {
+    expect(shouldSkipCiInfo("pull_request")).toBe(false);
+  });
+
+  it("returns false for push", () => {
+    expect(shouldSkipCiInfo("push")).toBe(false);
+  });
+
+  it("returns false for pull_request_target", () => {
+    expect(shouldSkipCiInfo("pull_request_target")).toBe(false);
+  });
+
+  it("returns false for issue_comment", () => {
+    expect(shouldSkipCiInfo("issue_comment")).toBe(false);
+  });
+});
+
+describe("isPREvent", () => {
+  it("returns true for pull_request", () => {
+    expect(isPREvent("pull_request")).toBe(true);
+  });
+
+  it("returns true for pull_request_target", () => {
+    expect(isPREvent("pull_request_target")).toBe(true);
+  });
+
+  it("returns true for pull_request_review", () => {
+    expect(isPREvent("pull_request_review")).toBe(true);
+  });
+
+  it("returns true for pull_request_review_comment", () => {
+    expect(isPREvent("pull_request_review_comment")).toBe(true);
+  });
+
+  it("returns false for push", () => {
+    expect(isPREvent("push")).toBe(false);
+  });
+
+  it("returns false for workflow_dispatch", () => {
+    expect(isPREvent("workflow_dispatch")).toBe(false);
+  });
+
+  it("returns false for schedule", () => {
+    expect(isPREvent("schedule")).toBe(false);
+  });
+
+  it("returns false for issue_comment", () => {
+    expect(isPREvent("issue_comment")).toBe(false);
+  });
+});
+
+describe("validateHeadSha", () => {
+  it("throws when head sha doesn't match latest", () => {
+    expect(() => validateHeadSha("abc123", "def456")).toThrow(
+      "The head sha (abc123) isn't latest (def456).",
+    );
+  });
+
+  it("does not throw when head sha matches latest", () => {
+    expect(() => validateHeadSha("abc123", "abc123")).not.toThrow();
+  });
+
+  it("does not throw when headSha is undefined", () => {
+    expect(() => validateHeadSha(undefined, "def456")).not.toThrow();
+  });
+
+  it("does not throw when latestHeadSha is undefined", () => {
+    expect(() => validateHeadSha("abc123", undefined)).not.toThrow();
+  });
+
+  it("does not throw when both are undefined", () => {
+    expect(() => validateHeadSha(undefined, undefined)).not.toThrow();
+  });
+
+  it("does not throw when headSha is empty string", () => {
+    expect(() => validateHeadSha("", "def456")).not.toThrow();
+  });
+
+  it("does not throw when latestHeadSha is empty string", () => {
+    expect(() => validateHeadSha("abc123", "")).not.toThrow();
+  });
+});

--- a/src/actions/list-targets/run.ts
+++ b/src/actions/list-targets/run.ts
@@ -1,0 +1,32 @@
+// Business logic for list-targets action
+// This file contains pure functions that can be tested without mocking
+
+/**
+ * Determines if ci-info should be skipped based on the event name.
+ * ci-info is skipped for workflow_dispatch and schedule events.
+ */
+export const shouldSkipCiInfo = (eventName: string): boolean => {
+  return eventName === "workflow_dispatch" || eventName === "schedule";
+};
+
+/**
+ * Determines if the event is a pull request event.
+ */
+export const isPREvent = (eventName: string): boolean => {
+  return eventName === "pull_request" || eventName.startsWith("pull_request_");
+};
+
+/**
+ * Validates that the head SHA matches the latest head SHA.
+ * Throws an error if they don't match.
+ */
+export const validateHeadSha = (
+  headSha?: string,
+  latestHeadSha?: string,
+): void => {
+  if (headSha && latestHeadSha && headSha !== latestHeadSha) {
+    throw new Error(
+      `The head sha (${headSha}) isn't latest (${latestHeadSha}).`,
+    );
+  }
+};


### PR DESCRIPTION
## Summary
- Extract CI event detection logic from index.ts into run.ts with:
  - shouldSkipCiInfo: checks if ci-info should be skipped (workflow_dispatch, schedule)
  - isPREvent: checks if event is a PR event
  - validateHeadSha: validates head SHA matches latest
- Add run.test.ts with test cases

## Test plan
- [x] Tests pass: `npm t -- src/actions/list-targets/run.test.ts`
- [x] Linting passes: `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)