### PR TITLE
feat: extract output-github-secrets action from setup

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,11 @@ inputs:
     description: A JSON representing a map whose keys are secret names and values are secret values. Used by setup to compute the secrets output, and by terraform-init, plan, and apply to pass secrets as environment variables during command execution.
     required: false
 
+  # output-github-secrets
+  github_secrets:
+    description: GitHub Secrets as JSON. Used by output-github-secrets to map secrets to environment variable names.
+    required: false
+
   # setup
   ssh_key:
     description: SSH private key to checkout private modules
@@ -106,11 +111,11 @@ outputs:
   terraform_command:
     description: Terraform command. By default, the value is "terraform". If you use OpenTofu, the value is "tofu"
 
-  # setup
+  # output-github-secrets
   secrets:
     description: >-
       A JSON representing a map whose keys are environment variable names
-      and values are secret values. Output by setup action.
+      and values are secret values. Output by output-github-secrets action.
 
   # get-global-config
   working_directory_file:

--- a/src/actions/output-github-secrets/index.ts
+++ b/src/actions/output-github-secrets/index.ts
@@ -1,0 +1,34 @@
+import * as core from "@actions/core";
+import * as lib from "../../lib";
+import * as env from "../../lib/env";
+import * as input from "../../lib/input";
+import { getTargetConfig } from "../get-target-config";
+import { run } from "./run";
+
+export const main = async () => {
+  const config = await lib.getConfig();
+  const targetConfig = await getTargetConfig(
+    {
+      target: env.all.TFACTION_TARGET,
+      workingDir: env.all.TFACTION_WORKING_DIR,
+      isApply: env.isApply,
+      jobType: lib.getJobType(),
+    },
+    config,
+  );
+
+  const result = run({
+    githubSecrets: input.githubSecrets,
+    secretsConfig: targetConfig.secretsConfig,
+  });
+
+  for (const [envName, secretName] of Object.entries(
+    targetConfig.secretsConfig ?? {},
+  )) {
+    core.info(
+      `map the secret ${secretName} to the environment variable ${envName}`,
+    );
+  }
+
+  core.setOutput("secrets", JSON.stringify(result.secrets));
+};

--- a/src/actions/output-github-secrets/run.test.ts
+++ b/src/actions/output-github-secrets/run.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import { run } from "./run";
+
+test("maps secrets correctly via secretsConfig", () => {
+  const result = run({
+    githubSecrets: JSON.stringify({
+      MY_SECRET: "secret_value_1",
+      OTHER_SECRET: "secret_value_2",
+    }),
+    secretsConfig: {
+      ENV_VAR_1: "MY_SECRET",
+      ENV_VAR_2: "OTHER_SECRET",
+    },
+  });
+  expect(result.secrets).toEqual({
+    ENV_VAR_1: "secret_value_1",
+    ENV_VAR_2: "secret_value_2",
+  });
+});
+
+test("returns empty object when secretsConfig is undefined", () => {
+  const result = run({
+    githubSecrets: JSON.stringify({ MY_SECRET: "value" }),
+  });
+  expect(result.secrets).toEqual({});
+});
+
+test("throws when a required secret is not found in githubSecrets", () => {
+  expect(() =>
+    run({
+      githubSecrets: JSON.stringify({}),
+      secretsConfig: {
+        ENV_VAR: "MISSING_SECRET",
+      },
+    }),
+  ).toThrow("secret is not found: MISSING_SECRET");
+});
+
+test("handles empty secretsConfig", () => {
+  const result = run({
+    githubSecrets: JSON.stringify({ MY_SECRET: "value" }),
+    secretsConfig: {},
+  });
+  expect(result.secrets).toEqual({});
+});

--- a/src/actions/output-github-secrets/run.ts
+++ b/src/actions/output-github-secrets/run.ts
@@ -1,0 +1,26 @@
+type Inputs = {
+  githubSecrets: string;
+  secretsConfig?: Record<string, string>;
+};
+
+type Result = {
+  secrets: Record<string, string>;
+};
+
+export const run = (inputs: Inputs): Result => {
+  if (!inputs.secretsConfig) {
+    return { secrets: {} };
+  }
+
+  const githubSecrets: Record<string, string> = JSON.parse(
+    inputs.githubSecrets,
+  );
+  const secrets: Record<string, string> = {};
+  for (const [envName, secretName] of Object.entries(inputs.secretsConfig)) {
+    if (!(secretName in githubSecrets)) {
+      throw new Error(`secret is not found: ${secretName}`);
+    }
+    secrets[envName] = githubSecrets[secretName];
+  }
+  return { secrets };
+};

--- a/src/actions/setup/index.ts
+++ b/src/actions/setup/index.ts
@@ -166,29 +166,6 @@ export const main = async () => {
     }
   }
 
-  // Process secrets
-  if (input.secrets) {
-    const inputSecrets: Record<string, string> = JSON.parse(input.secrets);
-    core.info(
-      `The list of secret names passed to the action: ${Object.keys(inputSecrets).join(", ")}`,
-    );
-    if (targetConfig.secretsConfig) {
-      const secretsOutput: Record<string, string> = {};
-      for (const [envName, secretName] of Object.entries(
-        targetConfig.secretsConfig,
-      )) {
-        if (!(secretName in inputSecrets)) {
-          throw new Error(`secret is not found: ${secretName}`);
-        }
-        core.info(
-          `map the secret ${secretName} to the environment variable ${envName}`,
-        );
-        secretsOutput[envName] = inputSecrets[secretName];
-      }
-      core.setOutput("secrets", JSON.stringify(secretsOutput));
-    }
-  }
-
   const executor = await aqua.NewExecutor({
     githubToken: githubToken,
     cwd: workingDir,

--- a/src/lib/input.ts
+++ b/src/lib/input.ts
@@ -47,6 +47,9 @@ export const prNumber = core.getInput("pr_number");
 // setup
 export const sshKey = core.getInput("ssh_key");
 
+// output-github-secrets
+export const githubSecrets = core.getInput("github_secrets");
+
 // update-drift-issue
 export const getRequiredIssue = (): string => {
   return core.getInput("issue", { required: true });

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ import * as generateConfigOut from "./actions/generate-config-out";
 import * as getTargetConfig from "./actions/get-target-config";
 import * as pickOutDriftIssues from "./actions/pick-out-drift-issues";
 import * as listTargets from "./actions/list-targets";
+import * as outputGithubSecrets from "./actions/output-github-secrets";
 import * as createDriftIssues from "./actions/create-drift-issues";
 import * as getOrCreateDriftIssue from "./actions/get-or-create-drift-issue";
 import * as updateDriftIssue from "./actions/update-drift-issue";
@@ -38,6 +39,7 @@ export const main = async (inputs: Inputs) => {
     ["get-or-create-drift-issue", getOrCreateDriftIssue],
     ["get-target-config", getTargetConfig],
     ["list-targets", listTargets],
+    ["output-github-secrets", outputGithubSecrets],
     ["pick-out-drift-issues", pickOutDriftIssues],
     ["plan", plan],
     ["release-module", releaseModule],


### PR DESCRIPTION
## Summary
- Extract the GitHub secrets output processing from the `setup` action into a new dedicated `output-github-secrets` action
- Add `github_secrets` input to `action.yaml` for passing GitHub Secrets JSON
- Remove secrets processing block from `setup/index.ts`, keeping setup focused on its core responsibilities

## Test plan
- [x] Unit tests added for `output-github-secrets/run.ts` (4 test cases)
- [x] All 786 existing tests pass (`npm t`)
- [x] Lint passes (`npm run lint`)
- [x] Format passes (`npm run fmt`)
- [ ] Manual test on a workflow using `action: output-github-secrets` with `github_secrets: ${{ toJSON(secrets) }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)