### PR TITLE
refactor: add tests for release-module

### DIFF
--- a/src/actions/release-module/index.ts
+++ b/src/actions/release-module/index.ts
@@ -1,62 +1,33 @@
-import * as github from "@actions/github";
 import * as fs from "fs";
+import * as github from "@actions/github";
 import * as core from "@actions/core";
 import * as env from "../../lib/env";
 import * as input from "../../lib/input";
+import { run } from "./run";
 
 export const main = async () => {
-  const modulePath = input.getRequiredModulePath();
-  const version = input.getRequiredVersion();
   const githubToken = input.getRequiredGitHubToken();
-
-  // Validate inputs
-  if (!modulePath) {
-    throw new Error("module_path is required");
-  }
-  if (!version) {
-    throw new Error("version is required");
-  }
-
-  // Check if module path exists
-  if (!fs.existsSync(modulePath) || !fs.statSync(modulePath).isDirectory()) {
-    throw new Error(`module_path is invalid. ${modulePath} isn't found`);
-  }
-
-  // Generate tag name
-  const moduleName = modulePath.replace(/\//g, "_");
-  const tag = `module_${moduleName}_${version}`;
-  core.info(`Tag: ${tag}`);
-
   const octokit = github.getOctokit(githubToken);
   const { owner, repo } = github.context.repo;
-  const sha = env.all.GITHUB_SHA;
-  const serverUrl = env.GITHUB_SERVER_URL;
-  const repository = env.all.GITHUB_REPOSITORY;
 
-  // Create tag
-  core.info(`Creating tag ${tag}`);
-  await octokit.rest.git.createRef({
-    owner,
-    repo,
-    ref: `refs/tags/${tag}`,
-    sha,
-  });
-
-  // Create release
-  const note = `module: ${modulePath}
-version: ${version}
-
-[Source code](${serverUrl}/${repository}/tree/${tag}/${modulePath})
-[Versions](${serverUrl}/${repository}/releases?q=${modulePath})`;
-
-  core.info(`Creating release ${tag}`);
-  await octokit.rest.repos.createRelease({
-    owner,
-    repo,
-    tag_name: tag,
-    name: tag,
-    body: note,
-  });
-
-  core.info(`Released ${tag}`);
+  await run(
+    {
+      modulePath: input.getRequiredModulePath(),
+      version: input.getRequiredVersion(),
+      sha: env.all.GITHUB_SHA,
+      serverUrl: env.GITHUB_SERVER_URL,
+      repository: env.all.GITHUB_REPOSITORY,
+      owner,
+      repo,
+      logger: {
+        info: core.info,
+      },
+    },
+    {
+      createRef: (params) => octokit.rest.git.createRef(params),
+      createRelease: (params) => octokit.rest.repos.createRelease(params),
+      isDirectory: (path) =>
+        fs.existsSync(path) && fs.statSync(path).isDirectory(),
+    },
+  );
 };

--- a/src/actions/release-module/run.test.ts
+++ b/src/actions/release-module/run.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  generateTag,
+  run,
+  type RunInput,
+  type RunDependencies,
+  type Logger,
+} from "./run";
+
+describe("generateTag", () => {
+  it("generates correct tag from simple path", () => {
+    expect(generateTag("foo", "v1.0.0")).toBe("module_foo_v1.0.0");
+  });
+
+  it("replaces / with _ in path", () => {
+    expect(generateTag("aws/modules/vpc", "v1.0.0")).toBe(
+      "module_aws_modules_vpc_v1.0.0",
+    );
+  });
+});
+
+describe("run", () => {
+  const createMockLogger = (): Logger => ({
+    info: vi.fn(),
+  });
+
+  const createMockDeps = (isDirectory: boolean = true): RunDependencies => ({
+    createRef: vi.fn().mockResolvedValue({}),
+    createRelease: vi.fn().mockResolvedValue({}),
+    isDirectory: vi.fn().mockReturnValue(isDirectory),
+  });
+
+  const createRunInput = (overrides?: Partial<RunInput>): RunInput => ({
+    modulePath: "aws/modules/vpc",
+    version: "v1.0.0",
+    sha: "abc123",
+    serverUrl: "https://github.com",
+    repository: "owner/repo",
+    owner: "owner",
+    repo: "repo",
+    logger: createMockLogger(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when modulePath is empty", async () => {
+    const input = createRunInput({ modulePath: "" });
+    const deps = createMockDeps();
+
+    await expect(run(input, deps)).rejects.toThrow("module_path is required");
+  });
+
+  it("throws when version is empty", async () => {
+    const input = createRunInput({ version: "" });
+    const deps = createMockDeps();
+
+    await expect(run(input, deps)).rejects.toThrow("version is required");
+  });
+
+  it("throws when modulePath is not a directory", async () => {
+    const input = createRunInput();
+    const deps = createMockDeps(false);
+
+    await expect(run(input, deps)).rejects.toThrow(
+      "module_path is invalid. aws/modules/vpc isn't found",
+    );
+  });
+
+  it("calls createRef with correct tag and SHA", async () => {
+    const input = createRunInput();
+    const deps = createMockDeps();
+
+    await run(input, deps);
+
+    expect(deps.createRef).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      ref: "refs/tags/module_aws_modules_vpc_v1.0.0",
+      sha: "abc123",
+    });
+  });
+
+  it("calls createRelease with correct tag, name, and body", async () => {
+    const input = createRunInput();
+    const deps = createMockDeps();
+
+    await run(input, deps);
+
+    expect(deps.createRelease).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      tag_name: "module_aws_modules_vpc_v1.0.0",
+      name: "module_aws_modules_vpc_v1.0.0",
+      body: expect.stringContaining("module: aws/modules/vpc"),
+    });
+  });
+
+  it("body contains module path, version, source code link, and versions link", async () => {
+    const input = createRunInput();
+    const deps = createMockDeps();
+
+    await run(input, deps);
+
+    const body = vi.mocked(deps.createRelease).mock.calls[0][0].body;
+    expect(body).toContain("module: aws/modules/vpc");
+    expect(body).toContain("version: v1.0.0");
+    expect(body).toContain(
+      "[Source code](https://github.com/owner/repo/tree/module_aws_modules_vpc_v1.0.0/aws/modules/vpc)",
+    );
+    expect(body).toContain(
+      "[Versions](https://github.com/owner/repo/releases?q=aws/modules/vpc)",
+    );
+  });
+
+  it("logs tag info and completion message", async () => {
+    const logger = createMockLogger();
+    const input = createRunInput({ logger });
+    const deps = createMockDeps();
+
+    await run(input, deps);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "Tag: module_aws_modules_vpc_v1.0.0",
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "Creating tag module_aws_modules_vpc_v1.0.0",
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "Creating release module_aws_modules_vpc_v1.0.0",
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "Released module_aws_modules_vpc_v1.0.0",
+    );
+  });
+});

--- a/src/actions/release-module/run.ts
+++ b/src/actions/release-module/run.ts
@@ -1,0 +1,96 @@
+export type Logger = {
+  info: (message: string) => void;
+};
+
+export type RunInput = {
+  modulePath: string;
+  version: string;
+  sha: string;
+  serverUrl: string;
+  repository: string;
+  owner: string;
+  repo: string;
+  logger: Logger;
+};
+
+export type RunDependencies = {
+  createRef: (params: {
+    owner: string;
+    repo: string;
+    ref: string;
+    sha: string;
+  }) => Promise<unknown>;
+  createRelease: (params: {
+    owner: string;
+    repo: string;
+    tag_name: string;
+    name: string;
+    body: string;
+  }) => Promise<unknown>;
+  isDirectory: (path: string) => boolean;
+};
+
+export const generateTag = (modulePath: string, version: string): string => {
+  const moduleName = modulePath.replace(/\//g, "_");
+  return `module_${moduleName}_${version}`;
+};
+
+export const run = async (
+  input: RunInput,
+  deps: RunDependencies,
+): Promise<void> => {
+  const {
+    modulePath,
+    version,
+    sha,
+    serverUrl,
+    repository,
+    owner,
+    repo,
+    logger,
+  } = input;
+
+  // Validate inputs
+  if (!modulePath) {
+    throw new Error("module_path is required");
+  }
+  if (!version) {
+    throw new Error("version is required");
+  }
+
+  // Check if module path exists
+  if (!deps.isDirectory(modulePath)) {
+    throw new Error(`module_path is invalid. ${modulePath} isn't found`);
+  }
+
+  // Generate tag name
+  const tag = generateTag(modulePath, version);
+  logger.info(`Tag: ${tag}`);
+
+  // Create tag
+  logger.info(`Creating tag ${tag}`);
+  await deps.createRef({
+    owner,
+    repo,
+    ref: `refs/tags/${tag}`,
+    sha,
+  });
+
+  // Create release
+  const note = `module: ${modulePath}
+version: ${version}
+
+[Source code](${serverUrl}/${repository}/tree/${tag}/${modulePath})
+[Versions](${serverUrl}/${repository}/releases?q=${modulePath})`;
+
+  logger.info(`Creating release ${tag}`);
+  await deps.createRelease({
+    owner,
+    repo,
+    tag_name: tag,
+    name: tag,
+    body: note,
+  });
+
+  logger.info(`Released ${tag}`);
+};


### PR DESCRIPTION
## Summary
- Extract business logic from `src/actions/release-module/index.ts` into `run.ts` with dependency injection for `createRef`, `createRelease`, and `isDirectory`
- Add `run.test.ts` with 9 test cases covering tag generation, input validation, directory checks, GitHub API calls, release body content, and logging
- Slim down `index.ts` to wiring only (env/input reading, Octokit setup, calling `run()`)

## Test plan
- [x] `npm t` — all 536 tests pass (including 9 new)
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)