### PR TITLE
refactor: add tests for actions/update-drift-issue

### DIFF
--- a/src/actions/update-drift-issue/index.ts
+++ b/src/actions/update-drift-issue/index.ts
@@ -4,16 +4,7 @@ import * as lib from "../../lib";
 import * as drift from "../../lib/drift";
 import * as env from "../../lib/env";
 import * as input from "../../lib/input";
-
-type Inputs = {
-  ghToken: string;
-  status: string;
-  issueNumber: number | undefined;
-  issueState: string | undefined;
-  repoOwner: string;
-  repoName: string;
-  skipTerraform: boolean;
-};
+import { run } from "./run";
 
 export const main = async () => {
   const issueNumberStr = env.all.TFACTION_DRIFT_ISSUE_NUMBER;
@@ -25,129 +16,19 @@ export const main = async () => {
   const config = await lib.getConfig();
   const driftIssueRepo = drift.getDriftIssueRepo(config);
 
-  const inputs: Inputs = {
-    ghToken: input.getRequiredGitHubToken(),
+  const ghToken = input.getRequiredGitHubToken();
+
+  await run({
     status: input.getRequiredStatus(),
     issueNumber: parseInt(issueNumberStr, 10),
     issueState: env.all.TFACTION_DRIFT_ISSUE_STATE,
     repoOwner: driftIssueRepo.owner,
     repoName: driftIssueRepo.name,
     skipTerraform: env.TFACTION_SKIP_TERRAFORM,
-  };
-
-  await run(inputs);
-};
-
-const run = async (inputs: Inputs) => {
-  if (inputs.issueNumber === undefined) {
-    return;
-  }
-
-  // Post comment if job failed
-  if (inputs.status !== "success") {
-    await postCommentIfNeeded(inputs);
-  }
-
-  // Close the drift issue if job succeeded and terraform wasn't skipped
-  if (
-    inputs.issueState === "open" &&
-    inputs.status === "success" &&
-    !inputs.skipTerraform
-  ) {
-    core.info("Closing drift issue");
-    await closeIssue(inputs);
-  }
-
-  // Reopen the drift issue if it was closed and job failed
-  if (inputs.issueState === "closed" && inputs.status !== "success") {
-    core.info("Reopening drift issue");
-    await reopenIssue(inputs);
-  }
-};
-
-const getLatestCommentBody = async (inputs: Inputs): Promise<string> => {
-  const octokit = github.getOctokit(inputs.ghToken);
-  const query = `
-    query($owner: String!, $name: String!, $issueNumber: Int!) {
-      repository(owner: $owner, name: $name) {
-        issue(number: $issueNumber) {
-          comments(last: 1) {
-            nodes {
-              body
-            }
-          }
-        }
-      }
-    }
-  `;
-
-  const result: {
-    repository: {
-      issue: {
-        comments: {
-          nodes: Array<{ body: string }>;
-        };
-      };
-    };
-  } = await octokit.graphql(query, {
-    owner: inputs.repoOwner,
-    name: inputs.repoName,
-    issueNumber: inputs.issueNumber,
-  });
-
-  return result.repository.issue.comments.nodes[0]?.body ?? "";
-};
-
-const postCommentIfNeeded = async (inputs: Inputs) => {
-  if (inputs.issueNumber === undefined) {
-    return;
-  }
-
-  const latestCommentBody = await getLatestCommentBody(inputs);
-
-  // If the latest comment already contains the job URL, skip posting
-  if (latestCommentBody.includes(env.runURL)) {
-    core.info("Latest comment already contains the job URL, skipping");
-    return;
-  }
-
-  const comment = `## :x: CI failed
-
-[Build link](${env.runURL})
-`;
-
-  const octokit = github.getOctokit(inputs.ghToken);
-  await octokit.rest.issues.createComment({
-    owner: inputs.repoOwner,
-    repo: inputs.repoName,
-    issue_number: inputs.issueNumber,
-    body: comment,
-  });
-  core.info("Posted a comment to the drift issue");
-};
-
-const closeIssue = async (inputs: Inputs) => {
-  if (inputs.issueNumber === undefined) {
-    return;
-  }
-  const octokit = github.getOctokit(inputs.ghToken);
-  await octokit.rest.issues.update({
-    owner: inputs.repoOwner,
-    repo: inputs.repoName,
-    issue_number: inputs.issueNumber,
-    state: "closed",
-  });
-};
-
-const reopenIssue = async (inputs: Inputs) => {
-  if (inputs.issueNumber === undefined) {
-    return;
-  }
-  const octokit = github.getOctokit(inputs.ghToken);
-  await octokit.rest.issues.update({
-    owner: inputs.repoOwner,
-    repo: inputs.repoName,
-    issue_number: inputs.issueNumber,
-    state: "open",
+    runURL: env.runURL,
+    octokit: github.getOctokit(ghToken),
+    logger: {
+      info: core.info,
+    },
   });
 };

--- a/src/actions/update-drift-issue/run.test.ts
+++ b/src/actions/update-drift-issue/run.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { run, type RunInput, type Octokit } from "./run";
+
+const createMockOctokit = () => ({
+  graphql: vi.fn(),
+  rest: {
+    issues: {
+      createComment: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+});
+
+const createMockLogger = () => ({
+  info: vi.fn(),
+});
+
+const createRunInput = (
+  overrides: Partial<RunInput> = {},
+): RunInput & { octokit: ReturnType<typeof createMockOctokit> } => {
+  const octokit = createMockOctokit();
+  return {
+    status: "success",
+    issueNumber: 42,
+    issueState: "open",
+    repoOwner: "owner",
+    repoName: "repo",
+    skipTerraform: false,
+    runURL: "https://github.com/owner/repo/actions/runs/123",
+    octokit: octokit as unknown as Octokit,
+    logger: createMockLogger(),
+    ...overrides,
+    // Ensure octokit from overrides is used if provided, otherwise use the created one
+  } as RunInput & { octokit: ReturnType<typeof createMockOctokit> };
+};
+
+describe("run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("early exit when issueNumber is undefined", async () => {
+    const input = createRunInput({ issueNumber: undefined });
+    await run(input);
+    expect(input.octokit.graphql).not.toHaveBeenCalled();
+    expect(input.octokit.rest.issues.createComment).not.toHaveBeenCalled();
+    expect(input.octokit.rest.issues.update).not.toHaveBeenCalled();
+  });
+
+  it("posts comment when status is not success", async () => {
+    const input = createRunInput({
+      status: "failure",
+      issueState: "open",
+    });
+    input.octokit.graphql.mockResolvedValue({
+      repository: {
+        issue: {
+          comments: {
+            nodes: [{ body: "some other comment" }],
+          },
+        },
+      },
+    });
+
+    await run(input);
+
+    expect(input.octokit.graphql).toHaveBeenCalled();
+    expect(input.octokit.rest.issues.createComment).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 42,
+      body: expect.stringContaining("CI failed"),
+    });
+  });
+
+  it("skips comment when latest comment already contains runURL", async () => {
+    const runURL = "https://github.com/owner/repo/actions/runs/123";
+    const input = createRunInput({
+      status: "failure",
+      issueState: "open",
+      runURL,
+    });
+    input.octokit.graphql.mockResolvedValue({
+      repository: {
+        issue: {
+          comments: {
+            nodes: [
+              {
+                body: `## :x: CI failed\n\n[Build link](${runURL})\n`,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    await run(input);
+
+    expect(input.octokit.graphql).toHaveBeenCalled();
+    expect(input.octokit.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it("posts comment with correct body format", async () => {
+    const runURL = "https://github.com/owner/repo/actions/runs/456";
+    const input = createRunInput({
+      status: "failure",
+      issueState: "open",
+      runURL,
+    });
+    input.octokit.graphql.mockResolvedValue({
+      repository: {
+        issue: {
+          comments: {
+            nodes: [],
+          },
+        },
+      },
+    });
+
+    await run(input);
+
+    expect(input.octokit.rest.issues.createComment).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 42,
+      body: `## :x: CI failed\n\n[Build link](${runURL})\n`,
+    });
+  });
+
+  it("closes issue when state=open, status=success, skipTerraform=false", async () => {
+    const input = createRunInput({
+      status: "success",
+      issueState: "open",
+      skipTerraform: false,
+    });
+
+    await run(input);
+
+    expect(input.octokit.rest.issues.update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 42,
+      state: "closed",
+    });
+  });
+
+  it("does not close issue when skipTerraform=true", async () => {
+    const input = createRunInput({
+      status: "success",
+      issueState: "open",
+      skipTerraform: true,
+    });
+
+    await run(input);
+
+    expect(input.octokit.rest.issues.update).not.toHaveBeenCalled();
+  });
+
+  it("does not close issue when status is not success", async () => {
+    const input = createRunInput({
+      status: "failure",
+      issueState: "open",
+    });
+    input.octokit.graphql.mockResolvedValue({
+      repository: {
+        issue: {
+          comments: {
+            nodes: [],
+          },
+        },
+      },
+    });
+
+    await run(input);
+
+    // update should not be called with "closed"
+    const updateCalls = input.octokit.rest.issues.update.mock.calls;
+    for (const call of updateCalls) {
+      expect(call[0].state).not.toBe("closed");
+    }
+  });
+
+  it("does not close issue when state is not open", async () => {
+    const input = createRunInput({
+      status: "success",
+      issueState: "closed",
+    });
+
+    await run(input);
+
+    // update should not be called with "closed"
+    const updateCalls = input.octokit.rest.issues.update.mock.calls;
+    for (const call of updateCalls) {
+      expect(call[0].state).not.toBe("closed");
+    }
+  });
+
+  it("reopens issue when state=closed and status is not success", async () => {
+    const input = createRunInput({
+      status: "failure",
+      issueState: "closed",
+    });
+    input.octokit.graphql.mockResolvedValue({
+      repository: {
+        issue: {
+          comments: {
+            nodes: [],
+          },
+        },
+      },
+    });
+
+    await run(input);
+
+    expect(input.octokit.rest.issues.update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 42,
+      state: "open",
+    });
+  });
+
+  it("does not reopen issue when state is not closed", async () => {
+    const input = createRunInput({
+      status: "failure",
+      issueState: "open",
+    });
+    input.octokit.graphql.mockResolvedValue({
+      repository: {
+        issue: {
+          comments: {
+            nodes: [],
+          },
+        },
+      },
+    });
+
+    await run(input);
+
+    // update should not be called with "open"
+    const updateCalls = input.octokit.rest.issues.update.mock.calls;
+    for (const call of updateCalls) {
+      expect(call[0].state).not.toBe("open");
+    }
+  });
+
+  it("does not reopen issue when status is success", async () => {
+    const input = createRunInput({
+      status: "success",
+      issueState: "closed",
+    });
+
+    await run(input);
+
+    // update should not be called with "open"
+    const updateCalls = input.octokit.rest.issues.update.mock.calls;
+    for (const call of updateCalls) {
+      expect(call[0].state).not.toBe("open");
+    }
+  });
+
+  it("both comment and reopen happen when state=closed and status=failure", async () => {
+    const input = createRunInput({
+      status: "failure",
+      issueState: "closed",
+    });
+    input.octokit.graphql.mockResolvedValue({
+      repository: {
+        issue: {
+          comments: {
+            nodes: [],
+          },
+        },
+      },
+    });
+
+    await run(input);
+
+    expect(input.octokit.rest.issues.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: "owner",
+        repo: "repo",
+        issue_number: 42,
+      }),
+    );
+    expect(input.octokit.rest.issues.update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 42,
+      state: "open",
+    });
+  });
+});

--- a/src/actions/update-drift-issue/run.ts
+++ b/src/actions/update-drift-issue/run.ts
@@ -1,0 +1,149 @@
+import * as core from "@actions/core";
+
+export type Octokit = {
+  graphql: <T>(query: string, variables: Record<string, unknown>) => Promise<T>;
+  rest: {
+    issues: {
+      createComment: (params: {
+        owner: string;
+        repo: string;
+        issue_number: number;
+        body: string;
+      }) => Promise<unknown>;
+      update: (params: {
+        owner: string;
+        repo: string;
+        issue_number: number;
+        state: "open" | "closed";
+      }) => Promise<unknown>;
+    };
+  };
+};
+
+export type RunInput = {
+  status: string;
+  issueNumber: number | undefined;
+  issueState: string | undefined;
+  repoOwner: string;
+  repoName: string;
+  skipTerraform: boolean;
+  runURL: string;
+  octokit: Octokit;
+  logger?: {
+    info: (msg: string) => void;
+  };
+};
+
+const getLatestCommentBody = async (input: RunInput): Promise<string> => {
+  const query = `
+    query($owner: String!, $name: String!, $issueNumber: Int!) {
+      repository(owner: $owner, name: $name) {
+        issue(number: $issueNumber) {
+          comments(last: 1) {
+            nodes {
+              body
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await input.octokit.graphql<{
+    repository: {
+      issue: {
+        comments: {
+          nodes: Array<{ body: string }>;
+        };
+      };
+    };
+  }>(query, {
+    owner: input.repoOwner,
+    name: input.repoName,
+    issueNumber: input.issueNumber,
+  });
+
+  return result.repository.issue.comments.nodes[0]?.body ?? "";
+};
+
+const postCommentIfNeeded = async (input: RunInput) => {
+  if (input.issueNumber === undefined) {
+    return;
+  }
+
+  const log = input.logger ?? core;
+
+  const latestCommentBody = await getLatestCommentBody(input);
+
+  // If the latest comment already contains the job URL, skip posting
+  if (latestCommentBody.includes(input.runURL)) {
+    log.info("Latest comment already contains the job URL, skipping");
+    return;
+  }
+
+  const comment = `## :x: CI failed
+
+[Build link](${input.runURL})
+`;
+
+  await input.octokit.rest.issues.createComment({
+    owner: input.repoOwner,
+    repo: input.repoName,
+    issue_number: input.issueNumber,
+    body: comment,
+  });
+  log.info("Posted a comment to the drift issue");
+};
+
+const closeIssue = async (input: RunInput) => {
+  if (input.issueNumber === undefined) {
+    return;
+  }
+  await input.octokit.rest.issues.update({
+    owner: input.repoOwner,
+    repo: input.repoName,
+    issue_number: input.issueNumber,
+    state: "closed",
+  });
+};
+
+const reopenIssue = async (input: RunInput) => {
+  if (input.issueNumber === undefined) {
+    return;
+  }
+  await input.octokit.rest.issues.update({
+    owner: input.repoOwner,
+    repo: input.repoName,
+    issue_number: input.issueNumber,
+    state: "open",
+  });
+};
+
+export const run = async (input: RunInput): Promise<void> => {
+  if (input.issueNumber === undefined) {
+    return;
+  }
+
+  const log = input.logger ?? core;
+
+  // Post comment if job failed
+  if (input.status !== "success") {
+    await postCommentIfNeeded(input);
+  }
+
+  // Close the drift issue if job succeeded and terraform wasn't skipped
+  if (
+    input.issueState === "open" &&
+    input.status === "success" &&
+    !input.skipTerraform
+  ) {
+    log.info("Closing drift issue");
+    await closeIssue(input);
+  }
+
+  // Reopen the drift issue if it was closed and job failed
+  if (input.issueState === "closed" && input.status !== "success") {
+    log.info("Reopening drift issue");
+    await reopenIssue(input);
+  }
+};


### PR DESCRIPTION
## Summary
- Refactored `src/actions/update-drift-issue/index.ts` into `index.ts` + `run.ts` + `run.test.ts` following the project convention
- Extracted business logic into `run.ts` with dependency injection (octokit, logger, runURL passed as parameters)
- Added 12 tests covering all branches: early exit, comment posting, comment deduplication, issue close/reopen logic

## Test plan
- [x] `npx vitest --run src/actions/update-drift-issue/run.test.ts` — 12 tests pass
- [x] `npx vitest --run` — all 686 tests pass
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)