### PR TITLE
refactor: replace manual core.startGroup/endGroup with ExecOptions group

### DIFF
--- a/src/actions/apply/terraform.ts
+++ b/src/actions/apply/terraform.ts
@@ -82,8 +82,6 @@ export const main = async (
   const applyOutput = path.join(tempDir, "apply_output.txt");
   const outputStream = fs.createWriteStream(applyOutput);
 
-  core.startGroup(`${tfCommand} apply`);
-
   // Run terraform apply with tfcmt
   let exitCode = 0;
   try {
@@ -106,6 +104,7 @@ export const main = async (
           cwd: workingDir,
           ignoreReturnCode: true,
           secretEnvs: secrets,
+          group: `${tfCommand} apply`,
           env: {
             GITHUB_TOKEN: githubTokenForGitHubProvider || githubToken,
             TFCMT_GITHUB_TOKEN: githubToken,
@@ -129,8 +128,6 @@ export const main = async (
   } finally {
     outputStream.end();
   }
-
-  core.endGroup();
 
   // If this is a drift issue, post the result to the drift issue
   if (driftIssueNumber) {

--- a/src/actions/apply/tfmigrate.ts
+++ b/src/actions/apply/tfmigrate.ts
@@ -55,7 +55,6 @@ export const main = async (
     cwd: workingDir,
   });
 
-  core.startGroup("tfmigrate apply");
   // Run tfmigrate apply with github-comment
   let exitCode = 0;
   try {
@@ -64,6 +63,7 @@ export const main = async (
         cwd: workingDir,
         ignoreReturnCode: true,
         secretEnvs: secrets,
+        group: "tfmigrate apply",
         env: {
           ...(env.all.TFMIGRATE_EXEC_PATH
             ? { TFMIGRATE_EXEC_PATH: env.all.TFMIGRATE_EXEC_PATH }
@@ -96,8 +96,6 @@ export const main = async (
   } finally {
     outputStream.end();
   }
-
-  core.endGroup();
 
   // If this is a drift issue, post the result to the drift issue
   if (driftIssueNumber) {

--- a/src/aqua/index.ts
+++ b/src/aqua/index.ts
@@ -93,11 +93,10 @@ export const NewExecutor = async (
 ): Promise<Executor> => {
   const installDir = await install();
   const executor = new Executor(installDir, options.githubToken);
-  core.startGroup("aqua i -l -a");
   await executor.exec("aqua", ["i", "-l", "-a"], {
     cwd: options.cwd,
+    group: "aqua i -l -a",
   });
-  core.endGroup();
   return executor;
 };
 
@@ -165,10 +164,19 @@ export class Executor {
     options?: ExecOptions,
   ): Promise<exec.ExecOutput> {
     const bArgs = this.buildArgs(command, args, options);
-    return await exec.getExecOutput(bArgs.command, bArgs.args, {
-      ...options,
-      env: this.env(options),
-    });
+    try {
+      if (options?.group) {
+        core.startGroup(options.group);
+      }
+      return await exec.getExecOutput(bArgs.command, bArgs.args, {
+        ...options,
+        env: this.env(options),
+      });
+    } finally {
+      if (options?.group) {
+        core.endGroup();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `group` support to `getExecOutput()` with the same try/finally pattern as `exec()`, fixing a latent bug where `plan/run.ts` already passed `group` to `getExecOutput` with no effect
- Replace all manual `core.startGroup`/`core.endGroup` calls with the `group` option on `exec`/`getExecOutput` in `NewExecutor`, `apply/terraform.ts`, `apply/tfmigrate.ts`, and `plan/run.ts`
- The try/finally in the executor ensures `endGroup` is always called, even if the command throws

## Test plan
- [x] `npm t` — all 794 tests pass
- [x] `npm run lint` — no errors
- [x] `npm run fmt` — no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)