### PR TITLE
feat: remove TFACTION_TARGET is required constraint

### DIFF
--- a/src/actions/create-scaffold-pr/run.test.ts
+++ b/src/actions/create-scaffold-pr/run.test.ts
@@ -152,22 +152,6 @@ describe("run", () => {
     vi.mocked(commit.create).mockResolvedValue("");
   });
 
-  it("throws when target is empty after getTargetConfig resolves", async () => {
-    vi.mocked(getTargetConfig.getTargetConfig).mockResolvedValue({
-      working_directory: "",
-      target: "",
-    } as unknown as Awaited<
-      ReturnType<typeof getTargetConfig.getTargetConfig>
-    >);
-
-    await expect(
-      run({
-        ...defaultRunInput,
-        target: "",
-      }),
-    ).rejects.toThrow("TFACTION_TARGET is required");
-  });
-
   it("returns early when no modified files found", async () => {
     vi.mocked(git.getModifiedFiles).mockResolvedValue([]);
 

--- a/src/actions/create-scaffold-pr/run.ts
+++ b/src/actions/create-scaffold-pr/run.ts
@@ -98,10 +98,6 @@ export const run = async (input: RunInput): Promise<void> => {
   const workingDir = targetConfigResult.working_directory || input.workingDir;
   const target = targetConfigResult.target || input.target;
 
-  if (!target) {
-    throw new Error("TFACTION_TARGET is required");
-  }
-
   await aqua.NewExecutor({
     cwd: workingDir,
     githubToken,

--- a/src/actions/test-module/index.ts
+++ b/src/actions/test-module/index.ts
@@ -15,12 +15,6 @@ export const main = async () => {
   const target = env.all.TFACTION_TARGET;
   const wd = env.all.TFACTION_WORKING_DIR;
 
-  if (!wd && !target) {
-    throw new Error(
-      "Either TFACTION_WORKING_DIR or TFACTION_TARGET is required",
-    );
-  }
-
   // absolute path to working dir
   const workingDir = path.join(config.git_root_dir, wd || target);
 

--- a/src/check-terraform-skip/index.test.ts
+++ b/src/check-terraform-skip/index.test.ts
@@ -16,20 +16,6 @@ test("normal", () => {
   ).toBe(false);
 });
 
-test("target is required", () => {
-  expect(() => {
-    getSkipTerraform(
-      {
-        skipLabelPrefix: "skip:",
-        labels: [],
-        prAuthor: "octocat",
-      },
-      {},
-      [],
-    );
-  }).toThrow();
-});
-
 test("skip label", () => {
   expect(
     getSkipTerraform(

--- a/src/check-terraform-skip/index.ts
+++ b/src/check-terraform-skip/index.ts
@@ -27,10 +27,6 @@ export const getSkipTerraform = (
   // https://suzuki-shunsuke.github.io/tfaction/docs/feature/support-skipping-terraform-renovate-pr
   const renovateLogin = config.renovate_login ?? "renovate[bot]";
 
-  if (!inputs.target) {
-    throw new Error("TFACTION_TARGET is required");
-  }
-
   if (renovateLogin !== inputs.prAuthor) {
     // If pull request author isn't Renovate bot
     // If the pull request has the skip label of the target, terraform is skipped.


### PR DESCRIPTION
## Summary
- Remove the "TFACTION_TARGET is required" validation from `create-scaffold-pr`, `test-module`, and `check-terraform-skip` to allow empty target strings
- Remove corresponding test cases that asserted on the removed validation
- This enables placing root modules or modules at the repository root (where target would be `""`)

## Test plan
- [x] `npm t` — all 794 tests pass
- [x] `npm run lint` — clean
- [x] `npm run fmt` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)