### PR TITLE
refactor: add tests for install

### DIFF
--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -1,11 +1,12 @@
 import * as core from "@actions/core";
 import * as lib from "../lib";
-import * as aqua from "../aqua";
 import * as input from "../lib/input";
+import { run } from "./run";
 
 export const main = async () => {
-  await aqua.NewExecutor({
+  await run({
     githubToken: input.githubToken,
+    aquaGlobalConfig: lib.aquaGlobalConfig,
+    exportVariable: core.exportVariable,
   });
-  core.exportVariable("AQUA_GLOBAL_CONFIG", lib.aquaGlobalConfig);
 };

--- a/src/install/run.test.ts
+++ b/src/install/run.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { run, type RunInput } from "./run";
+
+vi.mock("../aqua", () => ({
+  NewExecutor: vi.fn().mockResolvedValue({}),
+}));
+
+import * as aqua from "../aqua";
+
+const mockedNewExecutor = vi.mocked(aqua.NewExecutor);
+
+describe("run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls aqua.NewExecutor with the provided githubToken", async () => {
+    const input: RunInput = {
+      githubToken: "my-token",
+      aquaGlobalConfig: "/path/to/config",
+      exportVariable: vi.fn(),
+    };
+    await run(input);
+    expect(mockedNewExecutor).toHaveBeenCalledWith({
+      githubToken: "my-token",
+    });
+  });
+
+  it("calls exportVariable with AQUA_GLOBAL_CONFIG and the config value", async () => {
+    const exportVariable = vi.fn();
+    const input: RunInput = {
+      githubToken: "token",
+      aquaGlobalConfig: "/custom/aqua-global.yaml",
+      exportVariable,
+    };
+    await run(input);
+    expect(exportVariable).toHaveBeenCalledWith(
+      "AQUA_GLOBAL_CONFIG",
+      "/custom/aqua-global.yaml",
+    );
+  });
+
+  it("calls exportVariable after NewExecutor resolves", async () => {
+    const callOrder: string[] = [];
+    mockedNewExecutor.mockImplementation(async () => {
+      callOrder.push("NewExecutor");
+      return {} as aqua.Executor;
+    });
+    const exportVariable = vi.fn().mockImplementation(() => {
+      callOrder.push("exportVariable");
+    });
+    const input: RunInput = {
+      githubToken: "token",
+      aquaGlobalConfig: "/path/to/config",
+      exportVariable,
+    };
+    await run(input);
+    expect(callOrder).toEqual(["NewExecutor", "exportVariable"]);
+  });
+
+  it("handles empty githubToken", async () => {
+    const exportVariable = vi.fn();
+    const input: RunInput = {
+      githubToken: "",
+      aquaGlobalConfig: "/path/to/config",
+      exportVariable,
+    };
+    await run(input);
+    expect(mockedNewExecutor).toHaveBeenCalledWith({
+      githubToken: "",
+    });
+    expect(exportVariable).toHaveBeenCalledWith(
+      "AQUA_GLOBAL_CONFIG",
+      "/path/to/config",
+    );
+  });
+
+  it("propagates error when NewExecutor rejects", async () => {
+    mockedNewExecutor.mockRejectedValue(new Error("install failed"));
+    const exportVariable = vi.fn();
+    const input: RunInput = {
+      githubToken: "token",
+      aquaGlobalConfig: "/path/to/config",
+      exportVariable,
+    };
+    await expect(run(input)).rejects.toThrow("install failed");
+    expect(exportVariable).not.toHaveBeenCalled();
+  });
+});

--- a/src/install/run.ts
+++ b/src/install/run.ts
@@ -1,0 +1,14 @@
+import * as aqua from "../aqua";
+
+export type RunInput = {
+  githubToken: string;
+  aquaGlobalConfig: string;
+  exportVariable: (name: string, val: string) => void;
+};
+
+export const run = async (input: RunInput): Promise<void> => {
+  await aqua.NewExecutor({
+    githubToken: input.githubToken,
+  });
+  input.exportVariable("AQUA_GLOBAL_CONFIG", input.aquaGlobalConfig);
+};


### PR DESCRIPTION
## Summary
- Extract `run` function from `src/install/index.ts` into `src/install/run.ts` with dependency injection for testability
- Add 5 tests in `src/install/run.test.ts` covering `NewExecutor` invocation, `exportVariable` call, execution ordering, empty token handling, and error propagation
- Update `src/install/index.ts` to delegate to the extracted `run` function, keeping `input.ts`/`lib` references in the entry point per project conventions

## Test plan
- [x] `npx vitest --run src/install/run.test.ts` — 5 tests pass
- [x] `npx vitest --run` — all 716 tests pass
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)