### PR TITLE
feat: remove ssh_key input and SSH key setup from setup action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,11 +37,6 @@ inputs:
     description: GitHub Secrets as JSON. Used by output-github-secrets to map secrets to environment variable names.
     required: false
 
-  # setup
-  ssh_key:
-    description: SSH private key to checkout private modules
-    required: false
-
   # commit
   csm_app_id:
     description: GitHub App ID

--- a/src/actions/setup/index.ts
+++ b/src/actions/setup/index.ts
@@ -1,7 +1,5 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
-import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 
 import * as lib from "../../lib";
@@ -56,22 +54,6 @@ const addLabelToPR = async (
   } catch (error) {
     core.warning(`Failed to add label to PR: ${error}`);
   }
-};
-
-// Set up SSH key
-const setupSSHKey = async (sshKey: string): Promise<void> => {
-  if (!sshKey) {
-    return;
-  }
-
-  const sshDir = path.join(os.homedir(), ".ssh");
-  const keyPath = path.join(sshDir, "id_rsa");
-
-  await fs.promises.mkdir(sshDir, { recursive: true });
-  await fs.promises.writeFile(keyPath, sshKey);
-  await fs.promises.chmod(keyPath, 0o600);
-
-  core.info("SSH key configured for private modules");
 };
 
 export const main = async () => {
@@ -194,11 +176,6 @@ export const main = async () => {
       }
       throw error;
     }
-  }
-
-  if (input.sshKey) {
-    core.info("Setting up SSH key...");
-    await setupSSHKey(input.sshKey);
   }
 
   core.info("Setup completed successfully");

--- a/src/lib/input.ts
+++ b/src/lib/input.ts
@@ -46,9 +46,6 @@ export const getRequiredVersion = (): string => {
 export const migrationName = core.getInput("migration_name") || "main";
 export const prNumber = core.getInput("pr_number");
 
-// setup
-export const sshKey = core.getInput("ssh_key");
-
 // output-github-secrets
 export const githubSecrets = core.getInput("github_secrets");
 


### PR DESCRIPTION
## Summary
- Remove the `ssh_key` input from `action.yaml`
- Remove the `sshKey` export from `src/lib/input.ts`
- Remove the `setupSSHKey` function and its call site from `src/actions/setup/index.ts`, along with the now-unused `fs` and `os` imports

The `ssh_key` input is not used by the maintainer, and it is unclear if the current implementation is appropriate. Users can set up SSH keys themselves without tfaction support. This can be reconsidered if there is future demand.

## Test plan
- [x] `npm t` — all 815 tests pass
- [x] `npm run lint` — no lint errors
- [x] `npm run fmt` — formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)