### PR TITLE
debug: add diagnostic logging for secrets resolution

### DIFF
--- a/src/actions/get-target-config/index.ts
+++ b/src/actions/get-target-config/index.ts
@@ -136,6 +136,18 @@ export const getTargetConfig = async (
       const secretName = secret.secret_name || secret.env_name;
       secretsConfig[envName] = secretName;
     }
+    core.info(
+      `[debug] matched target group working_directory: ${targetGroup?.working_directory}`,
+    );
+    core.info(
+      `[debug] targetGroup.secrets length: ${targetGroup?.secrets?.length ?? "undefined"}`,
+    );
+    core.info(
+      `[debug] rootJobConfig.secrets length: ${rootJobConfig?.secrets?.length ?? "undefined"}`,
+    );
+    core.info(
+      `[debug] resolved secretsConfig count: ${Object.keys(secretsConfig).length}`,
+    );
     if (Object.keys(secretsConfig).length > 0) {
       result.secretsConfig = secretsConfig;
     }


### PR DESCRIPTION
## Summary
- Add diagnostic `core.info()` logging inside `getTargetConfig` to help identify why `secretsConfig` is `undefined` at runtime after PR #3602
- Logs the matched target group's `working_directory`, `targetGroup.secrets` length, `rootJobConfig.secrets` length, and the final resolved `secretsConfig` count

## Context
After #3602 was merged, the setup action's secrets output is not working. The "list of secret names passed to the action" log appears but the "map the secret" log does not, meaning `targetConfig.secretsConfig` is `undefined`. This PR adds logging to diagnose the root cause.

## Test plan
- [ ] Deploy to a test workflow and check the logs to identify why secrets are not being resolved
- [ ] Once root cause is identified, remove debug logging and apply the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)