### PR TITLE
feat(trivy): output human-readable result to log and Step Summary on failure

### DIFF
--- a/src/actions/test/trivy.test.ts
+++ b/src/actions/test/trivy.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { run, type RunInput } from "./trivy";
+import { run, type Logger, type RunInput } from "./trivy";
 import type { Config } from "../../lib/types";
 
 describe("run", () => {
   const createMockExecutor = () => ({
     getExecOutput: vi.fn(),
     exec: vi.fn(),
+  });
+
+  const createMockLogger = (): Logger => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    writeSummary: vi.fn().mockResolvedValue(undefined),
   });
 
   const createMockConfig = (overrides?: Partial<Config>): Config => ({
@@ -535,6 +541,170 @@ describe("run", () => {
       "reviewdog",
       expect.arrayContaining(["-f", "sarif"]),
       expect.any(Object),
+    );
+  });
+
+  it("re-runs trivy without --format, calls logger.error, and writes step summary preserving stdout/stderr order when exit code is non-zero", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ Results: [] }),
+        stderr: "",
+        exitCode: 1,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec
+      .mockImplementationOnce((_cmd, _args, options) => {
+        options?.listeners?.stdout?.(Buffer.from("line-stdout-1\n"));
+        options?.listeners?.stderr?.(Buffer.from("line-stderr-1\n"));
+        options?.listeners?.stdout?.(Buffer.from("line-stdout-2\n"));
+        return Promise.resolve(1);
+      })
+      .mockResolvedValueOnce(0); // reviewdog
+
+    const logger = createMockLogger();
+    const input: RunInput = {
+      executor: executor as unknown as RunInput["executor"],
+      workingDirectory: "/work",
+      githubToken: "token",
+      configPath: "",
+      trivy: { enabled: true },
+      eventName: "pull_request",
+      logger,
+    };
+
+    await expect(run(input)).rejects.toThrow("trivy failed");
+
+    expect(executor.exec).toHaveBeenCalledWith(
+      "trivy",
+      ["config", "."],
+      expect.objectContaining({
+        cwd: "/work",
+        ignoreReturnCode: true,
+      }),
+    );
+    // Re-run must NOT be wrapped in a log group.
+    const trivyReRunCall = executor.exec.mock.calls.find(
+      (call) => call[0] === "trivy",
+    );
+    expect(trivyReRunCall?.[2]).not.toHaveProperty("group");
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith("trivy failed");
+
+    expect(logger.writeSummary).toHaveBeenCalledTimes(1);
+    const summaryArg = vi.mocked(logger.writeSummary).mock.calls[0][0];
+    expect(summaryArg).toContain("## trivy");
+    expect(summaryArg).toContain("line-stdout-1\nline-stderr-1\nline-stdout-2");
+    expect(summaryArg).not.toContain("<details>");
+  });
+
+  it("does not re-run trivy or call logger.error when exit code is zero", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ Results: [] }),
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec.mockResolvedValue(0);
+
+    const logger = createMockLogger();
+    const input: RunInput = {
+      executor: executor as unknown as RunInput["executor"],
+      workingDirectory: "/work",
+      githubToken: "token",
+      configPath: "",
+      trivy: { enabled: true },
+      eventName: "pull_request",
+      logger,
+    };
+
+    await run(input);
+
+    const trivyReRunCall = executor.exec.mock.calls.find(
+      (call) => call[0] === "trivy",
+    );
+    expect(trivyReRunCall).toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.writeSummary).not.toHaveBeenCalled();
+  });
+
+  it("does not write step summary when re-run output is empty", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ Results: [] }),
+        stderr: "",
+        exitCode: 1,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec
+      .mockResolvedValueOnce(1) // re-run: no listener calls = empty
+      .mockResolvedValueOnce(0); // reviewdog
+
+    const logger = createMockLogger();
+    const input: RunInput = {
+      executor: executor as unknown as RunInput["executor"],
+      workingDirectory: "/work",
+      githubToken: "token",
+      configPath: "",
+      trivy: { enabled: true },
+      eventName: "pull_request",
+      logger,
+    };
+
+    await expect(run(input)).rejects.toThrow("trivy failed");
+
+    expect(logger.error).toHaveBeenCalledWith("trivy failed");
+    expect(logger.writeSummary).not.toHaveBeenCalled();
+  });
+
+  it("passes --config in re-run when configPath is provided", async () => {
+    const executor = createMockExecutor();
+    executor.getExecOutput
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ Results: [] }),
+        stderr: "",
+        exitCode: 1,
+      })
+      .mockResolvedValueOnce({
+        stdout: "-fail-level",
+        stderr: "",
+        exitCode: 0,
+      });
+    executor.exec.mockResolvedValue(1);
+
+    const logger = createMockLogger();
+    const input: RunInput = {
+      executor: executor as unknown as RunInput["executor"],
+      workingDirectory: "/work",
+      githubToken: "token",
+      configPath: "/path/to/trivy.yaml",
+      trivy: { enabled: true },
+      eventName: "pull_request",
+      logger,
+    };
+
+    await expect(run(input)).rejects.toThrow("trivy failed");
+
+    expect(executor.exec).toHaveBeenCalledWith(
+      "trivy",
+      ["config", "--config", "/path/to/trivy.yaml", "."],
+      expect.objectContaining({ cwd: "/work" }),
     );
   });
 

--- a/src/actions/test/trivy.test.ts
+++ b/src/actions/test/trivy.test.ts
@@ -156,7 +156,16 @@ describe("run", () => {
 
     expect(executor.getExecOutput).toHaveBeenCalledWith(
       "trivy",
-      ["config", "--format", "sarif", "--config", "/path/to/trivy.yaml", "."],
+      [
+        "config",
+        "--format",
+        "sarif",
+        "--exit-code",
+        "1",
+        "--config",
+        "/path/to/trivy.yaml",
+        ".",
+      ],
       expect.any(Object),
     );
   });
@@ -190,7 +199,7 @@ describe("run", () => {
 
     expect(executor.getExecOutput).toHaveBeenCalledWith(
       "trivy",
-      ["config", "--format", "sarif", "."],
+      ["config", "--format", "sarif", "--exit-code", "1", "."],
       expect.any(Object),
     );
   });
@@ -581,7 +590,7 @@ describe("run", () => {
 
     expect(executor.exec).toHaveBeenCalledWith(
       "trivy",
-      ["config", "."],
+      ["config", "--exit-code", "1", "."],
       expect.objectContaining({
         cwd: "/work",
         ignoreReturnCode: true,
@@ -703,7 +712,7 @@ describe("run", () => {
 
     expect(executor.exec).toHaveBeenCalledWith(
       "trivy",
-      ["config", "--config", "/path/to/trivy.yaml", "."],
+      ["config", "--exit-code", "1", "--config", "/path/to/trivy.yaml", "."],
       expect.objectContaining({ cwd: "/work" }),
     );
   });

--- a/src/actions/test/trivy.ts
+++ b/src/actions/test/trivy.ts
@@ -33,8 +33,16 @@ export const run = async (input: RunInput): Promise<void> => {
   };
 
   const configFlags = input.configPath ? ["--config", input.configPath] : [];
-  const sarifArgs = ["config", "--format", "sarif", ...configFlags, "."];
-  const humanArgs = ["config", ...configFlags, "."];
+  const sarifArgs = [
+    "config",
+    "--format",
+    "sarif",
+    "--exit-code",
+    "1",
+    ...configFlags,
+    ".",
+  ];
+  const humanArgs = ["config", "--exit-code", "1", ...configFlags, "."];
 
   const out = await executor.getExecOutput("trivy", sarifArgs, {
     cwd: input.workingDirectory,

--- a/src/actions/test/trivy.ts
+++ b/src/actions/test/trivy.ts
@@ -1,3 +1,4 @@
+import * as core from "@actions/core";
 import * as github from "@actions/github";
 
 import * as aqua from "../../aqua";
@@ -5,6 +6,8 @@ import * as types from "../../lib/types";
 
 export type Logger = {
   info: (message: string) => void;
+  error: (message: string) => void;
+  writeSummary: (content: string) => Promise<void>;
 };
 
 export type RunInput = {
@@ -14,19 +17,51 @@ export type RunInput = {
   configPath: string;
   trivy?: types.TrivyConfig;
   eventName?: string;
+  logger?: Logger;
 };
 
 export const run = async (input: RunInput): Promise<void> => {
-  const args = input.configPath
-    ? ["config", "--format", "sarif", "--config", input.configPath, "."]
-    : ["config", "--format", "sarif", "."];
   const executor = input.executor;
   const eventName = input.eventName ?? github.context.eventName;
-  const out = await executor.getExecOutput("trivy", args, {
+  const logger = input.logger ?? {
+    info: core.info,
+    error: core.error,
+    writeSummary: async (content: string) => {
+      core.summary.addRaw(content);
+      await core.summary.write();
+    },
+  };
+
+  const configFlags = input.configPath ? ["--config", input.configPath] : [];
+  const sarifArgs = ["config", "--format", "sarif", ...configFlags, "."];
+  const humanArgs = ["config", ...configFlags, "."];
+
+  const out = await executor.getExecOutput("trivy", sarifArgs, {
     cwd: input.workingDirectory,
     ignoreReturnCode: true,
     group: "trivy",
   });
+
+  if (out.exitCode !== 0) {
+    logger.error("trivy failed");
+    let combined = "";
+    await executor.exec("trivy", humanArgs, {
+      cwd: input.workingDirectory,
+      ignoreReturnCode: true,
+      listeners: {
+        stdout: (data: Buffer) => {
+          combined += data.toString();
+        },
+        stderr: (data: Buffer) => {
+          combined += data.toString();
+        },
+      },
+    });
+    const body = combined.trim();
+    if (body.length > 0) {
+      await logger.writeSummary(`## trivy\n\n\`\`\`\n${body}\n\`\`\`\n`);
+    }
+  }
 
   const filterMode = input.trivy?.reviewdog?.filter_mode ?? "nofilter";
 

--- a/src/aqua/index.ts
+++ b/src/aqua/index.ts
@@ -177,6 +177,7 @@ export class Executor {
     const envVars = this.env(options);
     try {
       if (options?.group) {
+        console.log("");
         core.startGroup(options.group);
       }
       if (options?.comment) {
@@ -194,6 +195,7 @@ export class Executor {
       });
     } finally {
       if (options?.group) {
+        console.log("");
         core.endGroup();
       }
     }


### PR DESCRIPTION
## Summary

When `trivy config --format sarif` exits non-zero, the Actions log currently shows only a SARIF JSON dump, which is hard for humans to scan. This PR mirrors the approach from #3968 (tflint) for trivy, with one deliberate deviation: because this is **error output**, the human-readable re-run is not hidden inside a collapsed log group, and the Step Summary content is not wrapped in `<details>` — the failure must be visible by default.

This PR also includes a small fix in `src/aqua/index.ts` to print a blank line around `core.startGroup` / `core.endGroup` boundaries, so that groups are not broken when the preceding output didn't end in a newline.

## Example

https://github.com/szksh-lab/tfaction-test/actions/runs/26227281171?pr=35

<img width="1194" height="986" alt="image" src="https://github.com/user-attachments/assets/fc1654f3-8269-4f51-913c-cdf5da29330c" />

<img width="1163" height="670" alt="image" src="https://github.com/user-attachments/assets/419d8f8c-27e5-46f4-af51-4f6d3f9dffc8" />


## Changes

### `src/actions/test/trivy.ts`

- Extend `Logger` with `error(message: string): void` and `writeSummary(content: string): Promise<void>`.
- Add `logger?: Logger` to `RunInput`. The default logger uses `core.info`, `core.error`, and `core.summary.addRaw(...).write()`.
- Split args into `sarifArgs = ["config", "--format", "sarif", ...configFlags, "."]` and `humanArgs = ["config", ...configFlags, "."]`, where `configFlags` is `["--config", input.configPath]` when configured.
- On non-zero exit from the SARIF run:
  - Emit a GitHub Actions error annotation via `logger.error(\"trivy failed\")` so the failure shows up at the top of the job page **before** reviewdog runs.
  - Re-run trivy with `humanArgs` (no `--format sarif`), capturing stdout and stderr into a single accumulating string via `executor.exec` listeners so the original interleaving is preserved.
  - If the combined output is non-empty, write it to the Step Summary as a `## trivy` heading + fenced code block.
- The existing reviewdog call and the final `throw new Error(\"trivy failed\")` are unchanged — the re-run sits between them.

### Deliberate deviations from #3968 (tflint)

- **No `group:` option on the re-run.** The human-readable output prints inline in the Actions log, not inside a collapsed group. Errors should be visible from the first glance, not behind a click.
- **No `<details>` wrapper in Step Summary.** Same reasoning — the section uses a `## trivy` heading + fenced code block so it renders expanded by default.
- **`core.error(\"trivy failed\")` is emitted before the re-run.** The trailing `throw new Error(\"trivy failed\")` already surfaces the failure, but only after reviewdog has run; the annotation makes the failure visible immediately at the top of the job page.

### `src/actions/test/trivy.test.ts`

- Add `createMockLogger` helper with `info`, `error`, and `writeSummary` mocks.
- 4 new tests:
  1. Re-runs trivy without `--format`, calls `logger.error(\"trivy failed\")`, and writes a step summary preserving stdout/stderr arrival order; the summary contains the combined output inside a fenced code block, and **does not** contain `<details>`; the re-run's exec options do **not** have a `group` key.
  2. Does not re-run trivy and does not call `logger.error` / `logger.writeSummary` when exit code is zero.
  3. Does not write step summary when the re-run output is empty (but `logger.error` is still called because the failure happened).
  4. Re-run passes `--config` when `configPath` is provided: `executor.exec` is called with `[\"config\", \"--config\", \"/path/to/trivy.yaml\", \".\"]`.

### `src/aqua/index.ts`

- In `Executor.exec`, emit `console.log(\"\")` (a blank line) immediately before `core.startGroup(...)` and immediately before `core.endGroup()`. This prevents broken groups when the preceding output didn't end in a newline.

## Implementation notes

- The re-run uses `executor.exec` (not `getExecOutput`) with `listeners.stdout` / `listeners.stderr` writing into a single combined buffer. `getExecOutput` returns stdout and stderr as separate strings, which would lose the chronological order between the two streams.
- `ignoreReturnCode: true` is set on the re-run so a non-zero re-run exit doesn't throw — we still want reviewdog to run and the final `throw new Error(\"trivy failed\")` to be the single failure path.

## Behavior details

- The re-run is **only** performed when the first run's exit code is non-zero. On a clean trivy exit, nothing extra runs and no error annotation is emitted.
- The existing reviewdog behavior (filter mode, fail level, reporter selection) is unchanged.
- The final \`throw new Error(\"trivy failed\")\` is unchanged, so the job still fails as before.

## Test plan

- [x] \`npm t\` — 50 files / 896 tests passed (was 892; +4 new tests)
- [x] \`npm run lint\` — eslint + tsc --noEmit clean
- [x] \`npm run fmt\` — formatting clean
- [ ] Manual: push to a \`pr/<num>\` branch with a workflow that triggers a trivy misconfiguration, then confirm:
  - A \`trivy failed\` error annotation appears at the top of the job page.
  - The Actions log shows the readable trivy output inline (not inside a collapsed group).
  - The job's Step Summary contains a \`## trivy\` section with the readable output in a fenced code block, expanded by default.
  - reviewdog still posts SARIF-driven review comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)