### PR TITLE
test(setup): add unit tests for helper functions

### DIFF
--- a/src/actions/setup/index.ts
+++ b/src/actions/setup/index.ts
@@ -12,34 +12,25 @@ import * as ciinfo from "../../ci-info";
 import { getTargetConfig } from "../get-target-config";
 import * as aquaUpdateChecksum from "./aqua-update-checksum";
 import * as checkTerraformSkip from "../../check-terraform-skip";
+import {
+  isPullRequestEvent as isPullRequestEventFn,
+  shouldSkipCIInfo as shouldSkipCIInfoFn,
+  checkLatestCommit as checkLatestCommitFn,
+} from "./run";
 
 // Check if this is a pull request event
 const isPullRequestEvent = (): boolean => {
-  const eventName = github.context.eventName;
-  return eventName === "pull_request" || eventName.startsWith("pull_request_");
+  return isPullRequestEventFn(github.context.eventName);
 };
 
 // Check if ci-info should be skipped
 const shouldSkipCIInfo = (): boolean => {
-  const eventName = github.context.eventName;
-  return eventName === "workflow_dispatch" || eventName === "schedule";
+  return shouldSkipCIInfoFn(github.context.eventName);
 };
 
 // Check if the PR head SHA is the latest
-const checkLatestCommit = async (latestHeadSHA: string): Promise<void> => {
-  const headSHA = github.context.payload.pull_request?.head?.sha;
-  if (!headSHA) {
-    throw new Error("Failed to get the current SHA from event payload");
-  }
-  if (!latestHeadSHA) {
-    throw new Error("Failed to get the pull request HEAD SHA");
-  }
-
-  if (headSHA !== latestHeadSHA) {
-    throw new Error(
-      `The head sha (${headSHA}) isn't latest (${latestHeadSHA}).`,
-    );
-  }
+const checkLatestCommit = (latestHeadSHA: string): void => {
+  checkLatestCommitFn(github.context.payload.pull_request, latestHeadSHA);
 };
 
 // Add label to PR

--- a/src/actions/setup/run.test.ts
+++ b/src/actions/setup/run.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  isPullRequestEvent,
+  shouldSkipCIInfo,
+  checkLatestCommit,
+  type PullRequestPayload,
+} from "./run";
+
+describe("isPullRequestEvent", () => {
+  it('returns true for "pull_request" event', () => {
+    expect(isPullRequestEvent("pull_request")).toBe(true);
+  });
+
+  it('returns true for "pull_request_target" event', () => {
+    expect(isPullRequestEvent("pull_request_target")).toBe(true);
+  });
+
+  it('returns true for "pull_request_review" event', () => {
+    expect(isPullRequestEvent("pull_request_review")).toBe(true);
+  });
+
+  it('returns true for "pull_request_review_comment" event', () => {
+    expect(isPullRequestEvent("pull_request_review_comment")).toBe(true);
+  });
+
+  it('returns false for "push" event', () => {
+    expect(isPullRequestEvent("push")).toBe(false);
+  });
+
+  it('returns false for "workflow_dispatch" event', () => {
+    expect(isPullRequestEvent("workflow_dispatch")).toBe(false);
+  });
+
+  it('returns false for "schedule" event', () => {
+    expect(isPullRequestEvent("schedule")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isPullRequestEvent("")).toBe(false);
+  });
+
+  it('returns false for "issues" event', () => {
+    expect(isPullRequestEvent("issues")).toBe(false);
+  });
+});
+
+describe("shouldSkipCIInfo", () => {
+  it('returns true for "workflow_dispatch" event', () => {
+    expect(shouldSkipCIInfo("workflow_dispatch")).toBe(true);
+  });
+
+  it('returns true for "schedule" event', () => {
+    expect(shouldSkipCIInfo("schedule")).toBe(true);
+  });
+
+  it('returns false for "pull_request" event', () => {
+    expect(shouldSkipCIInfo("pull_request")).toBe(false);
+  });
+
+  it('returns false for "push" event', () => {
+    expect(shouldSkipCIInfo("push")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(shouldSkipCIInfo("")).toBe(false);
+  });
+
+  it('returns false for "issues" event', () => {
+    expect(shouldSkipCIInfo("issues")).toBe(false);
+  });
+});
+
+describe("checkLatestCommit", () => {
+  it("does not throw when SHAs match", () => {
+    const payload: PullRequestPayload = {
+      head: {
+        sha: "abc123",
+      },
+    };
+    expect(() => checkLatestCommit(payload, "abc123")).not.toThrow();
+  });
+
+  it("throws when payload is undefined", () => {
+    expect(() => checkLatestCommit(undefined, "abc123")).toThrow(
+      "Failed to get the current SHA from event payload",
+    );
+  });
+
+  it("throws when payload.head is undefined", () => {
+    const payload: PullRequestPayload = {};
+    expect(() => checkLatestCommit(payload, "abc123")).toThrow(
+      "Failed to get the current SHA from event payload",
+    );
+  });
+
+  it("throws when payload.head.sha is undefined", () => {
+    const payload: PullRequestPayload = {
+      head: {},
+    };
+    expect(() => checkLatestCommit(payload, "abc123")).toThrow(
+      "Failed to get the current SHA from event payload",
+    );
+  });
+
+  it("throws when latestHeadSHA is empty string", () => {
+    const payload: PullRequestPayload = {
+      head: {
+        sha: "abc123",
+      },
+    };
+    expect(() => checkLatestCommit(payload, "")).toThrow(
+      "Failed to get the pull request HEAD SHA",
+    );
+  });
+
+  it("throws when SHAs do not match", () => {
+    const payload: PullRequestPayload = {
+      head: {
+        sha: "abc123",
+      },
+    };
+    expect(() => checkLatestCommit(payload, "def456")).toThrow(
+      "The head sha (abc123) isn't latest (def456).",
+    );
+  });
+
+  it("includes both SHAs in error message when they do not match", () => {
+    const payload: PullRequestPayload = {
+      head: {
+        sha: "oldsha123",
+      },
+    };
+    try {
+      checkLatestCommit(payload, "newsha456");
+      expect.fail("Expected an error to be thrown");
+    } catch (error) {
+      expect((error as Error).message).toContain("oldsha123");
+      expect((error as Error).message).toContain("newsha456");
+    }
+  });
+});

--- a/src/actions/setup/run.ts
+++ b/src/actions/setup/run.ts
@@ -1,0 +1,45 @@
+// Helper functions extracted from index.ts for unit testing
+
+// Check if the event is a pull request event
+export const isPullRequestEvent = (eventName: string): boolean => {
+  return eventName === "pull_request" || eventName.startsWith("pull_request_");
+};
+
+// Check if ci-info should be skipped
+export const shouldSkipCIInfo = (eventName: string): boolean => {
+  return eventName === "workflow_dispatch" || eventName === "schedule";
+};
+
+// Type for the pull request payload for testing purposes
+// Uses index signature to be compatible with GitHub's WebhookPayload type
+export type PullRequestPayload = {
+  head?: {
+    sha?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+// Check if the PR head SHA is the latest
+// Throws an error if:
+// - head SHA cannot be retrieved from payload
+// - latest HEAD SHA is not provided
+// - head SHA doesn't match latest HEAD SHA
+export const checkLatestCommit = (
+  payload: PullRequestPayload | undefined,
+  latestHeadSHA: string,
+): void => {
+  const headSHA = payload?.head?.sha;
+  if (!headSHA) {
+    throw new Error("Failed to get the current SHA from event payload");
+  }
+  if (!latestHeadSHA) {
+    throw new Error("Failed to get the pull request HEAD SHA");
+  }
+
+  if (headSHA !== latestHeadSHA) {
+    throw new Error(
+      `The head sha (${headSHA}) isn't latest (${latestHeadSHA}).`,
+    );
+  }
+};


### PR DESCRIPTION
## Summary
- Add unit tests for `src/actions/setup/` helper functions
- Create `run.ts` with extracted pure functions: isPullRequestEvent, shouldSkipCIInfo, checkLatestCommit
- Update `index.ts` to use the extracted functions
- 22 test cases covering various event types and error conditions

## Test plan
- [x] `npm t -- src/actions/setup/` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)