### PR TITLE
refactor: add tests for get-or-create-drift-issue

### DIFF
--- a/src/actions/get-or-create-drift-issue/index.ts
+++ b/src/actions/get-or-create-drift-issue/index.ts
@@ -2,43 +2,29 @@ import * as core from "@actions/core";
 import { Octokit } from "@octokit/core";
 import { paginateGraphQL } from "@octokit/plugin-paginate-graphql";
 import * as lib from "../../lib";
-import * as types from "../../lib/types";
-import * as drift from "../../lib/drift";
 import * as env from "../../lib/env";
 import * as input from "../../lib/input";
-import * as path from "path";
-
-type Inputs = {
-  target?: string;
-  workingDir?: string;
-  ghToken: string;
-  repo?: string;
-};
-
-type Result = {
-  number: number;
-  state: string;
-  url: string;
-};
-
-type Issue = {
-  url: string;
-  number: number;
-  state: string;
-};
+import { run } from "./run";
 
 export const main = async () => {
   const cfg = await lib.getConfig();
   if (!cfg.drift_detection) {
-    // dirft detection is disabled
+    // drift detection is disabled
     return;
   }
 
-  const result = await run(cfg, {
+  const ghToken = input.getRequiredGitHubToken();
+  const MyOctokit = Octokit.plugin(paginateGraphQL);
+  const graphqlOctokit = new MyOctokit({ auth: ghToken });
+
+  const result = await run({
+    config: cfg,
     target: env.all.TFACTION_TARGET,
     workingDir: env.all.TFACTION_WORKING_DIR,
-    ghToken: input.getRequiredGitHubToken(),
+    ghToken,
     repo: env.all.GITHUB_REPOSITORY,
+    graphqlOctokit,
+    logger: core,
   });
 
   if (result === undefined) {
@@ -49,100 +35,4 @@ export const main = async () => {
   core.exportVariable("TFACTION_DRIFT_ISSUE_STATE", result.state);
   core.info(result.url);
   core.summary.addRaw(`Drift Issue: ${result.url}`, true);
-};
-
-const run = async (
-  cfg: types.Config,
-  inputs: Inputs,
-): Promise<Result | undefined> => {
-  if (!cfg.drift_detection) {
-    core.info("drift detection is disabled");
-    return undefined;
-  }
-
-  const repoOwner =
-    cfg.drift_detection.issue_repo_owner ?? (inputs.repo ?? "").split("/")[0];
-  const repoName =
-    cfg.drift_detection.issue_repo_name ?? (inputs.repo ?? "").split("/")[1];
-  if (!repoOwner || !repoName) {
-    throw new Error("repo_owner and repo_name are required");
-  }
-  const tg = await lib.getTargetGroup(cfg, inputs.target, inputs.workingDir);
-
-  const wdConfig = lib.readTargetConfig(
-    path.join(cfg.git_root_dir, tg.workingDir, cfg.working_directory_file),
-  );
-
-  if (!drift.checkDriftDetectionEnabled(cfg, tg.group, wdConfig)) {
-    core.info("drift detection is disabled");
-    return;
-  }
-  core.info("drift detection is enabled");
-
-  if (!inputs.ghToken) {
-    throw new Error("GITHUB_TOKEN is required");
-  }
-
-  let issue = await getIssue(
-    tg.target,
-    inputs.ghToken,
-    `${repoOwner}/${repoName}`,
-  );
-  if (issue === undefined) {
-    core.info("creating a drift issue");
-    issue = await drift.createIssue(
-      tg.target,
-      inputs.ghToken,
-      repoOwner,
-      repoName,
-    );
-  }
-
-  return {
-    number: issue.number,
-    state: issue.state,
-    url: issue.url,
-  };
-};
-
-const getIssue = async (
-  target: string,
-  ghToken: string,
-  repo: string,
-): Promise<Issue | undefined> => {
-  const MyOctokit = Octokit.plugin(paginateGraphQL);
-  const octokit = new MyOctokit({ auth: ghToken });
-
-  const title = `Terraform Drift (${target})`;
-  const query = `query($cursor: String, $searchQuery: String!) {
-  search(first: 100, after: $cursor, query: $searchQuery, type: ISSUE) {
-    nodes {
-    	... on Issue {
-    		number
-    		title
-    		state
-    		url
-    	}
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-  }
-}`;
-
-  const pageIterator = octokit.graphql.paginate.iterator(query, {
-    issuesCursor: null,
-    searchQuery: `repo:${repo} "${title}" in:title`,
-  });
-
-  for await (const response of pageIterator) {
-    for (const issue of response.search.nodes) {
-      if (issue.title !== title) {
-        continue;
-      }
-      return issue;
-    }
-  }
-  return undefined;
 };

--- a/src/actions/get-or-create-drift-issue/run.test.ts
+++ b/src/actions/get-or-create-drift-issue/run.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  run,
+  getIssue,
+  type Logger,
+  type GraphQLPaginator,
+  type RunDependencies,
+} from "./run";
+import type * as types from "../../lib/types";
+
+const createMockLogger = (): Logger => ({
+  info: vi.fn(),
+});
+
+const createMockGraphqlOctokit = (
+  pages: Array<
+    Array<{ number: number; title: string; state: string; url: string }>
+  >,
+): GraphQLPaginator => {
+  return {
+    graphql: {
+      paginate: {
+        iterator: vi.fn().mockImplementation(async function* () {
+          for (const page of pages) {
+            yield { search: { nodes: page } };
+          }
+        }),
+      },
+    },
+  };
+};
+
+const createMockConfig = (
+  driftDetection?: types.Config["drift_detection"],
+): types.Config =>
+  ({
+    drift_detection: driftDetection,
+    working_directory_file: "tfaction.yaml",
+    git_root_dir: "/workspace",
+    target_groups: [{ working_directory: "aws" }],
+    replace_target: undefined,
+    config_path: "/workspace/tfaction-root.yaml",
+  }) as types.Config;
+
+const createMockDeps = (
+  overrides?: Partial<RunDependencies>,
+): RunDependencies => ({
+  getTargetGroup: vi.fn().mockResolvedValue({
+    target: "aws/foo",
+    workingDir: "aws/foo",
+    group: { working_directory: "aws" },
+  }),
+  readTargetConfig: vi.fn().mockReturnValue({}),
+  checkDriftDetectionEnabled: vi.fn().mockReturnValue(true),
+  createIssue: vi.fn().mockResolvedValue({
+    url: "https://github.com/owner/repo/issues/42",
+    number: 42,
+    state: "open",
+  }),
+  ...overrides,
+});
+
+describe("getIssue", () => {
+  it("returns undefined when no issues exist", async () => {
+    const graphqlOctokit = createMockGraphqlOctokit([[]]);
+
+    const result = await getIssue("aws/foo", graphqlOctokit, "owner/repo");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns matching issue when title matches exactly", async () => {
+    const graphqlOctokit = createMockGraphqlOctokit([
+      [
+        {
+          number: 1,
+          title: "Terraform Drift (aws/foo)",
+          state: "OPEN",
+          url: "https://github.com/owner/repo/issues/1",
+        },
+      ],
+    ]);
+
+    const result = await getIssue("aws/foo", graphqlOctokit, "owner/repo");
+
+    expect(result).toEqual({
+      number: 1,
+      title: "Terraform Drift (aws/foo)",
+      state: "OPEN",
+      url: "https://github.com/owner/repo/issues/1",
+    });
+  });
+
+  it("skips issues with non-matching titles", async () => {
+    const graphqlOctokit = createMockGraphqlOctokit([
+      [
+        {
+          number: 1,
+          title: "Terraform Drift (aws/bar)",
+          state: "OPEN",
+          url: "https://github.com/owner/repo/issues/1",
+        },
+        {
+          number: 2,
+          title: "Terraform Drift (aws/foo)",
+          state: "CLOSED",
+          url: "https://github.com/owner/repo/issues/2",
+        },
+      ],
+    ]);
+
+    const result = await getIssue("aws/foo", graphqlOctokit, "owner/repo");
+
+    expect(result).toEqual({
+      number: 2,
+      title: "Terraform Drift (aws/foo)",
+      state: "CLOSED",
+      url: "https://github.com/owner/repo/issues/2",
+    });
+  });
+
+  it("handles pagination across multiple pages", async () => {
+    const graphqlOctokit = createMockGraphqlOctokit([
+      [
+        {
+          number: 1,
+          title: "Terraform Drift (aws/bar)",
+          state: "OPEN",
+          url: "https://github.com/owner/repo/issues/1",
+        },
+      ],
+      [
+        {
+          number: 2,
+          title: "Terraform Drift (aws/foo)",
+          state: "OPEN",
+          url: "https://github.com/owner/repo/issues/2",
+        },
+      ],
+    ]);
+
+    const result = await getIssue("aws/foo", graphqlOctokit, "owner/repo");
+
+    expect(result).toEqual({
+      number: 2,
+      title: "Terraform Drift (aws/foo)",
+      state: "OPEN",
+      url: "https://github.com/owner/repo/issues/2",
+    });
+  });
+});
+
+describe("run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns undefined when drift_detection is falsy in config", async () => {
+    const logger = createMockLogger();
+    const graphqlOctokit = createMockGraphqlOctokit([]);
+    const deps = createMockDeps();
+
+    const result = await run(
+      {
+        config: createMockConfig(undefined),
+        ghToken: "token",
+        repo: "owner/repo",
+        graphqlOctokit,
+        logger,
+      },
+      deps,
+    );
+
+    expect(result).toBeUndefined();
+    expect(logger.info).toHaveBeenCalledWith("drift detection is disabled");
+  });
+
+  it("throws when repo_owner and repo_name cannot be resolved", async () => {
+    const logger = createMockLogger();
+    const graphqlOctokit = createMockGraphqlOctokit([]);
+    const deps = createMockDeps();
+
+    await expect(
+      run(
+        {
+          config: createMockConfig({ minimum_detection_interval: 168 }),
+          ghToken: "token",
+          repo: "",
+          graphqlOctokit,
+          logger,
+        },
+        deps,
+      ),
+    ).rejects.toThrow("repo_owner and repo_name are required");
+  });
+
+  it("throws when ghToken is empty", async () => {
+    const logger = createMockLogger();
+    const graphqlOctokit = createMockGraphqlOctokit([[]]);
+    const deps = createMockDeps();
+
+    await expect(
+      run(
+        {
+          config: createMockConfig({ minimum_detection_interval: 168 }),
+          ghToken: "",
+          repo: "owner/repo",
+          graphqlOctokit,
+          logger,
+        },
+        deps,
+      ),
+    ).rejects.toThrow("GITHUB_TOKEN is required");
+  });
+
+  it("returns undefined when drift detection is disabled for the target", async () => {
+    const logger = createMockLogger();
+    const graphqlOctokit = createMockGraphqlOctokit([]);
+    const deps = createMockDeps({
+      checkDriftDetectionEnabled: vi.fn().mockReturnValue(false),
+    });
+
+    const result = await run(
+      {
+        config: createMockConfig({ minimum_detection_interval: 168 }),
+        ghToken: "token",
+        repo: "owner/repo",
+        graphqlOctokit,
+        logger,
+      },
+      deps,
+    );
+
+    expect(result).toBeUndefined();
+    expect(logger.info).toHaveBeenCalledWith("drift detection is disabled");
+  });
+
+  it("returns existing issue if found", async () => {
+    const logger = createMockLogger();
+    const graphqlOctokit = createMockGraphqlOctokit([
+      [
+        {
+          number: 10,
+          title: "Terraform Drift (aws/foo)",
+          state: "OPEN",
+          url: "https://github.com/owner/repo/issues/10",
+        },
+      ],
+    ]);
+    const deps = createMockDeps();
+
+    const result = await run(
+      {
+        config: createMockConfig({ minimum_detection_interval: 168 }),
+        ghToken: "token",
+        repo: "owner/repo",
+        graphqlOctokit,
+        logger,
+      },
+      deps,
+    );
+
+    expect(result).toEqual({
+      number: 10,
+      state: "OPEN",
+      url: "https://github.com/owner/repo/issues/10",
+    });
+    expect(deps.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("calls createIssue when no existing issue found", async () => {
+    const logger = createMockLogger();
+    const graphqlOctokit = createMockGraphqlOctokit([[]]);
+    const deps = createMockDeps();
+
+    const result = await run(
+      {
+        config: createMockConfig({ minimum_detection_interval: 168 }),
+        ghToken: "token",
+        repo: "owner/repo",
+        graphqlOctokit,
+        logger,
+      },
+      deps,
+    );
+
+    expect(deps.createIssue).toHaveBeenCalledWith(
+      "aws/foo",
+      "token",
+      "owner",
+      "repo",
+    );
+    expect(result).toEqual({
+      number: 42,
+      state: "open",
+      url: "https://github.com/owner/repo/issues/42",
+    });
+  });
+
+  it("uses drift_detection.issue_repo_owner/issue_repo_name from config when set", async () => {
+    const logger = createMockLogger();
+    const graphqlOctokit = createMockGraphqlOctokit([[]]);
+    const deps = createMockDeps();
+
+    await run(
+      {
+        config: createMockConfig({
+          minimum_detection_interval: 168,
+          issue_repo_owner: "custom-owner",
+          issue_repo_name: "custom-repo",
+        }),
+        ghToken: "token",
+        repo: "default-owner/default-repo",
+        graphqlOctokit,
+        logger,
+      },
+      deps,
+    );
+
+    expect(deps.createIssue).toHaveBeenCalledWith(
+      "aws/foo",
+      "token",
+      "custom-owner",
+      "custom-repo",
+    );
+  });
+
+  it("falls back to splitting repo input when config values not set", async () => {
+    const logger = createMockLogger();
+    const graphqlOctokit = createMockGraphqlOctokit([[]]);
+    const deps = createMockDeps();
+
+    await run(
+      {
+        config: createMockConfig({ minimum_detection_interval: 168 }),
+        ghToken: "token",
+        repo: "fallback-owner/fallback-repo",
+        graphqlOctokit,
+        logger,
+      },
+      deps,
+    );
+
+    expect(deps.createIssue).toHaveBeenCalledWith(
+      "aws/foo",
+      "token",
+      "fallback-owner",
+      "fallback-repo",
+    );
+  });
+});

--- a/src/actions/get-or-create-drift-issue/run.ts
+++ b/src/actions/get-or-create-drift-issue/run.ts
@@ -1,0 +1,178 @@
+import * as lib from "../../lib";
+import * as types from "../../lib/types";
+import * as drift from "../../lib/drift";
+import * as path from "path";
+
+export type GraphQLPaginator = {
+  graphql: {
+    paginate: {
+      iterator: <T>(
+        query: string,
+        variables: Record<string, unknown>,
+      ) => AsyncIterable<T>;
+    };
+  };
+};
+
+export type Logger = {
+  info: (message: string) => void;
+};
+
+export type Result = {
+  number: number;
+  state: string;
+  url: string;
+};
+
+type Issue = {
+  url: string;
+  number: number;
+  state: string;
+};
+
+export type RunInput = {
+  config: types.Config;
+  target?: string;
+  workingDir?: string;
+  ghToken: string;
+  repo?: string;
+  graphqlOctokit: GraphQLPaginator;
+  logger: Logger;
+};
+
+export type GetTargetGroupFn = (
+  config: {
+    config_path: string;
+    working_directory_file: string;
+    target_groups: types.TargetGroup[];
+    replace_target?: types.Replace | undefined;
+  },
+  target?: string,
+  workingDir?: string,
+) => Promise<lib.Target>;
+
+export type ReadTargetConfigFn = (p: string) => types.TargetConfig;
+
+export type CreateIssueFn = (
+  target: string,
+  ghToken: string,
+  repoOwner: string,
+  repoName: string,
+) => Promise<Issue>;
+
+export type RunDependencies = {
+  getTargetGroup: GetTargetGroupFn;
+  readTargetConfig: ReadTargetConfigFn;
+  checkDriftDetectionEnabled: typeof drift.checkDriftDetectionEnabled;
+  createIssue: CreateIssueFn;
+};
+
+export const defaultDependencies: RunDependencies = {
+  getTargetGroup: lib.getTargetGroup,
+  readTargetConfig: lib.readTargetConfig,
+  checkDriftDetectionEnabled: drift.checkDriftDetectionEnabled,
+  createIssue: drift.createIssue,
+};
+
+export const getIssue = async (
+  target: string,
+  graphqlOctokit: GraphQLPaginator,
+  repo: string,
+): Promise<Issue | undefined> => {
+  const title = `Terraform Drift (${target})`;
+  const query = `query($cursor: String, $searchQuery: String!) {
+  search(first: 100, after: $cursor, query: $searchQuery, type: ISSUE) {
+    nodes {
+    	... on Issue {
+    		number
+    		title
+    		state
+    		url
+    	}
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}`;
+
+  const pageIterator = graphqlOctokit.graphql.paginate.iterator<{
+    search: {
+      nodes: Array<{
+        number: number;
+        title: string;
+        state: string;
+        url: string;
+      }>;
+    };
+  }>(query, {
+    issuesCursor: null,
+    searchQuery: `repo:${repo} "${title}" in:title`,
+  });
+
+  for await (const response of pageIterator) {
+    for (const issue of response.search.nodes) {
+      if (issue.title !== title) {
+        continue;
+      }
+      return issue;
+    }
+  }
+  return undefined;
+};
+
+export const run = async (
+  input: RunInput,
+  deps: RunDependencies = defaultDependencies,
+): Promise<Result | undefined> => {
+  const { config, ghToken, logger, graphqlOctokit } = input;
+
+  if (!config.drift_detection) {
+    logger.info("drift detection is disabled");
+    return undefined;
+  }
+
+  const repoOwner =
+    config.drift_detection.issue_repo_owner ?? (input.repo ?? "").split("/")[0];
+  const repoName =
+    config.drift_detection.issue_repo_name ?? (input.repo ?? "").split("/")[1];
+  if (!repoOwner || !repoName) {
+    throw new Error("repo_owner and repo_name are required");
+  }
+  const tg = await deps.getTargetGroup(config, input.target, input.workingDir);
+
+  const wdConfig = deps.readTargetConfig(
+    path.join(
+      config.git_root_dir,
+      tg.workingDir,
+      config.working_directory_file,
+    ),
+  );
+
+  if (!deps.checkDriftDetectionEnabled(config, tg.group, wdConfig)) {
+    logger.info("drift detection is disabled");
+    return;
+  }
+  logger.info("drift detection is enabled");
+
+  if (!ghToken) {
+    throw new Error("GITHUB_TOKEN is required");
+  }
+
+  let issue = await getIssue(
+    tg.target,
+    graphqlOctokit,
+    `${repoOwner}/${repoName}`,
+  );
+  if (issue === undefined) {
+    logger.info("creating a drift issue");
+    issue = await deps.createIssue(tg.target, ghToken, repoOwner, repoName);
+  }
+
+  return {
+    number: issue.number,
+    state: issue.state,
+    url: issue.url,
+  };
+};


### PR DESCRIPTION
## Summary
- Extract business logic from `index.ts` into `run.ts` with dependency injection for testability
- Add 12 tests covering `getIssue` (no issues, exact match, non-matching titles, pagination) and `run` (disabled drift detection, missing repo, empty token, disabled for target, existing issue, issue creation, custom repo config, fallback repo splitting)
- Slim down `index.ts` to only handle config loading, Octokit creation, and output handling

## Test plan
- [x] `npm t` — all 524 tests pass (12 new)
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)