### PR TITLE
refactor: add tests for terraform-init

### DIFF
--- a/src/actions/terraform-init/index.ts
+++ b/src/actions/terraform-init/index.ts
@@ -1,21 +1,12 @@
-import * as core from "@actions/core";
 import * as github from "@actions/github";
-import * as fs from "fs";
 import * as path from "path";
 
 import { getTargetConfig } from "../get-target-config";
 import * as lib from "../../lib";
 import * as env from "../../lib/env";
 import * as input from "../../lib/input";
-import * as git from "../../lib/git";
 import * as aqua from "../../aqua";
-import * as commit from "../../commit";
-
-// Check if this is a pull request event
-const isPullRequestEvent = (): boolean => {
-  const eventName = github.context.eventName;
-  return eventName === "pull_request" || eventName.startsWith("pull_request_");
-};
+import { isPullRequestEvent, run } from "./run";
 
 export const main = async () => {
   const githubToken = input.getRequiredGitHubToken();
@@ -36,7 +27,6 @@ export const main = async () => {
     targetConfig.working_directory,
   );
   const tfCommand = targetConfig.terraform_command;
-  const providersLockOpts = targetConfig.providers_lock_opts;
 
   const executor = await aqua.NewExecutor({
     githubToken,
@@ -47,89 +37,18 @@ export const main = async () => {
     tfCommand === "terragrunt" &&
     (await aqua.checkTerrgruntRun(executor, workingDir));
 
-  if (!isPullRequestEvent()) {
-    // Non-PR: just run init with github-comment
-    await executor.exec(tfCommand, ["init", "-input=false"], {
-      cwd: workingDir,
-      comment: {
-        token: githubToken,
-      },
-    });
-  } else {
-    // PR: init with lock file handling
-    const lockFile = workingDir
-      ? path.join(workingDir, ".terraform.lock.hcl")
-      : ".terraform.lock.hcl";
-    const existedBefore = fs.existsSync(lockFile);
-
-    // terraform init (try without upgrade first, then with upgrade on failure)
-    core.startGroup(`${tfCommand} init`);
-    const initResult = await executor.exec(
-      tfCommand,
-      ["init", "-input=false"],
-      {
-        cwd: workingDir,
-        ignoreReturnCode: true,
-      },
-    );
-    if (initResult !== 0) {
-      await executor.exec(tfCommand, ["init", "-input=false", "-upgrade"], {
-        cwd: workingDir,
-        comment: {
-          token: githubToken,
-        },
-      });
-    }
-    core.endGroup();
-
-    const lockArgs = providersLockOpts.split(/\s+/).filter((s) => s.length > 0);
-    await executor.exec(
-      tfCommand,
-      (terragruntRunAvailable ? ["run", "--"] : []).concat(
-        ["providers", "lock"],
-        lockArgs,
-      ),
-      {
-        cwd: workingDir,
-        group: terragruntRunAvailable
-          ? `${tfCommand} run -- providers lock`
-          : `${tfCommand} providers lock`,
-        comment: {
-          token: githubToken,
-        },
-      },
-    );
-
-    // Check if lock file changed
-    if (
-      !existedBefore ||
-      (await git.hasFileChanged(".terraform.lock.hcl", workingDir))
-    ) {
-      // Commit the change
-      const lockFileFromGitRootDir = path.relative(
-        config.git_root_dir,
-        path.join(config.workspace, lockFile),
-      );
-      await commit.create({
-        commitMessage: "chore: update .terraform.lock.hcl",
-        githubToken,
-        rootDir: config.git_root_dir,
-        files: new Set([lockFileFromGitRootDir]),
-        serverRepository: input.securefixActionServerRepository,
-        appId: input.securefixActionAppId,
-        appPrivateKey: input.securefixActionAppPrivateKey,
-      });
-    }
-  }
-
-  await executor.exec(
+  await run({
+    isPullRequest: isPullRequestEvent(github.context.eventName),
+    workingDir,
     tfCommand,
-    terragruntRunAvailable ? ["run", "--", "providers"] : ["providers"],
-    {
-      cwd: workingDir,
-      group: terragruntRunAvailable
-        ? `${tfCommand} run -- providers`
-        : `${tfCommand} providers`,
-    },
-  );
+    providersLockOpts: targetConfig.providers_lock_opts,
+    githubToken,
+    workspace: config.workspace,
+    gitRootDir: config.git_root_dir,
+    terragruntRunAvailable,
+    executor,
+    serverRepository: input.securefixActionServerRepository,
+    appId: input.securefixActionAppId,
+    appPrivateKey: input.securefixActionAppPrivateKey,
+  });
 };

--- a/src/actions/terraform-init/run.test.ts
+++ b/src/actions/terraform-init/run.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+import { isPullRequestEvent, run, type RunInput } from "./run";
+import type * as aqua from "../../aqua";
+
+vi.mock("@actions/core", () => ({
+  startGroup: vi.fn(),
+  endGroup: vi.fn(),
+}));
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof fs>("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+  };
+});
+
+vi.mock("../../lib/git", () => ({
+  hasFileChanged: vi.fn(),
+}));
+
+vi.mock("../../commit", () => ({
+  create: vi.fn(),
+}));
+
+const createMockExecutor = () => ({
+  exec: vi.fn().mockResolvedValue(0),
+  getExecOutput: vi.fn().mockResolvedValue({
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+  }),
+  installDir: "/mock/install",
+  githubToken: "mock-token",
+  env: vi.fn(),
+  buildArgs: vi.fn(),
+});
+
+type MockExecutor = ReturnType<typeof createMockExecutor>;
+
+const createBaseInput = (executor: MockExecutor): RunInput => ({
+  isPullRequest: false,
+  workingDir: "/test/working/dir",
+  tfCommand: "terraform",
+  providersLockOpts:
+    "-platform=windows_amd64 -platform=linux_amd64 -platform=darwin_amd64",
+  githubToken: "test-token",
+  workspace: "/github/workspace",
+  gitRootDir: "/github/workspace",
+  terragruntRunAvailable: false,
+  executor: executor as unknown as aqua.Executor,
+  serverRepository: "",
+  appId: "",
+  appPrivateKey: "",
+});
+
+describe("isPullRequestEvent", () => {
+  it("returns true for pull_request", () => {
+    expect(isPullRequestEvent("pull_request")).toBe(true);
+  });
+
+  it("returns true for pull_request_target", () => {
+    expect(isPullRequestEvent("pull_request_target")).toBe(true);
+  });
+
+  it("returns false for push", () => {
+    expect(isPullRequestEvent("push")).toBe(false);
+  });
+
+  it("returns false for schedule", () => {
+    expect(isPullRequestEvent("schedule")).toBe(false);
+  });
+});
+
+describe("run", () => {
+  let mockExecutor: MockExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecutor = createMockExecutor();
+  });
+
+  it("non-PR: calls init with comment and providers", async () => {
+    const input = createBaseInput(mockExecutor);
+
+    await run(input);
+
+    expect(mockExecutor.exec).toHaveBeenCalledTimes(2);
+    // init with comment
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      1,
+      "terraform",
+      ["init", "-input=false"],
+      expect.objectContaining({
+        cwd: "/test/working/dir",
+        comment: { token: "test-token" },
+      }),
+    );
+    // providers
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      2,
+      "terraform",
+      ["providers"],
+      expect.objectContaining({
+        cwd: "/test/working/dir",
+        group: "terraform providers",
+      }),
+    );
+  });
+
+  it("PR, init succeeds, lock not changed: init + providers lock + providers, no commit", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const gitMod = await import("../../lib/git");
+    vi.mocked(gitMod.hasFileChanged).mockResolvedValue(false);
+    const commitMod = await import("../../commit");
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+    };
+
+    await run(input);
+
+    // init + providers lock + providers = 3 exec calls
+    expect(mockExecutor.exec).toHaveBeenCalledTimes(3);
+    // init (no comment, ignoreReturnCode)
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      1,
+      "terraform",
+      ["init", "-input=false"],
+      expect.objectContaining({ ignoreReturnCode: true }),
+    );
+    // providers lock
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      2,
+      "terraform",
+      expect.arrayContaining(["providers", "lock"]),
+      expect.objectContaining({
+        comment: { token: "test-token" },
+      }),
+    );
+    // providers
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      3,
+      "terraform",
+      ["providers"],
+      expect.any(Object),
+    );
+    expect(commitMod.create).not.toHaveBeenCalled();
+  });
+
+  it("PR, init fails: retries with -upgrade", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const gitMod = await import("../../lib/git");
+    vi.mocked(gitMod.hasFileChanged).mockResolvedValue(false);
+
+    // First init returns non-zero
+    mockExecutor.exec
+      .mockResolvedValueOnce(1) // init fails
+      .mockResolvedValueOnce(0) // init -upgrade succeeds
+      .mockResolvedValueOnce(0) // providers lock
+      .mockResolvedValueOnce(0); // providers
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+    };
+
+    await run(input);
+
+    // init + init -upgrade + providers lock + providers = 4 exec calls
+    expect(mockExecutor.exec).toHaveBeenCalledTimes(4);
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      2,
+      "terraform",
+      ["init", "-input=false", "-upgrade"],
+      expect.objectContaining({
+        comment: { token: "test-token" },
+      }),
+    );
+  });
+
+  it("PR, lock file changed: calls commit.create", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const gitMod = await import("../../lib/git");
+    vi.mocked(gitMod.hasFileChanged).mockResolvedValue(true);
+    const commitMod = await import("../../commit");
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+    };
+
+    await run(input);
+
+    expect(commitMod.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commitMessage: "chore: update .terraform.lock.hcl",
+        githubToken: "test-token",
+      }),
+    );
+  });
+
+  it("PR, lock file new (did not exist before): calls commit.create without hasFileChanged", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const gitMod = await import("../../lib/git");
+    const commitMod = await import("../../commit");
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+    };
+
+    await run(input);
+
+    expect(gitMod.hasFileChanged).not.toHaveBeenCalled();
+    expect(commitMod.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commitMessage: "chore: update .terraform.lock.hcl",
+      }),
+    );
+  });
+
+  it("PR, lock file not changed: does not call commit.create", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const gitMod = await import("../../lib/git");
+    vi.mocked(gitMod.hasFileChanged).mockResolvedValue(false);
+    const commitMod = await import("../../commit");
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+    };
+
+    await run(input);
+
+    expect(commitMod.create).not.toHaveBeenCalled();
+  });
+
+  it("terragrunt run available: uses run -- prefix on providers lock and providers", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const gitMod = await import("../../lib/git");
+    vi.mocked(gitMod.hasFileChanged).mockResolvedValue(false);
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+      tfCommand: "terragrunt",
+      terragruntRunAvailable: true,
+    };
+
+    await run(input);
+
+    // providers lock with run -- prefix
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      2,
+      "terragrunt",
+      expect.arrayContaining(["run", "--", "providers", "lock"]),
+      expect.objectContaining({
+        group: "terragrunt run -- providers lock",
+      }),
+    );
+    // providers with run -- prefix
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      3,
+      "terragrunt",
+      ["run", "--", "providers"],
+      expect.objectContaining({
+        group: "terragrunt run -- providers",
+      }),
+    );
+  });
+
+  it("terragrunt run not available: no run -- prefix", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const gitMod = await import("../../lib/git");
+    vi.mocked(gitMod.hasFileChanged).mockResolvedValue(false);
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+      tfCommand: "terragrunt",
+      terragruntRunAvailable: false,
+    };
+
+    await run(input);
+
+    // providers lock without run -- prefix
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      2,
+      "terragrunt",
+      expect.arrayContaining(["providers", "lock"]),
+      expect.objectContaining({
+        group: "terragrunt providers lock",
+      }),
+    );
+    // Ensure "run" is not in the args
+    const lockCallArgs = mockExecutor.exec.mock.calls[1][1] as string[];
+    expect(lockCallArgs).not.toContain("run");
+
+    // providers without run -- prefix
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      3,
+      "terragrunt",
+      ["providers"],
+      expect.objectContaining({
+        group: "terragrunt providers",
+      }),
+    );
+  });
+
+  it("splits providersLockOpts by whitespace correctly", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const gitMod = await import("../../lib/git");
+    vi.mocked(gitMod.hasFileChanged).mockResolvedValue(false);
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+      providersLockOpts: "-platform=linux_amd64  -platform=darwin_arm64",
+    };
+
+    await run(input);
+
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      2,
+      "terraform",
+      ["providers", "lock", "-platform=linux_amd64", "-platform=darwin_arm64"],
+      expect.any(Object),
+    );
+  });
+
+  it("empty providersLockOpts: produces providers lock with no extra args", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const gitMod = await import("../../lib/git");
+    vi.mocked(gitMod.hasFileChanged).mockResolvedValue(false);
+
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: true,
+      providersLockOpts: "",
+    };
+
+    await run(input);
+
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      2,
+      "terraform",
+      ["providers", "lock"],
+      expect.any(Object),
+    );
+  });
+
+  it("non-PR + terragrunt: no run -- for init, uses run -- for providers", async () => {
+    const input = {
+      ...createBaseInput(mockExecutor),
+      isPullRequest: false,
+      tfCommand: "terragrunt",
+      terragruntRunAvailable: true,
+    };
+
+    await run(input);
+
+    expect(mockExecutor.exec).toHaveBeenCalledTimes(2);
+    // init (no run -- prefix)
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      1,
+      "terragrunt",
+      ["init", "-input=false"],
+      expect.any(Object),
+    );
+    // providers with run -- prefix
+    expect(mockExecutor.exec).toHaveBeenNthCalledWith(
+      2,
+      "terragrunt",
+      ["run", "--", "providers"],
+      expect.objectContaining({
+        group: "terragrunt run -- providers",
+      }),
+    );
+  });
+});

--- a/src/actions/terraform-init/run.ts
+++ b/src/actions/terraform-init/run.ts
@@ -1,0 +1,121 @@
+import * as core from "@actions/core";
+import * as fs from "fs";
+import * as path from "path";
+
+import * as aqua from "../../aqua";
+import * as git from "../../lib/git";
+import * as commit from "../../commit";
+
+// Check if this is a pull request event
+export const isPullRequestEvent = (eventName: string): boolean => {
+  return eventName === "pull_request" || eventName.startsWith("pull_request_");
+};
+
+export type RunInput = {
+  isPullRequest: boolean;
+  workingDir: string;
+  tfCommand: string;
+  providersLockOpts: string;
+  githubToken: string;
+  workspace: string;
+  gitRootDir: string;
+  terragruntRunAvailable: boolean;
+  executor: aqua.Executor;
+  serverRepository: string;
+  appId: string;
+  appPrivateKey: string;
+};
+
+export const run = async (input: RunInput): Promise<void> => {
+  if (!input.isPullRequest) {
+    // Non-PR: just run init with github-comment
+    await input.executor.exec(input.tfCommand, ["init", "-input=false"], {
+      cwd: input.workingDir,
+      comment: {
+        token: input.githubToken,
+      },
+    });
+  } else {
+    // PR: init with lock file handling
+    const lockFile = input.workingDir
+      ? path.join(input.workingDir, ".terraform.lock.hcl")
+      : ".terraform.lock.hcl";
+    const existedBefore = fs.existsSync(lockFile);
+
+    // terraform init (try without upgrade first, then with upgrade on failure)
+    core.startGroup(`${input.tfCommand} init`);
+    const initResult = await input.executor.exec(
+      input.tfCommand,
+      ["init", "-input=false"],
+      {
+        cwd: input.workingDir,
+        ignoreReturnCode: true,
+      },
+    );
+    if (initResult !== 0) {
+      await input.executor.exec(
+        input.tfCommand,
+        ["init", "-input=false", "-upgrade"],
+        {
+          cwd: input.workingDir,
+          comment: {
+            token: input.githubToken,
+          },
+        },
+      );
+    }
+    core.endGroup();
+
+    const lockArgs = input.providersLockOpts
+      .split(/\s+/)
+      .filter((s) => s.length > 0);
+    await input.executor.exec(
+      input.tfCommand,
+      (input.terragruntRunAvailable ? ["run", "--"] : []).concat(
+        ["providers", "lock"],
+        lockArgs,
+      ),
+      {
+        cwd: input.workingDir,
+        group: input.terragruntRunAvailable
+          ? `${input.tfCommand} run -- providers lock`
+          : `${input.tfCommand} providers lock`,
+        comment: {
+          token: input.githubToken,
+        },
+      },
+    );
+
+    // Check if lock file changed
+    if (
+      !existedBefore ||
+      (await git.hasFileChanged(".terraform.lock.hcl", input.workingDir))
+    ) {
+      // Commit the change
+      const lockFileFromGitRootDir = path.relative(
+        input.gitRootDir,
+        path.join(input.workspace, lockFile),
+      );
+      await commit.create({
+        commitMessage: "chore: update .terraform.lock.hcl",
+        githubToken: input.githubToken,
+        rootDir: input.gitRootDir,
+        files: new Set([lockFileFromGitRootDir]),
+        serverRepository: input.serverRepository,
+        appId: input.appId,
+        appPrivateKey: input.appPrivateKey,
+      });
+    }
+  }
+
+  await input.executor.exec(
+    input.tfCommand,
+    input.terragruntRunAvailable ? ["run", "--", "providers"] : ["providers"],
+    {
+      cwd: input.workingDir,
+      group: input.terragruntRunAvailable
+        ? `${input.tfCommand} run -- providers`
+        : `${input.tfCommand} providers`,
+    },
+  );
+};


### PR DESCRIPTION
## Summary
- Refactor `src/actions/terraform-init/index.ts` into `index.ts` + `run.ts` + `run.test.ts` following the project convention
- Extract business logic into `run.ts` with dependency injection via `RunInput` type
- Add 15 tests covering `isPullRequestEvent` and all `run()` code paths (non-PR, PR init retry, lock file change detection, terragrunt run prefix, providersLockOpts splitting)

## Test plan
- [x] `npm t` — all 640 tests pass
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)