### PR TITLE
fix(update-drift-issue): normalize issue state to lowercase for comparison

### DIFF
--- a/src/actions/update-drift-issue/run.test.ts
+++ b/src/actions/update-drift-issue/run.test.ts
@@ -259,6 +259,48 @@ describe("run", () => {
     }
   });
 
+  it("closes issue when state=OPEN (uppercase) and status=success", async () => {
+    const input = createRunInput({
+      status: "success",
+      issueState: "OPEN",
+      skipTerraform: false,
+    });
+
+    await run(input);
+
+    expect(input.octokit.rest.issues.update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 42,
+      state: "closed",
+    });
+  });
+
+  it("reopens issue when state=CLOSED (uppercase) and status=failure", async () => {
+    const input = createRunInput({
+      status: "failure",
+      issueState: "CLOSED",
+    });
+    input.octokit.graphql.mockResolvedValue({
+      repository: {
+        issue: {
+          comments: {
+            nodes: [],
+          },
+        },
+      },
+    });
+
+    await run(input);
+
+    expect(input.octokit.rest.issues.update).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 42,
+      state: "open",
+    });
+  });
+
   it("both comment and reopen happen when state=closed and status=failure", async () => {
     const input = createRunInput({
       status: "failure",

--- a/src/actions/update-drift-issue/run.ts
+++ b/src/actions/update-drift-issue/run.ts
@@ -131,9 +131,11 @@ export const run = async (input: RunInput): Promise<void> => {
     await postCommentIfNeeded(input);
   }
 
+  const issueState = input.issueState?.toLowerCase();
+
   // Close the drift issue if job succeeded and terraform wasn't skipped
   if (
-    input.issueState === "open" &&
+    issueState === "open" &&
     input.status === "success" &&
     !input.skipTerraform
   ) {
@@ -142,7 +144,7 @@ export const run = async (input: RunInput): Promise<void> => {
   }
 
   // Reopen the drift issue if it was closed and job failed
-  if (input.issueState === "closed" && input.status !== "success") {
+  if (issueState === "closed" && input.status !== "success") {
     log.info("Reopening drift issue");
     await reopenIssue(input);
   }


### PR DESCRIPTION
## Summary

`update-drift-issue` was failing to close drift issues even when the job succeeded.

The root cause is a case mismatch on `TFACTION_DRIFT_ISSUE_STATE`:

- `get-or-create-drift-issue` populates `TFACTION_DRIFT_ISSUE_STATE` from the GitHub GraphQL API, whose `IssueState` enum returns uppercase values (`OPEN` / `CLOSED`).
- `set-drift-env` populates the same variable with lowercase values (`open` / `closed`).
- `update-drift-issue/run.ts` was strictly comparing the value against the lowercase literals `"open"` / `"closed"`, so the close/reopen branches were silently skipped whenever the value came from the GraphQL path.

Example failing run: drift issue stayed open with `TFACTION_DRIFT_ISSUE_STATE=OPEN` and `status=success`.

## Changes

- `src/actions/update-drift-issue/run.ts`: normalize `input.issueState` with `?.toLowerCase()` once, then compare against `"open"` / `"closed"`. This accepts values from both upstream paths without forcing a normalization at every producer.
- `src/actions/update-drift-issue/run.test.ts`: add two regression tests covering uppercase `OPEN` (closes issue) and uppercase `CLOSED` (reopens issue).

## Test plan

- [x] `npm t` — 886 tests pass, including the two new uppercase-state cases
- [x] `npm run lint` — passes
- [x] `npm run fmt` — no changes
- [ ] Manual verification on a real workflow using the `pr/<number>` branch with a `get-or-create-drift-issue` → `update-drift-issue` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)