### PR TITLE
test: add unit tests for src/lib/drift.ts

### DIFF
--- a/src/lib/drift.test.ts
+++ b/src/lib/drift.test.ts
@@ -14,9 +14,7 @@ vi.mock("@actions/github", () => ({
 import * as github from "@actions/github";
 import { createIssue, getDriftIssueRepo } from "./drift";
 
-const createMockConfig = (
-  driftDetection?: Config["drift_detection"],
-): Config =>
+const createMockConfig = (driftDetection?: Config["drift_detection"]): Config =>
   ({
     drift_detection: driftDetection,
     working_directory_file: "tfaction.yaml",


### PR DESCRIPTION
## Summary
- Add 9 unit tests for `createIssue` and `getDriftIssueRepo` in `src/lib/drift.ts`
- `createIssue`: verify correct parameters, return value mapping, token passing, and target interpolation
- `getDriftIssueRepo`: verify config values, fallback to `github.context.repo`, and partial config handling

## Test plan
- [x] `npm t -- src/lib/drift.test.ts` — all 9 tests pass
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)