### PR TITLE
feat(test-workflow): support only_plan and plan_and_apply blocks

### DIFF
--- a/src/actions/list-targets/list-targets-with-changed-files/index.test.ts
+++ b/src/actions/list-targets/list-targets-with-changed-files/index.test.ts
@@ -1694,7 +1694,7 @@ test("module working dir with no changes produces no output", async () => {
 
 // test_workflow tests
 
-test("test_workflow: changed_files match and no working dirs changed adds test targets", async () => {
+test("test_workflow: plan_and_apply changed_files match and no working dirs changed adds test targets", async () => {
   expect(
     await run({
       config: {
@@ -1704,8 +1704,10 @@ test("test_workflow: changed_files match and no working dirs changed adds test t
           },
         ],
         test_workflow: {
-          working_directories: ["foo/dev"],
-          changed_files: [".github/workflows/*.yaml"],
+          plan_and_apply: {
+            working_directories: ["foo/dev"],
+            changed_files: [".github/workflows/*.yaml"],
+          },
         },
       },
       isApply: false,
@@ -1739,7 +1741,7 @@ test("test_workflow: changed_files match and no working dirs changed adds test t
   });
 });
 
-test("test_workflow: changed_files match but working dirs also changed returns normal targets", async () => {
+test("test_workflow: plan_and_apply changed_files match but working dirs also changed returns normal targets", async () => {
   expect(
     await run({
       config: {
@@ -1749,8 +1751,10 @@ test("test_workflow: changed_files match but working dirs also changed returns n
           },
         ],
         test_workflow: {
-          working_directories: ["foo/dev"],
-          changed_files: [".github/workflows/*.yaml"],
+          plan_and_apply: {
+            working_directories: ["foo/dev"],
+            changed_files: [".github/workflows/*.yaml"],
+          },
         },
       },
       isApply: false,
@@ -1784,7 +1788,7 @@ test("test_workflow: changed_files match but working dirs also changed returns n
   });
 });
 
-test("test_workflow: changed_files don't match and no working dirs changed returns no targets", async () => {
+test("test_workflow: plan_and_apply changed_files don't match and no working dirs changed returns no targets", async () => {
   expect(
     await run({
       config: {
@@ -1794,8 +1798,10 @@ test("test_workflow: changed_files don't match and no working dirs changed retur
           },
         ],
         test_workflow: {
-          working_directories: ["foo/dev"],
-          changed_files: [".github/workflows/*.yaml"],
+          plan_and_apply: {
+            working_directories: ["foo/dev"],
+            changed_files: [".github/workflows/*.yaml"],
+          },
         },
       },
       isApply: false,
@@ -1819,7 +1825,7 @@ test("test_workflow: changed_files don't match and no working dirs changed retur
   });
 });
 
-test("test_workflow: apply mode includes test targets", async () => {
+test("test_workflow: plan_and_apply apply mode includes test targets", async () => {
   expect(
     await run({
       config: {
@@ -1829,8 +1835,10 @@ test("test_workflow: apply mode includes test targets", async () => {
           },
         ],
         test_workflow: {
-          working_directories: ["foo/dev"],
-          changed_files: [".github/workflows/*.yaml"],
+          plan_and_apply: {
+            working_directories: ["foo/dev"],
+            changed_files: [".github/workflows/*.yaml"],
+          },
         },
       },
       isApply: true,
@@ -1862,4 +1870,246 @@ test("test_workflow: apply mode includes test targets", async () => {
       },
     ],
   });
+});
+
+test("test_workflow: only_plan changed_files match in plan mode adds targets", async () => {
+  expect(
+    await run({
+      config: {
+        target_groups: [
+          {
+            working_directory: "foo/**",
+          },
+        ],
+        test_workflow: {
+          only_plan: {
+            working_directories: ["foo/diff"],
+            changed_files: [".github/workflows/test.yaml"],
+          },
+        },
+      },
+      isApply: false,
+      labels: [],
+      changedFiles: [],
+      configFiles: ["foo/diff/tfaction.yaml"],
+      prBody: "",
+      payload: {
+        pull_request: {
+          body: "",
+        },
+      },
+      moduleCallers: {},
+      octokit: {} as ReturnType<typeof import("@actions/github").getOctokit>,
+      prNumber: 0,
+      maxChangedWorkingDirectories: 0,
+      relativeChangedFiles: [".github/workflows/test.yaml"],
+    }),
+  ).toStrictEqual({
+    targetConfigs: [
+      {
+        environment: undefined,
+        job_type: "terraform",
+        runs_on: "ubuntu-latest",
+        secrets: undefined,
+        skip_terraform: false,
+        target: "foo/diff",
+        working_directory: "foo/diff",
+      },
+    ],
+  });
+});
+
+test("test_workflow: only_plan changed_files match in apply mode does NOT add targets", async () => {
+  expect(
+    await run({
+      config: {
+        target_groups: [
+          {
+            working_directory: "foo/**",
+          },
+        ],
+        test_workflow: {
+          only_plan: {
+            working_directories: ["foo/diff"],
+            changed_files: [".github/workflows/test.yaml"],
+          },
+        },
+      },
+      isApply: true,
+      labels: [],
+      changedFiles: [],
+      configFiles: ["foo/diff/tfaction.yaml"],
+      prBody: "",
+      payload: {
+        pull_request: {
+          body: "",
+        },
+      },
+      moduleCallers: {},
+      octokit: {} as ReturnType<typeof import("@actions/github").getOctokit>,
+      prNumber: 0,
+      maxChangedWorkingDirectories: 0,
+      relativeChangedFiles: [".github/workflows/test.yaml"],
+    }),
+  ).toStrictEqual({
+    targetConfigs: [],
+  });
+});
+
+test("test_workflow: only_plan and plan_and_apply both match in plan mode adds both", async () => {
+  expect(
+    await run({
+      config: {
+        target_groups: [
+          {
+            working_directory: "foo/**",
+          },
+        ],
+        test_workflow: {
+          only_plan: {
+            working_directories: ["foo/diff"],
+            changed_files: [".github/workflows/test.yaml"],
+          },
+          plan_and_apply: {
+            working_directories: ["foo/nodiff"],
+            changed_files: [".github/workflows/apply.yaml"],
+          },
+        },
+      },
+      isApply: false,
+      labels: [],
+      changedFiles: [],
+      configFiles: ["foo/diff/tfaction.yaml", "foo/nodiff/tfaction.yaml"],
+      prBody: "",
+      payload: {
+        pull_request: {
+          body: "",
+        },
+      },
+      moduleCallers: {},
+      octokit: {} as ReturnType<typeof import("@actions/github").getOctokit>,
+      prNumber: 0,
+      maxChangedWorkingDirectories: 0,
+      relativeChangedFiles: [
+        ".github/workflows/test.yaml",
+        ".github/workflows/apply.yaml",
+      ],
+    }),
+  ).toStrictEqual({
+    targetConfigs: [
+      {
+        environment: undefined,
+        job_type: "terraform",
+        runs_on: "ubuntu-latest",
+        secrets: undefined,
+        skip_terraform: false,
+        target: "foo/nodiff",
+        working_directory: "foo/nodiff",
+      },
+      {
+        environment: undefined,
+        job_type: "terraform",
+        runs_on: "ubuntu-latest",
+        secrets: undefined,
+        skip_terraform: false,
+        target: "foo/diff",
+        working_directory: "foo/diff",
+      },
+    ],
+  });
+});
+
+test("test_workflow: only_plan and plan_and_apply both match in apply mode adds only plan_and_apply", async () => {
+  expect(
+    await run({
+      config: {
+        target_groups: [
+          {
+            working_directory: "foo/**",
+          },
+        ],
+        test_workflow: {
+          only_plan: {
+            working_directories: ["foo/diff"],
+            changed_files: [".github/workflows/test.yaml"],
+          },
+          plan_and_apply: {
+            working_directories: ["foo/nodiff"],
+            changed_files: [".github/workflows/apply.yaml"],
+          },
+        },
+      },
+      isApply: true,
+      labels: [],
+      changedFiles: [],
+      configFiles: ["foo/diff/tfaction.yaml", "foo/nodiff/tfaction.yaml"],
+      prBody: "",
+      payload: {
+        pull_request: {
+          body: "",
+        },
+      },
+      moduleCallers: {},
+      octokit: {} as ReturnType<typeof import("@actions/github").getOctokit>,
+      prNumber: 0,
+      maxChangedWorkingDirectories: 0,
+      relativeChangedFiles: [
+        ".github/workflows/test.yaml",
+        ".github/workflows/apply.yaml",
+      ],
+    }),
+  ).toStrictEqual({
+    targetConfigs: [
+      {
+        environment: undefined,
+        job_type: "terraform",
+        runs_on: "ubuntu-latest",
+        secrets: undefined,
+        skip_terraform: false,
+        target: "foo/nodiff",
+        working_directory: "foo/nodiff",
+      },
+    ],
+  });
+});
+
+test("test_workflow: duplicate working_directory in only_plan and plan_and_apply throws error", async () => {
+  await expect(
+    run({
+      config: {
+        target_groups: [
+          {
+            working_directory: "foo/**",
+          },
+        ],
+        test_workflow: {
+          only_plan: {
+            working_directories: ["foo/dev"],
+            changed_files: [".github/workflows/test.yaml"],
+          },
+          plan_and_apply: {
+            working_directories: ["foo/dev"],
+            changed_files: [".github/workflows/apply.yaml"],
+          },
+        },
+      },
+      isApply: false,
+      labels: [],
+      changedFiles: [],
+      configFiles: ["foo/dev/tfaction.yaml"],
+      prBody: "",
+      payload: {
+        pull_request: {
+          body: "",
+        },
+      },
+      moduleCallers: {},
+      octokit: {} as ReturnType<typeof import("@actions/github").getOctokit>,
+      prNumber: 0,
+      maxChangedWorkingDirectories: 0,
+      relativeChangedFiles: [".github/workflows/test.yaml"],
+    }),
+  ).rejects.toThrow(
+    /working_directories appear in both only_plan and plan_and_apply/,
+  );
 });

--- a/src/actions/list-targets/list-targets-with-changed-files/index.ts
+++ b/src/actions/list-targets/list-targets-with-changed-files/index.ts
@@ -328,18 +328,24 @@ export const run = async (input: Input): Promise<Result> => {
 
   // If no targets found, check test_workflow for fallback test targets
   const testWorkflow = input.config.test_workflow;
+  if (testWorkflow?.only_plan && testWorkflow?.plan_and_apply) {
+    const onlyPlanSet = new Set(testWorkflow.only_plan.working_directories);
+    const dupes = testWorkflow.plan_and_apply.working_directories.filter((wd) =>
+      onlyPlanSet.has(wd),
+    );
+    if (dupes.length > 0) {
+      throw new Error(
+        `test_workflow: working_directories appear in both only_plan and plan_and_apply: ${dupes.join(", ")}`,
+      );
+    }
+  }
   if (
     allTargetConfigs.length === 0 &&
     testWorkflow &&
     input.relativeChangedFiles
   ) {
-    const changedFilesMatch = input.relativeChangedFiles.some((file) =>
-      testWorkflow.changed_files.some((pattern) =>
-        minimatch(file, pattern, { dot: true }),
-      ),
-    );
-    if (changedFilesMatch) {
-      for (const wd of testWorkflow.working_directories) {
+    const addTestTargets = (wds: string[]) => {
+      for (const wd of wds) {
         const target = wdTargetMap.get(wd) ?? wd;
         const obj = getTargetConfigByTarget(
           config.target_groups,
@@ -352,6 +358,28 @@ export const run = async (input: Input): Promise<Result> => {
         if (obj !== undefined) {
           allTargetConfigs.push(obj);
         }
+      }
+    };
+    const planAndApply = testWorkflow.plan_and_apply;
+    if (planAndApply) {
+      const match = input.relativeChangedFiles.some((file) =>
+        planAndApply.changed_files.some((pattern) =>
+          minimatch(file, pattern, { dot: true }),
+        ),
+      );
+      if (match) {
+        addTestTargets(planAndApply.working_directories);
+      }
+    }
+    const onlyPlan = testWorkflow.only_plan;
+    if (onlyPlan && !isApply) {
+      const match = input.relativeChangedFiles.some((file) =>
+        onlyPlan.changed_files.some((pattern) =>
+          minimatch(file, pattern, { dot: true }),
+        ),
+      );
+      if (match) {
+        addTestTargets(onlyPlan.working_directories);
       }
     }
   }
@@ -379,8 +407,14 @@ type Input = {
     label_prefixes?: types.LabelPrefixes;
     skip_terraform_files?: string[];
     test_workflow?: {
-      working_directories: string[];
-      changed_files: string[];
+      only_plan?: {
+        working_directories: string[];
+        changed_files: string[];
+      };
+      plan_and_apply?: {
+        working_directories: string[];
+        changed_files: string[];
+      };
     };
   };
   isApply: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -329,8 +329,18 @@ export const RawConfig = z.object({
     .optional(),
   test_workflow: z
     .object({
-      working_directories: z.string().array(),
-      changed_files: z.string().array(),
+      only_plan: z
+        .object({
+          working_directories: z.string().array(),
+          changed_files: z.string().array(),
+        })
+        .optional(),
+      plan_and_apply: z
+        .object({
+          working_directories: z.string().array(),
+          changed_files: z.string().array(),
+        })
+        .optional(),
     })
     .optional(),
 });

--- a/website/docs/unreleased/test-workflow.md
+++ b/website/docs/unreleased/test-workflow.md
@@ -6,16 +6,33 @@ sidebar_position: 3400
 
 When GitHub Actions workflows are modified, it is desirable to verify that they still work correctly.
 If workflows are modified but no working directories are changed, you can configure tfaction to run plan and apply on specified working directories.
+
+`test_workflow` provides two blocks:
+
+- `only_plan`: only `plan` is run on these directories. `apply` is skipped. This is useful when you want to verify a workflow without applying any real changes — for example, when running `apply` on a production directory would cause drift, or when a `null_resource` placeholder is not enough to exercise the workflow.
+- `plan_and_apply`: both `plan` and `apply` are run on these directories.
+
 Add the configuration to tfaction-root.yaml.
 
 ```yaml title="tfaction-root.yaml"
 test_workflow:
-  working_directories:
-    # If no working directories are modified, plan and apply are run on the directories specified here
-    - test
-  changed_files:
-    # Run workflow tests when these files are changed
-    - .github/workflows/test.yaml
-    - .github/actions/test/**
-    - .github/workflows/apply.yaml
+  only_plan:
+    working_directories:
+      # If no working directories are modified, plan is run on the directories specified here.
+      # apply is NOT run on these directories.
+      - test/diff
+    changed_files:
+      # Run plan-only workflow tests when these files are changed
+      - .github/workflows/test.yaml
+      - .github/actions/test/**
+  plan_and_apply:
+    working_directories:
+      # If no working directories are modified, plan and apply are run on the directories specified here
+      - test/nodiff
+    changed_files:
+      # Run plan-and-apply workflow tests when these files are changed
+      - .github/workflows/apply.yaml
 ```
+
+Both blocks are optional, so you can configure either one or both.
+A working directory must not appear in both `only_plan` and `plan_and_apply`; doing so causes a validation error.


### PR DESCRIPTION
## Summary

Split the `test_workflow` configuration into two blocks so that workflow tests can run `plan` without `apply`:

- `only_plan`: a fallback set of working directories that are added to the target list **only when planning**. `apply` is skipped for these directories.
- `plan_and_apply`: a fallback set of working directories that are added to the target list for both `plan` and `apply`. This matches the previous behavior of `test_workflow`.

## Motivation

Previously `test_workflow` always ran both plan and apply on its `working_directories`. That made the feature unusable for a common workflow-testing case: you want to exercise a workflow against a real directory but you do **not** want `apply` to actually create resources or cause drift.

Concretely, neither of the following was supported:

- Pointing at a production directory just to verify the workflow — `apply` would mutate real resources or cause drift that becomes a blocker for unrelated PRs.
- Pointing at a `null_resource`-only directory — `null_resource` is often insufficient to exercise the workflow under test.

`only_plan` solves this by letting you designate test directories where `plan` runs but `apply` does not.

## Schema change (breaking, unreleased)

This feature is documented under `website/docs/unreleased/`, so the schema is changed without backwards compatibility. The previous shape:

~~~yaml
test_workflow:
  working_directories: [...]
  changed_files: [...]
~~~

is replaced by:

~~~yaml
test_workflow:
  only_plan:
    working_directories: [...]
    changed_files: [...]
  plan_and_apply:
    working_directories: [...]
    changed_files: [...]
~~~

Both `only_plan` and `plan_and_apply` are optional; either one or both may be configured. If they both contain the same working directory, configuration validation fails fast with a clear error.

## Behavior

The fallback runs only when no other targets are detected (unchanged from before). Within the fallback:

| Changed file matches | Plan phase (`isApply=false`) | Apply phase (`isApply=true`) |
|---|---|---|
| `only_plan.changed_files` only | adds `only_plan.working_directories` | nothing added |
| `plan_and_apply.changed_files` only | adds `plan_and_apply.working_directories` | adds `plan_and_apply.working_directories` |
| Both | adds both | adds only `plan_and_apply.working_directories` |

`isApply` is the same flag derived from `TFACTION_IS_APPLY` that already flows into `run()`; no new env handling was needed.

## Validation

If the same working directory appears in both `only_plan.working_directories` and `plan_and_apply.working_directories`, `run()` throws:

> `test_workflow: working_directories appear in both only_plan and plan_and_apply: <wd>`

## Files changed

- `src/lib/types.ts` — zod schema for `test_workflow` split into `only_plan` / `plan_and_apply`.
- `src/actions/list-targets/list-targets-with-changed-files/index.ts` — `Input` type updated; fallback evaluates the two blocks independently; `only_plan` is gated on `!isApply`; duplicate-working-directory validation added.
- `src/actions/list-targets/list-targets-with-changed-files/index.test.ts` — existing 4 cases rewritten against the new schema; 5 new cases cover `only_plan` in plan mode, `only_plan` in apply mode (no targets added), both blocks in plan mode, both blocks in apply mode, and the duplicate-validation error path.
- `website/docs/unreleased/test-workflow.md` — explains the two blocks, when to use `only_plan`, and the duplicate-wd validation.

## Test plan

- [x] `npm t` — 875 tests pass (47 in `list-targets-with-changed-files`)
- [x] `npm run lint` — clean
- [x] `npm run fmt` — clean
- [ ] Manual test via `pr/<this PR number>` branch:
  - [ ] A PR that only changes `only_plan.changed_files` triggers `plan` on the `only_plan` working directories but **skips** `apply`.
  - [ ] A PR that only changes `plan_and_apply.changed_files` triggers both `plan` and `apply` on the `plan_and_apply` working directories.
  - [ ] A config that lists the same working directory in both blocks surfaces the validation error in `list-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)