### PR TITLE
fix: introduce GitRootPath branded type and fix getModifiedFiles bug

### DIFF
--- a/src/actions/create-drift-issues/run.ts
+++ b/src/actions/create-drift-issues/run.ts
@@ -5,6 +5,7 @@ import * as lib from "../../lib";
 import * as types from "../../lib/types";
 import * as drift from "../../lib/drift";
 import * as git from "../../lib/git";
+import type { AbsolutePath, GitRelativePath } from "../../lib/paths";
 import * as path from "path";
 
 export type Issue = drift.Issue;
@@ -135,9 +136,9 @@ export type CreateIssueFn = (
 ) => Promise<drift.Issue>;
 
 export type ListWorkingDirFilesFn = (
-  gitRootDir: string,
+  gitRootDir: AbsolutePath,
   fileName: string,
-) => Promise<string[]>;
+) => Promise<GitRelativePath[]>;
 
 export type GetTargetGroupFn = (
   config: {

--- a/src/actions/create-scaffold-module-pr/run.test.ts
+++ b/src/actions/create-scaffold-module-pr/run.test.ts
@@ -30,6 +30,7 @@ import * as lib from "../../lib";
 import * as aqua from "../../aqua";
 import * as git from "../../lib/git";
 import * as commit from "../../commit";
+import type { GitRelativePath } from "../../lib/paths";
 
 import {
   generateBranchName,
@@ -134,7 +135,9 @@ describe("run", () => {
     vi.mocked(aqua.NewExecutor).mockResolvedValue(
       {} as unknown as Awaited<ReturnType<typeof aqua.NewExecutor>>,
     );
-    vi.mocked(git.getModifiedFiles).mockResolvedValue(["file1.tf"]);
+    vi.mocked(git.getModifiedFiles).mockResolvedValue([
+      "file1.tf",
+    ] as GitRelativePath[]);
     vi.mocked(commit.create).mockResolvedValue("");
   });
 

--- a/src/actions/create-scaffold-module-pr/run.ts
+++ b/src/actions/create-scaffold-module-pr/run.ts
@@ -54,6 +54,7 @@ export interface RunInput {
   githubToken: string;
   securefixAppId: string;
   securefixAppPrivateKey: string;
+  /** A relative path from the git root directory to the module */
   modulePath: string;
   actor: string;
   repository: string;

--- a/src/actions/create-scaffold-pr/run.test.ts
+++ b/src/actions/create-scaffold-pr/run.test.ts
@@ -35,6 +35,7 @@ import * as aqua from "../../aqua";
 import * as git from "../../lib/git";
 import * as commit from "../../commit";
 import * as getTargetConfig from "../get-target-config";
+import type { GitRelativePath } from "../../lib/paths";
 
 import {
   generateBranchName,
@@ -148,7 +149,9 @@ describe("run", () => {
     vi.mocked(aqua.NewExecutor).mockResolvedValue(
       {} as unknown as Awaited<ReturnType<typeof aqua.NewExecutor>>,
     );
-    vi.mocked(git.getModifiedFiles).mockResolvedValue(["file1.tf"]);
+    vi.mocked(git.getModifiedFiles).mockResolvedValue([
+      "file1.tf",
+    ] as GitRelativePath[]);
     vi.mocked(commit.create).mockResolvedValue("");
   });
 

--- a/src/actions/scaffold-tfmigrate/run.test.ts
+++ b/src/actions/scaffold-tfmigrate/run.test.ts
@@ -57,6 +57,7 @@ import * as aqua from "../../aqua";
 import * as git from "../../lib/git";
 import * as commit from "../../commit";
 import * as getTargetConfig from "../get-target-config";
+import type { GitRelativePath } from "../../lib/paths";
 
 import {
   generateBranchName,
@@ -409,7 +410,7 @@ describe("run", () => {
     vi.mocked(git.getModifiedFiles).mockResolvedValue([
       ".tfmigrate.hcl",
       "tfmigrate/20240101120000_main.hcl",
-    ]);
+    ] as GitRelativePath[]);
     vi.mocked(commit.create).mockResolvedValue("");
 
     // Default fs mocks for run: directories don't exist, template reads succeed

--- a/src/actions/test-module/index.ts
+++ b/src/actions/test-module/index.ts
@@ -1,10 +1,9 @@
-import * as path from "path";
-
 import * as lib from "../../lib";
 import * as env from "../../lib/env";
 import * as input from "../../lib/input";
 import * as aqua from "../../aqua";
 import { run } from "./run";
+import { joinAbsolute } from "../../lib/paths";
 
 export const main = async () => {
   const githubToken = input.getRequiredGitHubToken();
@@ -15,8 +14,7 @@ export const main = async () => {
   const target = env.all.TFACTION_TARGET;
   const wd = env.all.TFACTION_WORKING_DIR;
 
-  // absolute path to working dir
-  const workingDir = path.join(config.git_root_dir, wd || target);
+  const workingDir = joinAbsolute(config.git_root_dir, wd || target);
 
   const executor = await aqua.NewExecutor({
     githubToken,

--- a/src/actions/test-module/run.ts
+++ b/src/actions/test-module/run.ts
@@ -8,11 +8,12 @@ import { run as runTrivy } from "../../trivy";
 import { run as runTflint } from "../../tflint";
 import { run as runTerraformDocs } from "../../terraform-docs";
 import { create as createCommit } from "../../commit";
+import type { AbsolutePath } from "../../lib/paths";
 
 export type RunInput = {
   config: types.Config;
   target: string;
-  workingDir: string;
+  workingDir: AbsolutePath;
   githubToken: string;
   securefixAppId: string;
   securefixAppPrivateKey: string;

--- a/src/actions/test/run.ts
+++ b/src/actions/test/run.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 
 import * as types from "../../lib/types";
 import * as aqua from "../../aqua";
+import { joinAbsolute } from "../../lib/paths";
 import { TargetConfig } from "../get-target-config";
 import { run as runConftest } from "../../conftest";
 import { run as runTrivy } from "../../trivy";
@@ -22,8 +23,7 @@ export type RunInput = {
 export const run = async (input: RunInput): Promise<void> => {
   const { config, targetConfig, githubToken, executor } = input;
 
-  /** absolute path to working directory */
-  const workingDir = path.join(
+  const workingDir = joinAbsolute(
     config.git_root_dir,
     targetConfig.working_directory,
   );

--- a/src/commit/index.ts
+++ b/src/commit/index.ts
@@ -1,17 +1,15 @@
-import * as path from "path";
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 import * as securefix from "@csm-actions/securefix-action";
 import * as env from "../lib/env";
 import { run } from "./run";
+import type { GitRelativePath } from "../lib/paths";
 
 type Inputs = {
   commitMessage: string;
   githubToken: string;
-  /** A relative path from github.workspace to Git Root Directory */
   rootDir?: string;
-  /** Relative paths from Git Root Directory */
-  files: Set<string>;
+  files: Set<GitRelativePath>;
   serverRepository: string;
   appId: string;
   appPrivateKey: string;
@@ -20,13 +18,6 @@ type Inputs = {
 };
 
 export const create = async (inputs: Inputs): Promise<string> => {
-  for (const file of inputs.files) {
-    if (path.isAbsolute(file)) {
-      throw new Error(
-        `commit file path must be relative from git root, but got absolute path: ${file}`,
-      );
-    }
-  }
   if (inputs.serverRepository) {
     if (!inputs.appId || !inputs.appPrivateKey) {
       throw new Error(

--- a/src/conftest/index.test.ts
+++ b/src/conftest/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getConftestPaths, buildConftestArgs, buildPolicies } from "./index";
 import type * as types from "../lib/types";
+import { absolutePath } from "../lib/paths";
 
 vi.mock("glob", () => ({
   globSync: vi.fn(),
@@ -413,7 +414,7 @@ describe("buildPolicies", () => {
     trivy: { enabled: true },
     terraform_command: "terraform",
     working_directory_file: "tfaction.yaml",
-    git_root_dir: "/repo",
+    git_root_dir: absolutePath("/repo"),
     config_path: "/repo/tfaction-root.yaml",
     config_dir: "/repo",
     workspace: "/repo",

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,54 @@
+import * as path from "path";
+
+// --- Branded types ---
+export type AbsolutePath = string & { readonly __brand: "AbsolutePath" };
+export type GitRelativePath = string & { readonly __brand: "GitRelativePath" };
+export type GitRootPath = AbsolutePath & { readonly __gitRoot: true };
+
+// --- Constructors (validation at boundaries) ---
+export const absolutePath = (p: string): AbsolutePath => {
+  if (!path.isAbsolute(p)) {
+    throw new Error(`Expected absolute path, got: ${p}`);
+  }
+  return p as AbsolutePath;
+};
+
+export const gitRelativePath = (p: string): GitRelativePath => {
+  if (path.isAbsolute(p)) {
+    throw new Error(`Expected git-relative path, got absolute: ${p}`);
+  }
+  return p as GitRelativePath;
+};
+
+// --- Conversion functions ---
+export const joinAbsolute = (
+  base: AbsolutePath,
+  ...components: string[]
+): AbsolutePath => {
+  return path.join(base, ...components) as AbsolutePath;
+};
+
+export const toGitRelative = (
+  gitRoot: AbsolutePath,
+  target: AbsolutePath,
+): GitRelativePath => {
+  const rel = path.relative(gitRoot, target);
+  if (path.isAbsolute(rel) || rel.startsWith("..")) {
+    throw new Error(`Path ${target} is not inside git root ${gitRoot}`);
+  }
+  return rel as GitRelativePath;
+};
+
+export const resolveFromGitRoot = (
+  gitRoot: AbsolutePath,
+  rel: GitRelativePath,
+): AbsolutePath => {
+  return path.join(gitRoot, rel) as AbsolutePath;
+};
+
+export const joinGitRelative = (
+  base: GitRelativePath,
+  ...components: string[]
+): GitRelativePath => {
+  return path.join(base, ...components) as GitRelativePath;
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { GitRootPath } from "./paths";
 
 const GitHubEnvironment = z.union([
   z.string(),
@@ -315,8 +316,7 @@ type ParsedConfig = z.output<typeof RawConfig>;
 
 // Config with default values applied and dynamic fields added
 export interface Config extends ParsedConfig {
-  /** Absolute path to git root directory */
-  git_root_dir: string;
+  git_root_dir: GitRootPath;
   config_path: string;
   config_dir: string;
   workspace: string;

--- a/src/trivy/index.test.ts
+++ b/src/trivy/index.test.ts
@@ -8,6 +8,7 @@ import {
   type Logger,
 } from "./index";
 import type { Config } from "../lib/types";
+import { absolutePath } from "../lib/paths";
 
 describe("getSeverity", () => {
   it("returns ERROR for HIGH severity", () => {
@@ -180,7 +181,7 @@ describe("run", () => {
     trivy: { enabled: true },
     terraform_command: "terraform",
     working_directory_file: "tfaction.yaml",
-    git_root_dir: "/repo",
+    git_root_dir: absolutePath("/repo"),
     config_path: "/repo/tfaction-root.yaml",
     config_dir: "/repo",
     workspace: "/repo",


### PR DESCRIPTION
## Summary

- Introduce `GitRootPath` branded type (subtype of `AbsolutePath`) that can only be obtained from `getRootDir()`, preventing arbitrary absolute paths from being passed where a git root is required
- Fix bug in `scaffold-module` and `scaffold-working-dir` where `replaceInFiles` called `getModifiedFiles` with a subdirectory as `cwd`, causing `git ls-files` to return paths relative to that subdirectory instead of the git root
- Update git functions (`getModifiedFiles`, `getCurrentBranch`, `hasFileChangedPorcelain`, `listWorkingDirFiles`, `checkGitDiff`) to require `GitRootPath` instead of `AbsolutePath`
- Change `Config.git_root_dir` type from `AbsolutePath` to `GitRootPath`

## Test plan

- [x] `npm t` — all 794 tests pass
- [x] `npm run lint` — no type errors
- [x] `npm run fmt` — code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)