### PR TITLE
feat: make post comment templates configurable via tfaction-root.yaml

### DIFF
--- a/src/actions/apply/terraform.ts
+++ b/src/actions/apply/terraform.ts
@@ -336,6 +336,7 @@ const downloadPlanFile = async (): Promise<string> => {
         plan_workflow_name: planWorkflowName,
         branch: branch,
       },
+      commentOverrides: cfg.comments,
     });
     throw new Error("No workflow run is found");
   }
@@ -360,6 +361,7 @@ const downloadPlanFile = async (): Promise<string> => {
         wf_sha: headSha,
         pr_sha: prHeadSha,
       },
+      commentOverrides: cfg.comments,
     });
     throw new Error(
       `workflow run's headSha (${headSha}) is different from the associated pull request's head sha (${prHeadSha})`,

--- a/src/actions/create-follow-up-pr/run.ts
+++ b/src/actions/create-follow-up-pr/run.ts
@@ -270,6 +270,7 @@ export interface SkipCreateCommentParams {
   groupLabel: string;
   target: string;
   mentions: string;
+  commentOverrides?: Array<{ id: string; body: string }>;
 }
 
 export const postSkipCreateComment = async (
@@ -319,6 +320,7 @@ export const postSkipCreateComment = async (
       mentions: mentions,
       opts: optsString,
     },
+    commentOverrides: params.commentOverrides,
   });
   core.info("Posted skip-create-follow-up-pr comment");
 };
@@ -462,6 +464,7 @@ export const run = async (input: RunInput): Promise<void> => {
         mentions: prParams.mentions,
         follow_up_pr_url: followUpPrUrl,
       },
+      commentOverrides: config.comments,
     });
     core.info("Posted comment to the original PR");
   }
@@ -480,6 +483,7 @@ export const run = async (input: RunInput): Promise<void> => {
       groupLabel,
       target,
       mentions: prParams.mentions,
+      commentOverrides: config.comments,
     });
   }
 };

--- a/src/actions/list-targets/list-targets-with-changed-files/index.ts
+++ b/src/actions/list-targets/list-targets-with-changed-files/index.ts
@@ -239,6 +239,7 @@ const validateChangeLimits = async (
   maxChangedWorkingDirectories: number,
   octokit: ReturnType<typeof github.getOctokit>,
   prNumber: number,
+  commentOverrides?: Array<{ id: string; body: string }>,
 ): Promise<void> => {
   if (
     maxChangedWorkingDirectories > 0 &&
@@ -251,6 +252,7 @@ const validateChangeLimits = async (
       vars: {
         max_changed_dirs: `${maxChangedWorkingDirectories}`,
       },
+      commentOverrides,
     });
     throw new Error(
       `Too many working directories are changed (${targetConfigs.length}). Max is ${maxChangedWorkingDirectories}.`,
@@ -366,6 +368,7 @@ export const run = async (input: Input): Promise<Result> => {
     input.maxChangedWorkingDirectories,
     input.octokit,
     input.prNumber,
+    input.commentOverrides,
   );
 
   return result;
@@ -399,6 +402,7 @@ type Input = {
   prNumber: number;
   /** Relative paths from git_root_dir of changed files, for test_workflow matching */
   relativeChangedFiles?: string[];
+  commentOverrides?: Array<{ id: string; body: string }>;
 };
 
 /**
@@ -515,6 +519,7 @@ export const main = async (executor: aqua.Executor, pr: ciInfo.Result) => {
     prNumber: github.context.payload.pull_request?.number ?? 0,
     moduleCallers,
     relativeChangedFiles: pr.pr?.files ?? [],
+    commentOverrides: cfg.comments,
   });
 
   core.info(`result: ${JSON.stringify(result)}`);

--- a/src/actions/plan/run.ts
+++ b/src/actions/plan/run.ts
@@ -29,6 +29,7 @@ type Inputs = {
   prNumber?: number;
   executor: aqua.Executor;
   secrets?: Record<string, string>;
+  commentOverrides?: Array<{ id: string; body: string }>;
 };
 
 export type RunInputs = {
@@ -102,6 +103,7 @@ export const disableAutoMergeForRenovateChange = async (
     vars: {
       tfaction_target: inputs.target,
     },
+    commentOverrides: inputs.commentOverrides,
   });
 };
 
@@ -232,6 +234,7 @@ const generateTfmigrateHcl = async (inputs: Inputs): Promise<boolean> => {
       vars: {
         tfaction_target: inputs.target,
       },
+      commentOverrides: inputs.commentOverrides,
     });
     throw new Error(
       ".tfmigrate.hcl is required but neither S3 nor GCS bucket is configured",
@@ -488,6 +491,7 @@ export const main = async (
     prNumber: runInputs.prNumber,
     executor,
     secrets: runInputs.secrets,
+    commentOverrides: config.comments,
   };
 
   const jobType = runInputs.jobType;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -323,6 +323,13 @@ export const RawConfig = z.object({
       changed_files: z.string().array(),
     })
     .optional(),
+  comments: z
+    .object({
+      id: z.string(),
+      body: z.string(),
+    })
+    .array()
+    .optional(),
 });
 export type RawConfig = z.infer<typeof RawConfig>;
 


### PR DESCRIPTION
## Summary
- Add optional `comments` field to `tfaction-root.yaml` schema (`RawConfig`) as an array of `{ id, body }` objects
- Update `post()` in the comment module to check user overrides first before falling back to built-in `install/comment.yaml` templates
- Thread `commentOverrides` through all `post()` call sites: apply, plan, create-follow-up-pr, and list-targets

## Test plan
- [x] All 793 existing tests pass (`npm t`)
- [x] No lint errors (`npm run lint`)
- [x] Code formatted (`npm run fmt`)
- [ ] Manual test: add `comments` to a `tfaction-root.yaml` with a custom template body for a known key and verify the PR comment uses the override
- [ ] Manual test: verify that without `comments` configured, behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)