### PR TITLE
feat(comment): mirror PR comments to GitHub Step Summary

### DIFF
--- a/src/comment/exec.ts
+++ b/src/comment/exec.ts
@@ -9,7 +9,6 @@ import {
   type ExecTemplateEntry,
   loadConfig,
   registerHelpers,
-  buildCommentBody,
   postComment,
 } from "./index";
 import type { Comment } from "../aqua/run";
@@ -141,13 +140,19 @@ export const execAndComment = async (
     };
 
     const message = renderExecTemplate(match.template, templateContext);
-    const templateKey = key;
-    const body = buildCommentBody(message, templateKey, comment.vars ?? {});
 
     const octokit = github.getOctokit(comment.token);
     const prNumber = getPRNumber(comment);
 
-    await postComment(octokit, prNumber, body, comment.org, comment.repo);
+    await postComment(
+      octokit,
+      prNumber,
+      message,
+      key,
+      comment.vars ?? {},
+      comment.org,
+      comment.repo,
+    );
   }
 
   if (exitCode !== 0 && !execOptions?.ignoreReturnCode) {

--- a/src/comment/index.ts
+++ b/src/comment/index.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as core from "@actions/core";
 import * as github from "@actions/github";
 import * as yaml from "js-yaml";
 import Handlebars from "handlebars";
@@ -96,10 +97,16 @@ export const buildCommentBody = (
 export const postComment = async (
   octokit: ReturnType<typeof github.getOctokit>,
   prNumber: number,
-  body: string,
+  message: string,
+  templateKey: string,
+  vars: Record<string, string | string[]>,
   org?: string,
   repo?: string,
 ): Promise<void> => {
+  core.summary.addRaw(message).addEOL();
+  await core.summary.write();
+
+  const body = buildCommentBody(message, templateKey, vars);
   await octokit.rest.issues.createComment({
     owner: org ?? github.context.repo.owner,
     repo: repo ?? github.context.repo.repo,
@@ -120,7 +127,11 @@ export const post = async (inputs: Inputs): Promise<void> => {
   const template = Handlebars.compile(templateConfig.template);
   const message = template({ Vars: inputs.vars });
 
-  const body = buildCommentBody(message, inputs.templateKey, inputs.vars);
-
-  await postComment(inputs.octokit, inputs.prNumber, body);
+  await postComment(
+    inputs.octokit,
+    inputs.prNumber,
+    message,
+    inputs.templateKey,
+    inputs.vars,
+  );
 };


### PR DESCRIPTION
<img width="786" height="692" alt="image" src="https://github.com/user-attachments/assets/2b9e7e36-67e0-47d4-ba2a-6442f603d94c" />

--

<img width="743" height="684" alt="image" src="https://github.com/user-attachments/assets/1c53e3ad-c9b7-4714-bd26-8f3cdb9094c6" />


## Context

`src/comment/index.ts`'s `postComment()` is the single chokepoint
through which every PR comment is posted — both the template path
(`post()`) and the command-execution path (`execAndComment()` in
`src/comment/exec.ts`) go through it.

Until now, comment content only landed on the PR. That means:

- When you open the GitHub Actions job page, you cannot see the
  result directly — you have to navigate to the PR comment.
- When no PR is associated with the run (manual `workflow_dispatch`,
  fork PR where the comment API token lacks permission, etc.) the
  comment content is lost entirely, even though it was rendered.
- When the PR comment API call itself fails, the rendered output is
  gone.

This PR mirrors the rendered comment message to
`$GITHUB_STEP_SUMMARY` so the same content always appears on the job
page regardless of PR availability or API success.

## Approach

`postComment()` becomes the single mirror point. Inside it we:

1. Write the rendered `message` (without the
   `<!-- github-comment: ... -->` metadata block) to
   `core.summary` and flush via `core.summary.write()` — this runs
   **before** `octokit.rest.issues.createComment` so the Summary
   is preserved even if the GitHub API call throws.
2. Build the full body with `buildCommentBody()` (now called inside
   `postComment` instead of by each caller) and post it to the PR as
   before. PR comment content is unchanged — metadata HTML comment
   still present for idempotency tracking.

`core.summary.write()`'s default is append (`overwrite: false`), so
when several comments are posted in the same job they accumulate in
the Step Summary in order.

## Changes

### `src/comment/index.ts`

- Import `@actions/core`.
- `postComment()` signature: `body: string` →
  `message: string, templateKey: string, vars: Record<string, string | string[]>`.
  The function now owns `buildCommentBody()` internally and writes to
  `core.summary` before posting.
- `post()` no longer calls `buildCommentBody()`; it passes
  `message` / `templateKey` / `vars` directly to `postComment()`.

### `src/comment/exec.ts`

- Drop the unused `buildCommentBody` import.
- `execAndComment()` no longer builds the body; it passes `message`
  and the matched template `key` plus `comment.vars` to
  `postComment()`.

## Behavior

- PR comment body: **unchanged** (still wrapped with the metadata
  HTML comment for `github-comment`-style deduplication).
- Step Summary: shows only the rendered `message`. The
  `<!-- github-comment: ... -->` line is intentionally excluded so
  the Summary stays clean.
- Step Summary is written even when the PR comment API call fails or
  when no actual PR is reachable.
- Multiple comments in the same job append to the Summary.

## Test plan

- [x] `npm run lint` passes
- [x] `npm t` passes (875 tests)
- [x] `npm run fmt` clean
- [ ] Manual verification via `pr/<PR number>` branch: run a workflow
      that triggers both `post()` (e.g. `tfaction-toolkit` template
      comments) and `execAndComment()` (terraform plan/apply) and
      confirm the Step Summary tab on the job page shows the same
      rendered content as the PR comments, without metadata leakage.
- [ ] Manual verification: confirm Summary still appears in a run
      where no PR is associated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)