### PR TITLE
fix(tflint): make failure output visible by default

### DIFF
--- a/src/actions/test/tflint.test.ts
+++ b/src/actions/test/tflint.test.ts
@@ -9,6 +9,7 @@ describe("run", () => {
 
   const createMockLogger = (): Logger => ({
     info: vi.fn(),
+    error: vi.fn(),
     setOutput: vi.fn(),
     writeSummary: vi.fn().mockResolvedValue(undefined),
   });
@@ -632,14 +633,21 @@ describe("run", () => {
 
     await run(input);
 
-    expect(executor.exec).toHaveBeenCalledWith(
-      "tflint",
-      ["--call-module-type=all"],
-      expect.objectContaining({ group: "tflint (human-readable)" }),
+    const reRunCall = executor.exec.mock.calls.find(
+      (call) =>
+        call[0] === "tflint" &&
+        Array.isArray(call[1]) &&
+        call[1].length === 1 &&
+        call[1][0] === "--call-module-type=all",
     );
+    expect(reRunCall).toBeDefined();
+    expect(reRunCall?.[2]).not.toHaveProperty("group");
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith("tflint failed");
     expect(logger.writeSummary).toHaveBeenCalledTimes(1);
     const summaryArg = vi.mocked(logger.writeSummary).mock.calls[0][0];
-    expect(summaryArg).toContain("<details>");
+    expect(summaryArg).toContain("## tflint");
+    expect(summaryArg).not.toContain("<details>");
     expect(summaryArg).toContain("line-stdout-1\nline-stderr-1\nline-stdout-2");
   });
 
@@ -667,11 +675,15 @@ describe("run", () => {
 
     await run(input);
 
-    expect(executor.exec).not.toHaveBeenCalledWith(
-      "tflint",
-      ["--call-module-type=all"],
-      expect.objectContaining({ group: "tflint (human-readable)" }),
+    const reRunCall = executor.exec.mock.calls.find(
+      (call) =>
+        call[0] === "tflint" &&
+        Array.isArray(call[1]) &&
+        call[1].length === 1 &&
+        call[1][0] === "--call-module-type=all",
     );
+    expect(reRunCall).toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
     expect(logger.writeSummary).not.toHaveBeenCalled();
   });
 
@@ -702,6 +714,7 @@ describe("run", () => {
 
     await run(input);
 
+    expect(logger.error).toHaveBeenCalledWith("tflint failed");
     expect(logger.writeSummary).not.toHaveBeenCalled();
   });
 
@@ -732,12 +745,16 @@ describe("run", () => {
 
     await expect(run(input)).rejects.toThrow("code is fixed by tflint --fix");
 
+    expect(logger.error).not.toHaveBeenCalled();
     expect(logger.writeSummary).not.toHaveBeenCalled();
-    expect(executor.exec).not.toHaveBeenCalledWith(
-      "tflint",
-      ["--call-module-type=all"],
-      expect.objectContaining({ group: "tflint (human-readable)" }),
+    const reRunCall = executor.exec.mock.calls.find(
+      (call) =>
+        call[0] === "tflint" &&
+        Array.isArray(call[1]) &&
+        call[1].length === 1 &&
+        call[1][0] === "--call-module-type=all",
     );
+    expect(reRunCall).toBeUndefined();
   });
 
   it("re-runs tflint when fix is true but no files changed and exit code is non-zero", async () => {
@@ -808,7 +825,7 @@ describe("run", () => {
     expect(executor.exec).toHaveBeenCalledWith(
       "tflint",
       ["--module"],
-      expect.objectContaining({ group: "tflint (human-readable)" }),
+      expect.objectContaining({ ignoreReturnCode: true }),
     );
   });
 

--- a/src/actions/test/tflint.ts
+++ b/src/actions/test/tflint.ts
@@ -9,6 +9,7 @@ import { listFiles } from "./sarif";
 
 export type Logger = {
   info: (message: string) => void;
+  error: (message: string) => void;
   setOutput: (name: string, value: string) => void;
   writeSummary: (content: string) => Promise<void>;
 };
@@ -59,6 +60,7 @@ export const run = async (input: RunInput): Promise<void> => {
   const eventName = input.eventName ?? github.context.eventName;
   const logger = input.logger ?? {
     info: core.info,
+    error: core.error,
     setOutput: core.setOutput,
     writeSummary: async (content: string) => {
       core.summary.addRaw(content);
@@ -122,10 +124,10 @@ export const run = async (input: RunInput): Promise<void> => {
   }
 
   if (out.exitCode !== 0) {
+    logger.error("tflint failed");
     let combined = "";
     await executor.exec("tflint", commonArgs, {
       cwd: input.workingDirectory,
-      group: "tflint (human-readable)",
       ignoreReturnCode: true,
       listeners: {
         stdout: (data: Buffer) => {
@@ -138,9 +140,7 @@ export const run = async (input: RunInput): Promise<void> => {
     });
     const body = combined.trim();
     if (body.length > 0) {
-      await logger.writeSummary(
-        `<details><summary>tflint</summary>\n\n\`\`\`\n${body}\n\`\`\`\n\n</details>\n`,
-      );
+      await logger.writeSummary(`## tflint\n\n\`\`\`\n${body}\n\`\`\`\n`);
     }
   }
 


### PR DESCRIPTION
## Summary

Align the tflint failure path with the trivy pattern landed in #3970, so that tflint failures are visible at a glance instead of hidden behind a click. Error output should be displayed by default — collapsing it defeats the purpose of the human-readable re-run added by #3968.

## Background

#3968 added a second tflint run (without `--format sarif`) on non-zero exit, so log readers don't have to scan a SARIF JSON dump. That re-run was wrapped in a `tflint (human-readable)` log group, and its captured output was written to the GitHub Step Summary inside `<details><summary>tflint</summary>…</details>`.

#3970 changed the equivalent code path for `trivy`:

- Re-run prints **inline** in the Actions log (no `group:`).
- Step Summary uses `## trivy` + fenced code block (no `<details>`).
- A `core.error(\"trivy failed\")` annotation is emitted right before the re-run, so the failure surfaces at the top of the job page before reviewdog runs.

This PR brings tflint to the same shape.

## Changes

### `src/actions/test/tflint.ts`

- Add `error: (message: string) => void` to the `Logger` type, alongside the existing `info`, `setOutput`, and `writeSummary` fields.
- Add `error: core.error` to the default logger constructed inside `run`. The default still falls back to `@actions/core` for all four methods.
- In the non-zero-exit block (the existing human-readable re-run):
  - Emit `logger.error(\"tflint failed\")` as the first statement, before the re-run executes. This produces a GitHub Actions error annotation visible at the top of the job page.
  - Drop the `group: \"tflint (human-readable)\"` option on the `executor.exec` re-run call. The readable output now prints inline in the Actions log instead of inside a collapsed group.
  - Replace the Step Summary template:
    - **Before:** \`<details><summary>tflint</summary>\\n\\n\\\`\\\`\\\`\\n\${body}\\n\\\`\\\`\\\`\\n\\n</details>\\n\`
    - **After:** \`## tflint\\n\\n\\\`\\\`\\\`\\n\${body}\\n\\\`\\\`\\\`\\n\`
  - Both formats keep the captured stdout/stderr content; only the wrapping changes from a collapsed `<details>` block to a top-level heading + fenced code block.

No other code paths are touched. The `--init` call, the help-derived `commonArgs` resolution (`--call-module-type=all` vs `--module`), the `--fix` flow (early return / commit-and-throw), and the reviewdog invocation remain exactly as before.

### `src/actions/test/tflint.test.ts`

- Add `error: vi.fn()` to `createMockLogger` so the new `Logger.error` field is satisfied at type-check and call sites.
- Update the four existing re-run-related tests that previously relied on `group: \"tflint (human-readable)\"` or `<details>`:
  1. **`re-runs tflint without --format and writes step summary preserving stdout/stderr order when exit code is non-zero`**
     - Find the re-run call by scanning `executor.exec.mock.calls` for one whose args are exactly `[\"--call-module-type=all\"]`.
     - Assert the re-run call's options object **does not** have a `group` property.
     - Assert `logger.error` was called exactly once with `\"tflint failed\"`.
     - Replace `expect(summaryArg).toContain(\"<details>\")` with `expect(summaryArg).toContain(\"## tflint\")` plus `expect(summaryArg).not.toContain(\"<details>\")`.
  2. **`does not re-run tflint when exit code is zero`**
     - Replace the `not.toHaveBeenCalledWith(... group: \"tflint (human-readable)\")` assertion with a scan-then-assert-undefined check on `executor.exec.mock.calls` for the re-run args shape.
     - Add `expect(logger.error).not.toHaveBeenCalled()`.
  3. **`does not write step summary when re-run output is empty`**
     - Add `expect(logger.error).toHaveBeenCalledWith(\"tflint failed\")` to make explicit that the error annotation still fires when the captured body is empty (only the summary write is skipped).
  4. **`does not re-run tflint when fix is true and changes are committed`**
     - Same fix as #2: drop the `group:` assertion, scan-and-assert-undefined for the re-run args, add `expect(logger.error).not.toHaveBeenCalled()`.
  5. **`uses --module in re-run when tflint does not support --call-module-type`**
     - Replace `expect.objectContaining({ group: \"tflint (human-readable)\" })` with `expect.objectContaining({ ignoreReturnCode: true })`. The `ignoreReturnCode` flag is a stable property of the re-run call options that distinguishes it from the `--init` call.

No new tests were added — the existing six re-run / failure-path tests already cover the relevant branches; this PR only changes their assertions to match the new behavior.

## Behavior summary

| Scenario | Before (#3968) | After (this PR) |
|---|---|---|
| tflint exit 0 | nothing extra runs | unchanged |
| tflint exit ≠ 0, `--fix` commits a change | `throw` before re-run | unchanged |
| tflint exit ≠ 0, no fix or no diff | re-run inside collapsed `tflint (human-readable)` group, Step Summary in `<details>` | `core.error(\"tflint failed\")` annotation; re-run prints **inline**; Step Summary `## tflint` heading + fenced code block, expanded by default |
| reviewdog driving review comments / fail-level | unchanged | unchanged |
| Final `throw new Error(...)` after reviewdog | unchanged | unchanged |

## Test plan

- [x] `npm t` — 50 files / 896 tests pass (no count change; this PR adjusts existing test assertions, no new tests added)
- [x] `npm run lint` — eslint + `tsc --noEmit` clean
- [x] `npm run fmt`
- [ ] Manual: push a `pr/<num>` branch with a target that has a tflint violation, then confirm:
  - The job page shows a `tflint failed` error annotation at the top.
  - The Actions log shows the readable tflint output **inline** (not inside a collapsed `tflint (human-readable)` group).
  - The Step Summary contains a `## tflint` section, expanded by default (no `<details>`).
  - reviewdog still posts SARIF-driven review comments and fail-level behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)