### PR TITLE
fix(hide-comment): handle metadata without Program/Command fields

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -77,7 +77,8 @@ inputs:
   if:
     description: >-
       CEL expression to determine which comments to hide.
-      Available variables - Comment.HasMeta (bool), Comment.Meta (object with SHA1, Program, Command, JobName, PRNumber, Target, WorkflowName, Vars), Commit.SHA1 (string).
+      Available variables - Comment.HasMeta (bool), Comment.Meta (object with SHA1, Vars, and optional Program, Command, JobName, PRNumber, Target, WorkflowName, TemplateKey), Commit.SHA1 (string).
+      Optional fields may be absent depending on which tool wrote the metadata (e.g. github-comment omits Program/Command); guard accesses with has() to avoid evaluation errors.
     required: false
 
   # apply-label

--- a/src/actions/hide-comment/run.test.ts
+++ b/src/actions/hide-comment/run.test.ts
@@ -122,6 +122,17 @@ describe("run", () => {
       isMinimized,
     );
 
+  const makeGitHubCommentMeta = (
+    id: string,
+    sha: string,
+    isMinimized: boolean = false,
+  ) =>
+    makeComment(
+      id,
+      `Result\n<!-- github-comment: {"JobName":"lintnet","SHA1":"${sha}","TemplateKey":"default","Vars":{},"WorkflowName":"test"} -->`,
+      isMinimized,
+    );
+
   const graphqlPage = (
     nodes: Array<{ id: string; body: string; isMinimized: boolean }>,
     hasNextPage: boolean = false,
@@ -235,6 +246,31 @@ describe("run", () => {
       ]),
     );
     octokit.graphql.mockResolvedValue({});
+
+    const input: RunInput = {
+      octokit: octokit as unknown as RunInput["octokit"],
+      repoOwner: "owner",
+      repoName: "repo",
+      prNumber: 1,
+      commitSHA: "new-sha",
+      ifCondition: DEFAULT_CONDITION,
+      logger,
+    };
+
+    const result = await run(input);
+    expect(result.hiddenCount).toBe(1);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it("hides github-comment-style comments (no Program/Command) with old SHA", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+
+    octokit.graphql
+      .mockResolvedValueOnce(
+        graphqlPage([makeGitHubCommentMeta("c1", "old-sha")]),
+      )
+      .mockResolvedValue({});
 
     const input: RunInput = {
       octokit: octokit as unknown as RunInput["octokit"],

--- a/src/actions/hide-comment/run.ts
+++ b/src/actions/hide-comment/run.ts
@@ -39,7 +39,7 @@ type Comment = {
 };
 
 export const DEFAULT_CONDITION =
-  'Comment.HasMeta && Comment.Meta.SHA1 != Commit.SHA1 && !(Comment.Meta.Program == "tfcmt" && Comment.Meta.Command == "apply")';
+  'Comment.HasMeta && Comment.Meta.SHA1 != Commit.SHA1 && !(has(Comment.Meta.Program) && has(Comment.Meta.Command) && Comment.Meta.Program == "tfcmt" && Comment.Meta.Command == "apply")';
 
 const metaPattern = /<!-- github-comment: ({.*?}) -->/s;
 


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

## Summary

Fix the `hide-comment` action so that PR comments whose metadata was written by `github-comment` (and any other producer that omits `Program` / `Command`) are correctly hidden against the default `if` condition.

## Background

Since `tfaction@v2.0.0-3`, only a subset of stale PR comments are hidden when `hide-comment` runs. Observed in the field as e.g. `Found 22 comments / Hidden 1 of 9` — only `tfcmt` plan comments are minimized, while `lintnet` and other `github-comment`-style comments survive across pushes.

Example comment that should be hidden but is not:

```
<!-- github-comment: {"JobName":"lintnet","SHA1":"<old-sha>","TemplateKey":"default","Vars":{},"WorkflowName":"test"} -->
```

Example comment that is hidden correctly today:

```
<!-- github-comment: {"Command":"plan","JobName":"plan","PRNumber":4037,"Program":"tfcmt","SHA1":"<old-sha>","Target":"sre","Vars":{},"WorkflowName":"test"} -->
```

## Root cause

`src/actions/hide-comment/run.ts` ships this default CEL expression:

```ts
'Comment.HasMeta && Comment.Meta.SHA1 != Commit.SHA1 && !(Comment.Meta.Program == "tfcmt" && Comment.Meta.Command == "apply")'
```

- The two trailing predicates reference `Comment.Meta.Program` / `Comment.Meta.Command` unconditionally.
- `github-comment`'s official metadata shape (`{JobName, JobID, WorkflowName, TemplateKey, Vars, SHA1}`) does not include `Program` / `Command`, and `tfaction`'s own `buildCommentBody` (`src/comment/index.ts`) likewise emits only `{JobName, SHA1, TemplateKey, Vars}`.
- `@marcbachmann/cel-js` does not silently coerce missing keys — it throws:
  ```
  $ node -e "const {evaluate} = require('@marcbachmann/cel-js'); evaluate('Comment.Meta.Program == \"tfcmt\"', {Comment:{Meta:{}}})"
  Error: No such key: Program
  ```
- The `try/catch` in `run.ts` swallows that exception and falls through with `result = false`, i.e. "do not hide". Net effect: every comment without `Program`/`Command` is effectively whitelisted.

## Changes (what's in the base..head diff)

Three files; 39 insertions, 2 deletions.

### `src/actions/hide-comment/run.ts` — `DEFAULT_CONDITION`

Wrap the `Program` / `Command` lookups with CEL's `has()` macro so the apply-protection clause is only evaluated when both fields exist:

```diff
 export const DEFAULT_CONDITION =
-  'Comment.HasMeta && Comment.Meta.SHA1 != Commit.SHA1 && !(Comment.Meta.Program == "tfcmt" && Comment.Meta.Command == "apply")';
+  'Comment.HasMeta && Comment.Meta.SHA1 != Commit.SHA1 && !(has(Comment.Meta.Program) && has(Comment.Meta.Command) && Comment.Meta.Program == "tfcmt" && Comment.Meta.Command == "apply")';
```

CEL's `&&` is short-circuiting, so `has(Comment.Meta.Program)` returning `false` prevents the missing-key lookup from ever happening. `cel-js`'s `has()` returns `false` for both absent keys and keys explicitly set to `undefined` (verified locally), so `buildCELContext` does not need to change.

Semantics preserved:

| metadata shape | `SHA1 != Commit.SHA1` | hidden before | hidden after |
|---|---|---|---|
| `tfcmt` + `Command=plan` | yes | yes | yes |
| `tfcmt` + `Command=apply` | yes | no (protected) | no (protected) |
| `github-comment` (no `Program`/`Command`) | yes | **no (bug)** | **yes (fixed)** |
| any shape | no (same SHA) | no | no |
| no metadata | n/a (`HasMeta=false`) | no | no |

### `src/actions/hide-comment/run.test.ts` — regression test

Adds `makeGitHubCommentMeta` (a `github-comment`-shaped fixture without `Program`/`Command`) and a new `it` case asserting that one such comment with an old SHA is hidden under `DEFAULT_CONDITION`. The test fails on `main` (`hiddenCount: 0 != 1`) and passes on this branch.

### `action.yaml` — `if` input description

Documents that fields beyond `SHA1` / `Vars` are optional depending on which tool wrote the metadata (e.g. `github-comment` omits `Program`/`Command`), and recommends guarding accesses with `has()` in custom expressions. No behavioral change.

## Verification

```
$ npm t
Test Files  48 passed (48)
     Tests  870 passed (870)

$ npx eslint src/actions/hide-comment/run.ts src/actions/hide-comment/run.test.ts
(clean)

$ npx tsc --noEmit
(clean)

$ npx prettier -c src/actions/hide-comment/run.ts src/actions/hide-comment/run.test.ts action.yaml
(clean)
```

Manual CEL check against the new default with `Comment.HasMeta=true` and `Commit.SHA1='new'`:

| case | `Meta` | want | got |
|---|---|---|---|
| github-comment, old SHA | `{SHA1:'old', JobName, TemplateKey, Vars, WorkflowName}` | hide (`true`) | `true` |
| tfcmt plan, old SHA | `{SHA1:'old', Program:'tfcmt', Command:'plan', ...}` | hide (`true`) | `true` |
| tfcmt apply, old SHA | `{SHA1:'old', Program:'tfcmt', Command:'apply', ...}` | keep (`false`) | `false` |
| same SHA | `{SHA1:'new', ...}` | keep (`false`) | `false` |

## Compatibility

- The default condition keeps the same logical meaning for `tfcmt` metadata; the only behavioral change is that comments without `Program`/`Command` now match the SHA-mismatch rule (which is the intended behavior).
- Custom `if` expressions supplied by users are unaffected — only `DEFAULT_CONDITION` changes. Users who write their own conditions referencing `Comment.Meta.Program` directly on github-comment-shaped metadata would already hit the same `No such key` error today; the updated `action.yaml` description nudges them toward `has()` guards.

## Out of scope

- Adding `Program`/`Command` to `tfaction`'s native `buildCommentBody` metadata — breaking change to existing comment metadata format; not required once the default condition tolerates absent fields.
- Refactoring `buildCELContext` to drop undefined entries — not needed for the bug fix because cel-js's `has()` already treats `undefined` and absent keys identically.
- Upstream change to `@marcbachmann/cel-js` to coerce missing keys to falsy — out of scope for this repo.
