### PR TITLE
fix(ci-info): add trailing newline to text output files

### DIFF
--- a/src/ci-info/index.test.ts
+++ b/src/ci-info/index.test.ts
@@ -156,7 +156,7 @@ describe("writeOutputFiles", () => {
       path.join(tempDir, "pr_files.txt"),
       "utf-8",
     );
-    expect(content).toBe("src/index.ts\nREADME.md");
+    expect(content).toBe("src/index.ts\nREADME.md\n");
   });
 
   it("writes pr_all_filenames.txt including previous_filename for renames", async () => {
@@ -190,7 +190,7 @@ describe("writeOutputFiles", () => {
       path.join(tempDir, "labels.txt"),
       "utf-8",
     );
-    expect(content).toBe("bug\nenhancement\nurgent");
+    expect(content).toBe("bug\nenhancement\nurgent\n");
   });
 
   it("handles empty labels array", async () => {
@@ -642,13 +642,13 @@ describe("run", () => {
       path.join(tempDir, "labels.txt"),
       "utf-8",
     );
-    expect(labelsContent).toBe("deployed");
+    expect(labelsContent).toBe("deployed\n");
 
     const filesContent = await fs.readFile(
       path.join(tempDir, "pr_files.txt"),
       "utf-8",
     );
-    expect(filesContent).toBe("file1.ts\nfile2.ts");
+    expect(filesContent).toBe("file1.ts\nfile2.ts\n");
   });
 
   it("logs info messages during execution", async () => {

--- a/src/ci-info/index.ts
+++ b/src/ci-info/index.ts
@@ -181,7 +181,7 @@ export const writeOutputFiles = async (
   );
 
   // Write pr_files.txt
-  const filenames = files.map((f) => f.filename).join("\n");
+  const filenames = files.map((f) => `${f.filename}\n`).join("");
   await fs.writeFile(path.join(dir, "pr_files.txt"), filenames);
 
   // Write pr_all_filenames.txt (including previous_filename for renames)
@@ -194,11 +194,13 @@ export const writeOutputFiles = async (
   });
   await fs.writeFile(
     path.join(dir, "pr_all_filenames.txt"),
-    Array.from(allFilenames).join("\n"),
+    Array.from(allFilenames)
+      .map((f) => `${f}\n`)
+      .join(""),
   );
 
   // Write labels.txt
-  const labels = (prData.labels || []).map((l) => l.name).join("\n");
+  const labels = (prData.labels || []).map((l) => `${l.name}\n`).join("");
   await fs.writeFile(path.join(dir, "labels.txt"), labels);
 };
 


### PR DESCRIPTION
## Summary

`writeOutputFiles` in `src/ci-info/index.ts` writes three plain-text files (`pr_files.txt`, `pr_all_filenames.txt`, `labels.txt`) using `join("\n")`, which omits the trailing newline on the last line. This violates the POSIX convention that text files end with a newline and can confuse tools that read these files line-by-line (e.g. `while read` loops in shell, line-count utilities).

This PR makes the three files end with a trailing newline when they are non-empty, while keeping empty inputs as empty files (no spurious lone newline).

## Changes

### `src/ci-info/index.ts`

- `pr_files.txt`: `files.map(f => f.filename).join("\n")` → `files.map(f => `${f.filename}\n`).join("")`
- `pr_all_filenames.txt`: same transformation applied to the `Set` of filenames (including renames' `previous_filename`).
- `labels.txt`: same transformation applied to PR label names.

The `${item}\n` + `join("")` pattern naturally preserves the existing behavior for empty arrays (still produces `""`), so empty files remain empty rather than becoming a stray `"\n"`.

### `src/ci-info/index.test.ts`

Updated four `toBe` assertions that explicitly encoded the missing trailing newline:

- `pr_files.txt` writes filenames only: `"src/index.ts\nREADME.md"` → `"src/index.ts\nREADME.md\n"`
- `labels.txt` writes label names: `"bug\nenhancement\nurgent"` → `"bug\nenhancement\nurgent\n"`
- `run` integration test, `labels.txt`: `"deployed"` → `"deployed\n"`
- `run` integration test, `pr_files.txt`: `"file1.ts\nfile2.ts"` → `"file1.ts\nfile2.ts\n"`

The empty-array cases (`expect(content).toBe("")` for empty labels/files) are unchanged — empty inputs still produce empty files.

The `pr_all_filenames.txt` rename test uses `content.split("\n").toContain(...)` and continues to pass (the split now yields an extra trailing `""`, which doesn't affect the `toContain` assertions).

## Verification

- `npm test -- src/ci-info/index.test.ts`: 30/30 pass.
- `npm run lint`: no new errors in changed files (existing 609 pre-existing issues are unrelated, in vendored/transpiled code).
- `npm run fmt`: no changes.
