### PR TITLE
chore: deprecate update_related_pull_requests config

### DIFF
--- a/src/actions/apply/terraform.test.ts
+++ b/src/actions/apply/terraform.test.ts
@@ -123,7 +123,6 @@ const createMockWriteStream = () => ({
 const createMockConfig = (overrides: Record<string, unknown> = {}) => ({
   git_root_dir: "/git/root",
   plan_workflow_name: "plan.yaml",
-  update_related_pull_requests: { enabled: true },
   target_groups: [],
   working_directory_file: "tfaction.yaml",
   module_file: "tfaction_module.yaml",

--- a/src/actions/apply/tfmigrate.test.ts
+++ b/src/actions/apply/tfmigrate.test.ts
@@ -101,7 +101,6 @@ const createMockWriteStream = () => ({
 const createMockConfig = (overrides: Record<string, unknown> = {}) => ({
   git_root_dir: "/git/root",
   plan_workflow_name: "plan.yaml",
-  update_related_pull_requests: { enabled: true },
   target_groups: [],
   working_directory_file: "tfaction.yaml",
   module_file: "tfaction_module.yaml",

--- a/src/actions/update-pr-branch/index.ts
+++ b/src/actions/update-pr-branch/index.ts
@@ -24,9 +24,6 @@ export const main = async () => {
   await run({
     githubToken,
     target: targetConfig.target,
-    disableUpdateRelatedPullRequests: !(
-      cfg.update_related_pull_requests?.enabled ?? true
-    ),
     csmActionsServerRepository: cfg.csm_actions?.server_repository ?? "",
     csmAppId: input.csmAppId,
     csmAppPrivateKey: input.csmAppPrivateKey,

--- a/src/actions/update-pr-branch/run.test.ts
+++ b/src/actions/update-pr-branch/run.test.ts
@@ -28,7 +28,6 @@ const createMockLogger = () => ({
 const createBaseInput = (overrides: Partial<RunInput> = {}): RunInput => ({
   githubToken: "gh-token",
   target: "aws/dev/vpc",
-  disableUpdateRelatedPullRequests: false,
   csmActionsServerRepository: "",
   csmAppId: "",
   csmAppPrivateKey: "",
@@ -46,21 +45,6 @@ const createBaseInput = (overrides: Partial<RunInput> = {}): RunInput => ({
 describe("run", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it("skips when disableUpdateRelatedPullRequests is true", async () => {
-    const logger = createMockLogger();
-    const input = createBaseInput({
-      disableUpdateRelatedPullRequests: true,
-      logger,
-    });
-
-    await run(input);
-
-    expect(logger.info).toHaveBeenCalledWith(
-      "Skip updating related pull requests",
-    );
-    expect(listRelatedPullRequests).not.toHaveBeenCalled();
   });
 
   it("calls updateBranchByCommit when csmActionsServerRepository is empty", async () => {

--- a/src/actions/update-pr-branch/run.ts
+++ b/src/actions/update-pr-branch/run.ts
@@ -10,7 +10,6 @@ import {
 export type RunInput = {
   githubToken: string;
   target: string;
-  disableUpdateRelatedPullRequests: boolean;
   csmActionsServerRepository: string;
   csmAppId: string;
   csmAppPrivateKey: string;
@@ -31,11 +30,6 @@ export type RunInput = {
 };
 
 export const run = async (input: RunInput): Promise<void> => {
-  if (input.disableUpdateRelatedPullRequests) {
-    input.logger.info("Skip updating related pull requests");
-    return;
-  }
-
   const octokit = github.getOctokit(input.githubToken);
   const prNumbers = await listRelatedPullRequests({
     octokit,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -295,11 +295,6 @@ export const RawConfig = z.object({
     })
     .optional(),
   terraform_command: z.string().default("terraform"),
-  update_related_pull_requests: z
-    .object({
-      enabled: z.boolean().optional(),
-    })
-    .optional(),
   working_directory_file: z.string().default("tfaction.yaml"),
   module_file: z.string().default("tfaction_module.yaml"),
   replace_target: Replace.optional(),

--- a/tests/opentofu/tfaction-root.yaml
+++ b/tests/opentofu/tfaction-root.yaml
@@ -31,9 +31,6 @@ scaffold_working_directory:
 #     skip_push: false # default is false
 #     prune: true # default is false
 
-update_related_pull_requests:
-  enabled: true
-
 drift_detection:
   enabled: false
   issue_repo_owner: suzuki-shunsuke

--- a/tests/terragrunt/tfaction-root.yaml
+++ b/tests/terragrunt/tfaction-root.yaml
@@ -31,9 +31,6 @@ scaffold_working_directory:
 #     skip_push: false # default is false
 #     prune: true # default is false
 
-update_related_pull_requests:
-  enabled: true
-
 drift_detection:
   enabled: false
   issue_repo_owner: suzuki-shunsuke

--- a/tests/tfaction-root.yaml
+++ b/tests/tfaction-root.yaml
@@ -31,9 +31,6 @@ aqua:
     skip_push: false # default is false
     prune: true # default is false{}
 
-update_related_pull_requests:
-  enabled: true
-
 drift_detection:
   enabled: true
   issue_repo_owner: suzuki-shunsuke

--- a/website/docs/unreleased/update-pr-branch.md
+++ b/website/docs/unreleased/update-pr-branch.md
@@ -14,16 +14,11 @@ tfaction automatically updates PR branches. There are two types of updates:
 When terraform apply is run for a root module, PRs that modify the same root module need to be updated and have terraform plan run again.
 Otherwise, reviews based on an outdated plan are unreliable, and the plan file in GitHub Artifacts becomes stale, causing apply to fail even if the PR is merged.
 
-tfaction updates these PRs automatically by default, so users do not need any special configuration. However, you can disable automatic updates through settings.
+tfaction updates these PRs automatically by default, so users do not need any special configuration.
+If you want to disable automatic updates, you can simply not run the `update-pr-branch` action in your workflow.
 That said, as mentioned above, updating before merging is necessary, so disabling this is not recommended.
 
 - Adding the `tfaction:disable-auto-update` label to a PR prevents that PR from being automatically updated
-- You can disable this in tfaction-root.yaml:
-
-```yaml
-update_related_pull_requests:
-  enabled: false
-```
 
 ## 2. Automatic Update During PR CI
 


### PR DESCRIPTION
## Summary

- Remove the `update_related_pull_requests` config setting from `tfaction-root.yaml` schema and all usages
- The `update-pr-branch` action has been separated from the `apply` action, so users can disable automatic PR branch updates by simply not running the `update-pr-branch` action in their workflow
- Update documentation to reflect the new way to disable automatic updates

## Test plan

- [x] `npm t` — All 814 tests pass
- [x] `npm run lint` — No lint errors
- [x] `npm run fmt` — Code is formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)