### PR TITLE
feat(list-targets): post PR comment when terraform-config-inspect fails

### DIFF
--- a/install/comment.yaml
+++ b/install/comment.yaml
@@ -190,3 +190,16 @@ exec:
         {{join_command}}
 
         {{hidden_combined_output}}
+
+  terraform-config-inspect:
+    - when: ExitCode != 0
+      template: |
+        ## :x: {{#if Vars.tfaction_target}}{{Vars.tfaction_target}}: {{/if}}Failed to resolve module dependencies
+
+        {{link}} | [document](https://suzuki-shunsuke.github.io/tfaction/docs/unreleased/detect-module-dependency)
+
+        Failed to resolve module dependencies using [terraform-config-inspect](https://github.com/hashicorp/terraform-config-inspect).
+
+        {{join_command}}
+
+        {{hidden_combined_output}}

--- a/src/actions/list-targets/list-targets-with-changed-files/index.ts
+++ b/src/actions/list-targets/list-targets-with-changed-files/index.ts
@@ -523,16 +523,18 @@ export const main = async (executor: aqua.Executor, pr: ciInfo.Result) => {
     moduleWorkingDirs.add(path.dirname(configFile));
   }
 
+  const githubToken = input.getRequiredGitHubToken();
+
   let moduleCallers: ModuleToCallers | null = null;
   if (cfg.update_local_path_module_caller?.enabled) {
     moduleCallers = await listModuleCallers(
       cfg.git_root_dir,
       configFiles,
+      githubToken,
       executor,
     );
   }
 
-  const githubToken = input.getRequiredGitHubToken();
   const octokit = github.getOctokit(githubToken);
 
   const result = await run({

--- a/src/actions/list-targets/list-targets-with-changed-files/list-module-callers/index.ts
+++ b/src/actions/list-targets/list-targets-with-changed-files/list-module-callers/index.ts
@@ -8,6 +8,7 @@ import * as aqua from "../../../../aqua";
  * List module callers in the git repository.
  * @param gitRootDir - Absolute path to the git root directory
  * @param configFiles - Relative file paths from git_root_dir to config files
+ * @param githubToken - GitHub token used to post a PR comment when `terraform-config-inspect` fails
  * @param executor
  * @returns Relative path to module from git_root_dir => Relative paths from git_root_dir to module callers
  */
@@ -15,6 +16,7 @@ export const list = async (
   gitRootDir: string,
   /** relative file paths from git_root_dir */
   configFiles: string[],
+  githubToken: string,
   executor: aqua.Executor,
 ): Promise<ModuleToCallers> => {
   const rawModuleCalls: ModuleCalls = {};
@@ -102,6 +104,12 @@ export const list = async (
       ["--json"],
       {
         cwd: absTfDir,
+        group: "terraform-config-inspect",
+        comment: {
+          token: githubToken,
+          key: "terraform-config-inspect",
+          vars: { tfaction_target: tfDir },
+        },
       },
     );
     const inspection = JSON.parse(outInspect.stdout);

--- a/src/aqua/run.ts
+++ b/src/aqua/run.ts
@@ -12,7 +12,8 @@ export type Comment = {
     | "terraform-docs"
     | "tfmigrate-plan"
     | "tfmigrate-apply"
-    | "drift-apply";
+    | "drift-apply"
+    | "terraform-config-inspect";
   vars?: Partial<Record<varKey, string>>;
   org?: string;
   repo?: string;


### PR DESCRIPTION
## Summary

When `list-targets-with-changed-files` runs `terraform-config-inspect --json` over each Terraform working directory to discover local-path module dependencies, a failure (e.g. invalid HCL in a `*.tf` file) currently throws inside `JSON.parse` with no PR feedback — contributors have to read GitHub Actions logs to find out which directory broke.

This change finishes wiring the existing `execAndComment` pipeline into that call site so a failure is reported back as a PR comment naming the failing working directory, before the action re-throws and aborts as before.

## Changes

### `install/comment.yaml`

Adds a new `exec.terraform-config-inspect` template that fires on `ExitCode != 0`. The rendered comment includes:

- A heading: `## :x: <tfaction_target>: Failed to resolve module dependencies`
- A build link plus a link to the docs page on module-dependency detection
- A short prose sentence pointing at the upstream [terraform-config-inspect](https://github.com/hashicorp/terraform-config-inspect) project
- The exact command (`{{join_command}}`) and the captured stdout/stderr in a collapsible `<details>` block (`{{hidden_combined_output}}`)

### `src/aqua/run.ts`

Extends the `Comment.key` union (used by `aqua.Executor.exec` / `getExecOutput`'s `comment` option) with `"terraform-config-inspect"` so the new key is type-safe.

### `src/actions/list-targets/list-targets-with-changed-files/list-module-callers/index.ts`

- Adds a new `githubToken: string` parameter to `list()` (placed between `configFiles` and `executor`), with a JSDoc entry explaining it's used for the failure comment. The function lives outside the action entry point, so per the repo convention it must not call `core.getInput` itself — the token is threaded through from the caller.
- Wires `comment` into the existing `executor.getExecOutput("terraform-config-inspect", ["--json"], …)` call, passing the token, the new `key: "terraform-config-inspect"`, and `vars: { tfaction_target: tfDir }` so the comment identifies which directory failed. Also adds `group: "terraform-config-inspect"` so the log output is collapsed under a labeled group in the Actions UI.
- Behavior on failure: `execAndComment` posts the comment, then re-throws (because `ignoreReturnCode` is not set), so the action still aborts — only the user feedback is new.

### `src/actions/list-targets/list-targets-with-changed-files/index.ts`

Hoists the existing `input.getRequiredGitHubToken()` call above the `listModuleCallers` invocation and threads the resulting token through. The `octokit` construction further down still uses the same `githubToken` binding, so the only effective change is ordering plus the extra argument.

## Test plan

- [x] `npm t` — 875 tests pass (48 files)
- [x] `npm run lint` — `eslint && tsc --noEmit` clean
- [x] `npm run fmt` — formatter reports no changes for the touched files
- [ ] Manual end-to-end (per `CONTRIBUTING.md` "Manual test"): push a PR branch via `pr/<n>`, introduce invalid HCL under a tracked working directory, run the workflow that invokes `list-targets-with-changed-files`, and confirm the PR receives a comment headed `:x: <dir>: Failed to resolve module dependencies` with the captured output in the collapsible block, and that the action still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)