### PR TITLE
fix(list-targets): exclude template_dir from target detection

### DIFF
--- a/src/actions/list-targets/list-targets-with-changed-files/index.test.ts
+++ b/src/actions/list-targets/list-targets-with-changed-files/index.test.ts
@@ -1151,6 +1151,92 @@ test("multiple modules changed", async () => {
   });
 });
 
+test("template_dir config files are excluded", async () => {
+  expect(
+    await run({
+      config: {
+        target_groups: [
+          {
+            working_directory: "aws/",
+            template_dir: "templates/aws",
+          },
+        ],
+      },
+      isApply: false,
+      labels: [],
+      changedFiles: ["aws/dev/main.tf", "templates/aws/dev/main.tf"],
+      configFiles: ["aws/dev/tfaction.yaml", "templates/aws/dev/tfaction.yaml"],
+      prBody: "",
+      payload: {
+        pull_request: {
+          body: "",
+        },
+      },
+      moduleCallers: {},
+      moduleFiles: [],
+      githubToken: "xxx",
+      maxChangedWorkingDirectories: 0,
+      maxChangedModules: 0,
+      executor: await aqua.NewExecutor({}),
+    }),
+  ).toStrictEqual({
+    modules: [],
+    targetConfigs: [
+      {
+        environment: undefined,
+        job_type: "terraform",
+        runs_on: "ubuntu-latest",
+        secrets: undefined,
+        target: "aws/dev",
+        working_directory: "aws/dev",
+      },
+    ],
+  });
+});
+
+test("template_dir with trailing slash", async () => {
+  expect(
+    await run({
+      config: {
+        target_groups: [
+          {
+            working_directory: "aws/",
+            template_dir: "templates/aws/",
+          },
+        ],
+      },
+      isApply: false,
+      labels: [],
+      changedFiles: ["aws/dev/main.tf"],
+      configFiles: ["aws/dev/tfaction.yaml", "templates/aws/dev/tfaction.yaml"],
+      prBody: "",
+      payload: {
+        pull_request: {
+          body: "",
+        },
+      },
+      moduleCallers: {},
+      moduleFiles: [],
+      githubToken: "xxx",
+      maxChangedWorkingDirectories: 0,
+      maxChangedModules: 0,
+      executor: await aqua.NewExecutor({}),
+    }),
+  ).toStrictEqual({
+    modules: [],
+    targetConfigs: [
+      {
+        environment: undefined,
+        job_type: "terraform",
+        runs_on: "ubuntu-latest",
+        secrets: undefined,
+        target: "aws/dev",
+        working_directory: "aws/dev",
+      },
+    ],
+  });
+});
+
 test("runs_on as array", async () => {
   expect(
     await run({


### PR DESCRIPTION
## Summary
- `list-targets` uses `git ls-files` to find all `tfaction.yaml` files and treats their parent directories as working directories. If a `template_dir` (configured in `target_groups[].template_dir`) contains a `tfaction.yaml`, that template directory was incorrectly treated as a target.
- Filter `configFiles` to exclude any config file whose directory falls under a `template_dir` path before building the working directory list.
- Added tests for `template_dir` exclusion, including trailing slash handling.

## Test plan
- [x] `npm t` — all 796 tests pass, including 2 new tests
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)