### PR TITLE
fix: add ESLint rules to detect missing await on Promises

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -23,5 +23,20 @@ export default defineConfig([
     },
   },
   tseslint.configs.recommended,
+  {
+    files: ["**/*.{ts,mts,cts}"],
+    ignores: ["eslint.config.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/require-await": "error",
+    },
+  },
   globalIgnores(["docusaurus.config.js", "website/*", "build/*", "dist/*"]),
 ]);

--- a/src/actions/apply/terraform.test.ts
+++ b/src/actions/apply/terraform.test.ts
@@ -552,18 +552,16 @@ describe("main", () => {
     });
 
     // First exec call is tfcmt apply (succeeds), second is drift issue (fails)
-    mockExecutor.exec.mockImplementation(
-      async (cmd: string, args?: string[]) => {
-        if (
-          cmd === "tfcmt" &&
-          args &&
-          args.some((a: string) => a.includes("tfcmt-drift.yaml"))
-        ) {
-          throw new Error("drift posting error");
-        }
-        return 0;
-      },
-    );
+    mockExecutor.exec.mockImplementation((cmd: string, args?: string[]) => {
+      if (
+        cmd === "tfcmt" &&
+        args &&
+        args.some((a: string) => a.includes("tfcmt-drift.yaml"))
+      ) {
+        throw new Error("drift posting error");
+      }
+      return Promise.resolve(0);
+    });
 
     // Should not throw
     await main();
@@ -634,14 +632,12 @@ describe("main", () => {
     const { mockExecutor } = await setupMainMocks();
 
     // Make tfcmt apply return non-zero
-    mockExecutor.exec.mockImplementation(
-      async (_cmd: string, args?: string[]) => {
-        if (args && args.includes("apply") && args.includes("-auto-approve")) {
-          return 1;
-        }
-        return 0;
-      },
-    );
+    mockExecutor.exec.mockImplementation((_cmd: string, args?: string[]) => {
+      if (args && args.includes("apply") && args.includes("-auto-approve")) {
+        return Promise.resolve(1);
+      }
+      return Promise.resolve(0);
+    });
 
     await expect(main()).rejects.toThrow("terraform apply failed");
 

--- a/src/actions/apply/tfmigrate.test.ts
+++ b/src/actions/apply/tfmigrate.test.ts
@@ -269,11 +269,11 @@ describe("main", () => {
     });
 
     // First exec call is tfmigrate apply (succeeds), second is drift issue (fails)
-    mockExecutor.exec.mockImplementation(async (cmd: string) => {
+    mockExecutor.exec.mockImplementation((cmd: string) => {
       if (cmd === "bash") {
         throw new Error("drift posting error");
       }
-      return 0;
+      return Promise.resolve(0);
     });
 
     // Should not throw

--- a/src/actions/create-drift-issues/run.test.ts
+++ b/src/actions/create-drift-issues/run.test.ts
@@ -61,7 +61,7 @@ describe("listIssues", () => {
     return {
       graphql: {
         paginate: {
-          iterator: vi.fn().mockImplementation(async function* () {
+          iterator: vi.fn().mockImplementation(function* () {
             for (const page of pages) {
               yield { search: { nodes: page } };
             }
@@ -248,7 +248,7 @@ describe("run", () => {
   const createMockGraphqlOctokit = (issues: Issue[]): GraphQLPaginator => ({
     graphql: {
       paginate: {
-        iterator: vi.fn().mockImplementation(async function* () {
+        iterator: vi.fn().mockImplementation(function* () {
           yield {
             search: {
               nodes: issues.map((i) => ({

--- a/src/actions/create-scaffold-module-pr/run.ts
+++ b/src/actions/create-scaffold-module-pr/run.ts
@@ -47,7 +47,7 @@ gh pr create -R "${repository}" ${draftOpt}\\
 `;
 
   core.summary.addRaw(summary);
-  core.summary.write();
+  void core.summary.write();
 };
 
 export interface RunInput {

--- a/src/actions/create-scaffold-pr/run.ts
+++ b/src/actions/create-scaffold-pr/run.ts
@@ -51,7 +51,7 @@ gh pr create -R "${repository}" ${draftOpt}\\
 `;
 
   core.summary.addRaw(summary);
-  core.summary.write();
+  void core.summary.write();
 };
 
 export interface RunInput {

--- a/src/actions/get-or-create-drift-issue/run.test.ts
+++ b/src/actions/get-or-create-drift-issue/run.test.ts
@@ -20,7 +20,7 @@ const createMockGraphqlOctokit = (
   return {
     graphql: {
       paginate: {
-        iterator: vi.fn().mockImplementation(async function* () {
+        iterator: vi.fn().mockImplementation(function* () {
           for (const page of pages) {
             yield { search: { nodes: page } };
           }

--- a/src/actions/test-module/run.test.ts
+++ b/src/actions/test-module/run.test.ts
@@ -259,7 +259,7 @@ describe("run", () => {
     const { commitMod } = await getMocks();
     // Simulate fmt producing output via the listeners.stdout callback
     mockExecutor.exec.mockImplementation(
-      async (
+      (
         cmd: string,
         args: string[],
         options?: { listeners?: { stdout?: (data: Buffer) => void } },
@@ -267,7 +267,7 @@ describe("run", () => {
         if (args[0] === "fmt") {
           options?.listeners?.stdout?.(Buffer.from("main.tf\nvariables.tf\n"));
         }
-        return 0;
+        return Promise.resolve(0);
       },
     );
 
@@ -299,7 +299,7 @@ describe("run", () => {
   it("commit message includes terraformCommand", async () => {
     const { commitMod } = await getMocks();
     mockExecutor.exec.mockImplementation(
-      async (
+      (
         cmd: string,
         args: string[],
         options?: { listeners?: { stdout?: (data: Buffer) => void } },
@@ -307,7 +307,7 @@ describe("run", () => {
         if (args[0] === "fmt") {
           options?.listeners?.stdout?.(Buffer.from("main.tf\n"));
         }
-        return 0;
+        return Promise.resolve(0);
       },
     );
 
@@ -329,7 +329,7 @@ describe("run", () => {
 
     const callOrder: string[] = [];
     mockExecutor.exec.mockImplementation(
-      async (
+      (
         cmd: string,
         args: string[],
         options?: { listeners?: { stdout?: (data: Buffer) => void } },
@@ -340,21 +340,24 @@ describe("run", () => {
           callOrder.push("fmt");
           options?.listeners?.stdout?.(Buffer.from("main.tf\n"));
         }
-        return 0;
+        return Promise.resolve(0);
       },
     );
-    vi.mocked(trivyMod.run).mockImplementation(async () => {
+    vi.mocked(trivyMod.run).mockImplementation(() => {
       callOrder.push("trivy");
+      return Promise.resolve();
     });
-    vi.mocked(tflintMod.run).mockImplementation(async () => {
+    vi.mocked(tflintMod.run).mockImplementation(() => {
       callOrder.push("tflint");
+      return Promise.resolve();
     });
-    vi.mocked(terraformDocsMod.run).mockImplementation(async () => {
+    vi.mocked(terraformDocsMod.run).mockImplementation(() => {
       callOrder.push("terraform-docs");
+      return Promise.resolve();
     });
-    vi.mocked(commitMod.create).mockImplementation(async () => {
+    vi.mocked(commitMod.create).mockImplementation(() => {
       callOrder.push("commit");
-      return "";
+      return Promise.resolve("");
     });
 
     const mockFs = createMockFs();
@@ -375,7 +378,7 @@ describe("run", () => {
   it("workingDirFromGitRoot is computed correctly", async () => {
     const { commitMod } = await getMocks();
     mockExecutor.exec.mockImplementation(
-      async (
+      (
         cmd: string,
         args: string[],
         options?: { listeners?: { stdout?: (data: Buffer) => void } },
@@ -383,7 +386,7 @@ describe("run", () => {
         if (args[0] === "fmt") {
           options?.listeners?.stdout?.(Buffer.from("outputs.tf\n"));
         }
-        return 0;
+        return Promise.resolve(0);
       },
     );
 

--- a/src/actions/test/run.test.ts
+++ b/src/actions/test/run.test.ts
@@ -412,29 +412,33 @@ describe("run", () => {
     } = await getMocks();
 
     const callOrder: string[] = [];
-    vi.mocked(conftestMod.run).mockImplementation(async () => {
+    vi.mocked(conftestMod.run).mockImplementation(() => {
       callOrder.push("conftest");
+      return Promise.resolve();
     });
-    mockExecutor.exec.mockImplementation(async () => {
+    mockExecutor.exec.mockImplementation(() => {
       callOrder.push("validate");
-      return 0;
+      return Promise.resolve(0);
     });
-    vi.mocked(trivyMod.run).mockImplementation(async () => {
+    vi.mocked(trivyMod.run).mockImplementation(() => {
       callOrder.push("trivy");
+      return Promise.resolve();
     });
-    vi.mocked(tflintMod.run).mockImplementation(async () => {
+    vi.mocked(tflintMod.run).mockImplementation(() => {
       callOrder.push("tflint");
+      return Promise.resolve();
     });
-    vi.mocked(fmtMod.fmt).mockImplementation(async () => {
+    vi.mocked(fmtMod.fmt).mockImplementation(() => {
       callOrder.push("fmt");
-      return { exitCode: 0, stdout: "main.tf\n", stderr: "" };
+      return Promise.resolve({ exitCode: 0, stdout: "main.tf\n", stderr: "" });
     });
-    vi.mocked(commitMod.create).mockImplementation(async () => {
+    vi.mocked(commitMod.create).mockImplementation(() => {
       callOrder.push("commit");
-      return "";
+      return Promise.resolve("");
     });
-    vi.mocked(terraformDocsMod.run).mockImplementation(async () => {
+    vi.mocked(terraformDocsMod.run).mockImplementation(() => {
       callOrder.push("terraform-docs");
+      return Promise.resolve();
     });
 
     const input = createRunInput(mockExecutor, undefined, {

--- a/src/check-terraform-skip/index.ts
+++ b/src/check-terraform-skip/index.ts
@@ -13,7 +13,7 @@ type SkipTerraformConfig = {
   renovate_terraform_labels?: string[];
 };
 
-export const main = async (config: SkipTerraformConfig, inputs: Inputs) => {
+export const main = (config: SkipTerraformConfig, inputs: Inputs) => {
   const isSkip = getSkipTerraform(inputs, config, inputs.labels);
   core.exportVariable("TFACTION_SKIP_TERRAFORM", isSkip);
   core.setOutput("skip_terraform", isSkip);

--- a/src/ci-info/index.ts
+++ b/src/ci-info/index.ts
@@ -297,7 +297,7 @@ export const run = async (input: RunInput): Promise<Result> => {
 
 export const main = async (): Promise<Result> => {
   const octokit = github.getOctokit(input.getRequiredGitHubToken());
-  return run({
+  return await run({
     prNumber: github.context.payload.pull_request?.number,
     octokit,
   });

--- a/src/install/run.test.ts
+++ b/src/install/run.test.ts
@@ -42,9 +42,9 @@ describe("run", () => {
 
   it("calls exportVariable after NewExecutor resolves", async () => {
     const callOrder: string[] = [];
-    mockedNewExecutor.mockImplementation(async () => {
+    mockedNewExecutor.mockImplementation(() => {
       callOrder.push("NewExecutor");
-      return {} as aqua.Executor;
+      return Promise.resolve({} as aqua.Executor);
     });
     const exportVariable = vi.fn().mockImplementation(() => {
       callOrder.push("exportVariable");

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -23,45 +23,45 @@ beforeEach(() => {
 
 describe("getModifiedFiles", () => {
   it("returns list of modified/untracked files from git output", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from("file1.tf\nfile2.tf\n"));
-      return 0;
+      return Promise.resolve(0);
     });
     const result = await getModifiedFiles(".");
     expect(result).toEqual(["file1.tf", "file2.tf"]);
   });
 
   it("filters out empty lines", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from("file1.tf\n\n\nfile2.tf\n"));
-      return 0;
+      return Promise.resolve(0);
     });
     const result = await getModifiedFiles(".");
     expect(result).toEqual(["file1.tf", "file2.tf"]);
   });
 
   it("trims whitespace from file names", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from("  file1.tf  \n  file2.tf  \n"));
-      return 0;
+      return Promise.resolve(0);
     });
     const result = await getModifiedFiles(".");
     expect(result).toEqual(["file1.tf", "file2.tf"]);
   });
 
   it("returns empty array when no files modified", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from(""));
-      return 0;
+      return Promise.resolve(0);
     });
     const result = await getModifiedFiles(".");
     expect(result).toEqual([]);
   });
 
   it("passes dir and cwd to exec correctly", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from(""));
-      return 0;
+      return Promise.resolve(0);
     });
     await getModifiedFiles("src", "/workspace");
     expect(exec.exec).toHaveBeenCalledWith(
@@ -116,18 +116,18 @@ describe("isFileTracked", () => {
 
 describe("getCurrentBranch", () => {
   it("returns trimmed branch name", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from("feature/my-branch\n"));
-      return 0;
+      return Promise.resolve(0);
     });
     const result = await getCurrentBranch();
     expect(result).toBe("feature/my-branch");
   });
 
   it("passes cwd to exec", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from("main\n"));
-      return 0;
+      return Promise.resolve(0);
     });
     await getCurrentBranch("/workspace");
     expect(exec.exec).toHaveBeenCalledWith(
@@ -140,18 +140,18 @@ describe("getCurrentBranch", () => {
 
 describe("hasFileChangedPorcelain", () => {
   it("returns true when output is non-empty (file changed)", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from(" M main.tf\n"));
-      return 0;
+      return Promise.resolve(0);
     });
     const result = await hasFileChangedPorcelain("main.tf");
     expect(result).toBe(true);
   });
 
   it("returns false when output is empty (file unchanged)", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from(""));
-      return 0;
+      return Promise.resolve(0);
     });
     const result = await hasFileChangedPorcelain("main.tf");
     expect(result).toBe(false);
@@ -213,26 +213,26 @@ describe("getRootDir", () => {
 describe("checkGitDiff", () => {
   it("returns only changed files from the input list", async () => {
     vi.mocked(exec.exec)
-      .mockImplementationOnce(async (_cmd, _args, options) => {
+      .mockImplementationOnce((_cmd, _args, options) => {
         options?.listeners?.stdout?.(Buffer.from(" M file1.tf\n"));
-        return 0;
+        return Promise.resolve(0);
       })
-      .mockImplementationOnce(async (_cmd, _args, options) => {
+      .mockImplementationOnce((_cmd, _args, options) => {
         options?.listeners?.stdout?.(Buffer.from(""));
-        return 0;
+        return Promise.resolve(0);
       })
-      .mockImplementationOnce(async (_cmd, _args, options) => {
+      .mockImplementationOnce((_cmd, _args, options) => {
         options?.listeners?.stdout?.(Buffer.from("?? file3.tf\n"));
-        return 0;
+        return Promise.resolve(0);
       });
     const result = await checkGitDiff(["file1.tf", "file2.tf", "file3.tf"]);
     expect(result).toEqual({ changedFiles: ["file1.tf", "file3.tf"] });
   });
 
   it("returns empty array when no files changed", async () => {
-    vi.mocked(exec.exec).mockImplementation(async (_cmd, _args, options) => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
       options?.listeners?.stdout?.(Buffer.from(""));
-      return 0;
+      return Promise.resolve(0);
     });
     const result = await checkGitDiff(["file1.tf", "file2.tf"]);
     expect(result).toEqual({ changedFiles: [] });

--- a/src/test-action-terragrunt/index.ts
+++ b/src/test-action-terragrunt/index.ts
@@ -8,7 +8,7 @@ type TestData = {
   actual: string;
 };
 
-export const main = async () => {
+export const main = () => {
   // Compare outputs
   const testdata: TestData[] = [
     {

--- a/src/test-action/index.ts
+++ b/src/test-action/index.ts
@@ -1,7 +1,7 @@
 import { diffString } from "json-diff";
 import * as env from "../lib/env";
 
-export const main = async () => {
+export const main = () => {
   // Compare outputs
   const testdata = [
     {


### PR DESCRIPTION
## Summary
- Add type-checked ESLint config with `no-floating-promises`, `no-misused-promises`, and `require-await` rules to prevent the class of bugs fixed in PR #3615 (missing `await` on Promise)
- Fix all existing violations: remove unnecessary `async` from synchronous functions, add `await` where missing, use `void` for intentionally unhandled promises, and update mock implementations in tests

## Test plan
- [x] `npm run lint` passes with no violations
- [x] `npm t` — all 794 tests pass
- [x] `npm run fmt` — formatting is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)