### PR TITLE
fix: skip conftest when destroy=true in test action

### DIFF
--- a/src/actions/test/run.test.ts
+++ b/src/actions/test/run.test.ts
@@ -113,14 +113,14 @@ describe("run", () => {
     });
   });
 
-  it("conftest always runs", async () => {
+  it("conftest runs when destroy=false", async () => {
     const { conftestMod } = await getMocks();
     const input = createRunInput(mockExecutor);
     await run(input);
     expect(conftestMod.run).toHaveBeenCalledOnce();
   });
 
-  it("destroy=true skips validate, trivy, tflint, fmt, terraform-docs", async () => {
+  it("destroy=true skips conftest, validate, trivy, tflint, fmt, terraform-docs", async () => {
     const { conftestMod, trivyMod, tflintMod, terraformDocsMod, fmtMod } =
       await getMocks();
     const input = createRunInput(mockExecutor, undefined, {
@@ -132,7 +132,7 @@ describe("run", () => {
 
     await run(input);
 
-    expect(conftestMod.run).toHaveBeenCalledOnce();
+    expect(conftestMod.run).not.toHaveBeenCalled();
     expect(mockExecutor.exec).not.toHaveBeenCalled();
     expect(trivyMod.run).not.toHaveBeenCalled();
     expect(tflintMod.run).not.toHaveBeenCalled();

--- a/src/actions/test/run.ts
+++ b/src/actions/test/run.ts
@@ -31,16 +31,18 @@ export const run = async (input: RunInput): Promise<void> => {
   const target = targetConfig.target;
   const serverRepository = config.securefix_action?.server_repository ?? "";
 
-  await runConftest(
-    {
-      gitRootDir: config.git_root_dir,
-      githubToken,
-      plan: false,
-      executor,
-    },
-    config,
-    targetConfig,
-  );
+  if (!destroy) {
+    await runConftest(
+      {
+        gitRootDir: config.git_root_dir,
+        githubToken,
+        plan: false,
+        executor,
+      },
+      config,
+      targetConfig,
+    );
+  }
 
   if (!destroy) {
     await executor.exec(tfCommand, ["validate"], {


### PR DESCRIPTION
## Summary
- Wrap the `runConftest` call in `if (!destroy)` in `src/actions/test/run.ts` so conftest is skipped when `destroy=true`, consistent with validate, trivy, tflint, fmt, and terraform-docs
- Update tests to verify conftest is skipped on destroy and rename test descriptions accordingly

## Test plan
- [x] `npx vitest --run src/actions/test/run.test.ts` — 18 tests pass
- [x] `npx vitest --run` — all 716 tests pass
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)