### PR TITLE
feat(tflint): output human-readable result to log and Step Summary on failure

### DIFF
--- a/src/actions/test/tflint.test.ts
+++ b/src/actions/test/tflint.test.ts
@@ -10,6 +10,7 @@ describe("run", () => {
   const createMockLogger = (): Logger => ({
     info: vi.fn(),
     setOutput: vi.fn(),
+    writeSummary: vi.fn().mockResolvedValue(undefined),
   });
 
   // Empty SARIF output (no results)
@@ -596,6 +597,218 @@ describe("run", () => {
       expect.objectContaining({
         githubToken: "fix-token",
       }),
+    );
+  });
+
+  it("re-runs tflint without --format and writes step summary preserving stdout/stderr order when exit code is non-zero", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({ stdout: "--call-module-type", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: emptySarifOutput,
+        stderr: "",
+        exitCode: 2,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec
+      .mockResolvedValueOnce(0) // tflint --init
+      .mockImplementationOnce((_cmd, _args, options) => {
+        options?.listeners?.stdout?.(Buffer.from("line-stdout-1\n"));
+        options?.listeners?.stderr?.(Buffer.from("line-stderr-1\n"));
+        options?.listeners?.stdout?.(Buffer.from("line-stdout-2\n"));
+        return Promise.resolve(2);
+      })
+      .mockResolvedValueOnce(0); // reviewdog
+
+    const logger = createMockLogger();
+    const input = createMockInput({
+      executor: executor as unknown as RunInput["executor"],
+      logger,
+    });
+
+    await run(input);
+
+    expect(executor.exec).toHaveBeenCalledWith(
+      "tflint",
+      ["--call-module-type=all"],
+      expect.objectContaining({ group: "tflint (human-readable)" }),
+    );
+    expect(logger.writeSummary).toHaveBeenCalledTimes(1);
+    const summaryArg = vi.mocked(logger.writeSummary).mock.calls[0][0];
+    expect(summaryArg).toContain("<details>");
+    expect(summaryArg).toContain("line-stdout-1\nline-stderr-1\nline-stdout-2");
+  });
+
+  it("does not re-run tflint when exit code is zero", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({ stdout: "--call-module-type", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: emptySarifOutput,
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec.mockResolvedValue(0);
+
+    const logger = createMockLogger();
+    const input = createMockInput({
+      executor: executor as unknown as RunInput["executor"],
+      logger,
+    });
+
+    await run(input);
+
+    expect(executor.exec).not.toHaveBeenCalledWith(
+      "tflint",
+      ["--call-module-type=all"],
+      expect.objectContaining({ group: "tflint (human-readable)" }),
+    );
+    expect(logger.writeSummary).not.toHaveBeenCalled();
+  });
+
+  it("does not write step summary when re-run output is empty", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({ stdout: "--call-module-type", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: emptySarifOutput,
+        stderr: "",
+        exitCode: 2,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec
+      .mockResolvedValueOnce(0) // tflint --init
+      .mockResolvedValueOnce(2) // re-run: no listener calls = empty
+      .mockResolvedValueOnce(0); // reviewdog
+
+    const logger = createMockLogger();
+    const input = createMockInput({
+      executor: executor as unknown as RunInput["executor"],
+      logger,
+    });
+
+    await run(input);
+
+    expect(logger.writeSummary).not.toHaveBeenCalled();
+  });
+
+  it("does not re-run tflint when fix is true and changes are committed", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({ stdout: "--call-module-type", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: sarifOutputWithFile("main.tf"),
+        stderr: "",
+        exitCode: 2,
+      });
+    executor.exec.mockResolvedValue(0);
+
+    const createCommit = vi.fn().mockResolvedValue("");
+    const checkGitDiff = vi.fn().mockResolvedValue({
+      changedFiles: ["main.tf"],
+    });
+    const logger = createMockLogger();
+
+    const input = createMockInput({
+      executor: executor as unknown as RunInput["executor"],
+      fix: true,
+      createCommit,
+      checkGitDiff,
+      logger,
+    });
+
+    await expect(run(input)).rejects.toThrow("code is fixed by tflint --fix");
+
+    expect(logger.writeSummary).not.toHaveBeenCalled();
+    expect(executor.exec).not.toHaveBeenCalledWith(
+      "tflint",
+      ["--call-module-type=all"],
+      expect.objectContaining({ group: "tflint (human-readable)" }),
+    );
+  });
+
+  it("re-runs tflint when fix is true but no files changed and exit code is non-zero", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({ stdout: "--call-module-type", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: sarifOutputWithFile("main.tf"),
+        stderr: "",
+        exitCode: 2,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec
+      .mockResolvedValueOnce(0)
+      .mockImplementationOnce((_cmd, _args, options) => {
+        options?.listeners?.stdout?.(Buffer.from("1 issue found"));
+        return Promise.resolve(2);
+      })
+      .mockResolvedValueOnce(0);
+
+    const checkGitDiff = vi.fn().mockResolvedValue({ changedFiles: [] });
+    const logger = createMockLogger();
+
+    const input = createMockInput({
+      executor: executor as unknown as RunInput["executor"],
+      fix: true,
+      checkGitDiff,
+      logger,
+    });
+
+    await run(input);
+
+    expect(logger.writeSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses --module in re-run when tflint does not support --call-module-type", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({ stdout: "Usage: tflint [OPTIONS]", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: emptySarifOutput,
+        stderr: "",
+        exitCode: 2,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec
+      .mockResolvedValueOnce(0)
+      .mockImplementationOnce((_cmd, _args, options) => {
+        options?.listeners?.stdout?.(Buffer.from("issue"));
+        return Promise.resolve(2);
+      })
+      .mockResolvedValueOnce(0);
+
+    const input = createMockInput({
+      executor: executor as unknown as RunInput["executor"],
+    });
+
+    await run(input);
+
+    expect(executor.exec).toHaveBeenCalledWith(
+      "tflint",
+      ["--module"],
+      expect.objectContaining({ group: "tflint (human-readable)" }),
     );
   });
 

--- a/src/actions/test/tflint.ts
+++ b/src/actions/test/tflint.ts
@@ -10,6 +10,7 @@ import { listFiles } from "./sarif";
 export type Logger = {
   info: (message: string) => void;
   setOutput: (name: string, value: string) => void;
+  writeSummary: (content: string) => Promise<void>;
 };
 
 export type CommitCreator = (params: {
@@ -56,7 +57,14 @@ export const run = async (input: RunInput): Promise<void> => {
   const githubTokenForFix = input.githubTokenForFix || input.githubToken;
   const executor = input.executor;
   const eventName = input.eventName ?? github.context.eventName;
-  const logger = input.logger ?? { info: core.info, setOutput: core.setOutput };
+  const logger = input.logger ?? {
+    info: core.info,
+    setOutput: core.setOutput,
+    writeSummary: async (content: string) => {
+      core.summary.addRaw(content);
+      await core.summary.write();
+    },
+  };
   const createCommit = input.createCommit ?? defaultCreateCommit;
   const checkGitDiff = input.checkGitDiff ?? defaultCheckGitDiff;
 
@@ -68,22 +76,24 @@ export const run = async (input: RunInput): Promise<void> => {
     },
   });
 
-  const args = ["--format", "sarif"];
+  const commonArgs: string[] = [];
 
   const help = await executor.getExecOutput("tflint", ["--help"], {
     cwd: input.workingDirectory,
     silent: true,
   });
   if (help.stdout.includes("--call-module-type")) {
-    args.push("--call-module-type=all");
+    commonArgs.push("--call-module-type=all");
   } else {
-    args.push("--module");
-  }
-  if (input.fix) {
-    args.push("--fix");
+    commonArgs.push("--module");
   }
 
-  const out = await executor.getExecOutput("tflint", args, {
+  const sarifArgs = ["--format", "sarif", ...commonArgs];
+  if (input.fix) {
+    sarifArgs.push("--fix");
+  }
+
+  const out = await executor.getExecOutput("tflint", sarifArgs, {
     cwd: input.workingDirectory,
     group: "tflint",
     ignoreReturnCode: true,
@@ -108,6 +118,29 @@ export const run = async (input: RunInput): Promise<void> => {
         appPrivateKey: input.csmAppPrivateKey,
       });
       throw new Error("code is fixed by tflint --fix");
+    }
+  }
+
+  if (out.exitCode !== 0) {
+    let combined = "";
+    await executor.exec("tflint", commonArgs, {
+      cwd: input.workingDirectory,
+      group: "tflint (human-readable)",
+      ignoreReturnCode: true,
+      listeners: {
+        stdout: (data: Buffer) => {
+          combined += data.toString();
+        },
+        stderr: (data: Buffer) => {
+          combined += data.toString();
+        },
+      },
+    });
+    const body = combined.trim();
+    if (body.length > 0) {
+      await logger.writeSummary(
+        `<details><summary>tflint</summary>\n\n\`\`\`\n${body}\n\`\`\`\n\n</details>\n`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

When `tflint --format sarif` exits non-zero, log readers currently see a SARIF JSON dump in the workflow log, which is hard to scan. This PR makes failures readable while keeping reviewdog driven by SARIF.

- On a non-zero exit from `tflint --format sarif`, run tflint a second time **without** `--format` so it prints in its default human-readable form.
- Capture stdout and stderr in arrival order via `@actions/exec` listeners (a single accumulating string) so the original interleaving is preserved.
- Write the captured output to the GitHub Actions Step Summary inside a collapsible `<details>` block, fenced as a code block.
- The second run is wrapped in a `tflint (human-readable)` log group so it is collapsible in the Actions log too.
- The original SARIF run still feeds reviewdog — review comments and fail-level behavior are unchanged.

## Test

https://github.com/szksh-lab/tfaction-test/actions/runs/26204552154?pr=35

<img width="1178" height="513" alt="image" src="https://github.com/user-attachments/assets/ddbc204a-6f21-4cda-b04e-abe283c031b9" />

## Behavior details

- The second run is **only** performed when the first run's exit code is non-zero. On a clean tflint exit, nothing extra runs.
- In `--fix` mode:
  - If no SARIF results are reported, behavior is unchanged (early return).
  - If files were modified and a fix commit is created, the existing `throw` happens **before** the readable re-run — the commit message already conveys the result, so no extra output is produced.
  - If violations exist but tflint couldn't fix any of them (no git diff), the readable re-run executes before reviewdog.
- The shared common args (`--call-module-type=all` vs `--module`, decided once from `tflint --help`) are reused for both runs to keep them consistent.
- ANSI color codes from tflint are passed through as-is for now. If this turns out to break Step Summary rendering, we'll strip ANSI / set `NO_COLOR=1` as a follow-up.

## Implementation notes

- `Logger` gains a `writeSummary(content: string): Promise<void>` method. The default implementation calls `core.summary.addRaw(content).write()`; tests inject a `vi.fn()`.
- The re-run uses `executor.exec` (not `getExecOutput`) with `listeners.stdout` / `listeners.stderr` writing into a single combined buffer. `getExecOutput` returns stdout and stderr as separate strings, which would lose the chronological order between the two streams.

## Files

- `src/actions/test/tflint.ts` — re-run logic, shared `commonArgs`, extended `Logger` default.
- `src/actions/test/tflint.test.ts` — `writeSummary` added to the mock logger; 6 new tests covering: re-run + summary on failure, no re-run on success, empty re-run output, fix-with-commit skips re-run, fix-with-no-diff triggers re-run, `--module` fallback path.

## Test plan

- [x] `npm t` (50 files / 892 tests passed)
- [x] `npm run lint` (eslint + tsc --noEmit)
- [x] `npm run fmt`
- [ ] Manual: build a `pr/<num>` workflow that intentionally has a tflint violation and confirm the Step Summary renders the readable output, and the SARIF reviewdog comment still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)