### PR TITLE
fix(plan): remove duplicate outputs

### DIFF
--- a/src/actions/plan/run.ts
+++ b/src/actions/plan/run.ts
@@ -437,7 +437,6 @@ export const runTerraformPlan = async (
   core.setOutput("detailed_exitcode", detailedExitcode);
 
   core.setOutput("plan_binary", tempPlanBinary);
-  core.setOutput("plan_binary_artifact_path", tempPlanBinary); // Keep for backward compatibility
 
   // If terraform plan failed, exit immediately
   if (detailedExitcode === 1) {
@@ -477,7 +476,6 @@ export const runTerraformPlan = async (
   core.setOutput("result_summary", getResultSummary(showResult.stdout));
 
   core.setOutput("plan_json", tempPlanJson);
-  core.setOutput("plan_json_artifact_path", tempPlanJson); // Keep for backward compatibility
 
   // Upload plan files as artifact
   core.startGroup("upload plan artifacts");

--- a/website/docs/unreleased/v2-upgrade-guide.md
+++ b/website/docs/unreleased/v2-upgrade-guide.md
@@ -38,6 +38,8 @@ If it isn't, check the `TFACTION_CONFIG` environment variable in your workflow f
   - Remove SSH Key configuration
   - Add update-pr-branch action after apply action
   - Rename inputs `securefix_action_app_id` and `securefix_action_app_private_key` to `csm_app_id` and `csm_app_private_key`
+  - Rename the output `plan` action's `plan_binary_artifact_path` to `plan_binary`
+  - Rename the output `plan` action's `plan_json_artifact_path` to `plan_json`
 - tfaction-root.yaml changes
   - If `plan_workflow_name` specifies a workflow name, change it to a file name (e.g., `test` to `test.yaml`)
   - Configure `available_providers`


### PR DESCRIPTION
## ⚠️ Breaking Changes

These outputs are removed.

- plan_binary_artifact_path
- plan_json_artifact_path

### How To Migrate

Rename outputs

- plan_binary_artifact_path => plan_binary
  - e.g. `${{ steps.plan.outputs.plan_binary_artifact_path }}` => `${{ steps.plan.outputs.plan_binary }}`
- plan_json_artifact_path => plan_json
  - e.g. `${{ steps.plan.outputs.plan_json_artifact_path }}` => `${{ steps.plan.outputs.plan_json }}`