### PR TITLE
fix: validate that commit file paths are relative from git root

### DIFF
--- a/src/commit/index.ts
+++ b/src/commit/index.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 import * as securefix from "@csm-actions/securefix-action";
@@ -19,6 +20,13 @@ type Inputs = {
 };
 
 export const create = async (inputs: Inputs): Promise<string> => {
+  for (const file of inputs.files) {
+    if (path.isAbsolute(file)) {
+      throw new Error(
+        `commit file path must be relative from git root, but got absolute path: ${file}`,
+      );
+    }
+  }
   if (inputs.serverRepository) {
     if (!inputs.appId || !inputs.appPrivateKey) {
       throw new Error(


### PR DESCRIPTION
## Summary
- Add runtime validation in `commit.create()` to reject absolute file paths, preventing bugs where paths accidentally include the git root prefix (e.g., `/git/root/aws/test/main.tf` instead of `aws/test/main.tf`)
- The `Inputs.files` type already had a JSDoc comment requiring relative paths, but there was no runtime enforcement
- This single check covers all ~10 callers that construct commit file paths

## Test plan
- [x] `npm t` — all 794 tests pass
- [x] `npm run lint` — no errors
- [x] `npm run fmt` — no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)