### PR TITLE
fix: add missing await to action.main() in src/run.ts

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -60,5 +60,5 @@ export const main = async (inputs: Inputs) => {
   if (action === undefined) {
     throw new Error(`Unknown action: ${inputs.action}`);
   }
-  action.main();
+  await action.main();
 };


### PR DESCRIPTION
## Summary
- Add missing `await` to `action.main()` call in `src/run.ts:63`
- Without `await`, exceptions thrown by async action handlers result in unhandled promise rejections instead of being caught by the `try/catch` in `src/index.ts` and passed to `core.setFailed`

## Test plan
- [x] `npm t` — all 794 tests pass
- [x] `npm run lint` — clean
- [x] `npm run fmt` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)