### PR TITLE
feat(plan): mirror tfcmt plan result to GitHub Actions Step Summary

### DIFF
--- a/src/actions/plan/index.ts
+++ b/src/actions/plan/index.ts
@@ -37,6 +37,7 @@ export const main = async () => {
     ciInfoTempDir: env.all.CI_INFO_TEMP_DIR,
     prNumber: github.context.issue.number,
     secrets: mergeSecrets(input.secrets, input.awsSecrets),
+    stepSummaryPath: env.all.GITHUB_STEP_SUMMARY,
   });
 
   // Step 5: Commit .tfmigrate.hcl if changed (for tfmigrate job type)

--- a/src/actions/plan/run.test.ts
+++ b/src/actions/plan/run.test.ts
@@ -155,17 +155,12 @@ describe("runTerraformPlan", () => {
   });
 
   it("returns correctly when detailedExitcode=0 (no changes)", async () => {
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = createBaseInputs(mockExecutor);
     const result = await runTerraformPlan(inputs);
@@ -182,11 +177,7 @@ describe("runTerraformPlan", () => {
   });
 
   it("throws error when detailedExitcode=1 (failure)", async () => {
-    mockExecutor.getExecOutput.mockResolvedValueOnce({
-      exitCode: 1,
-      stdout: "",
-      stderr: "Error: terraform plan failed",
-    });
+    mockExecutor.exec.mockResolvedValueOnce(1); // terraform plan fails
 
     const inputs = createBaseInputs(mockExecutor);
 
@@ -197,17 +188,12 @@ describe("runTerraformPlan", () => {
   });
 
   it("returns correctly when detailedExitcode=2 (has changes)", async () => {
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 2,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(2); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = createBaseInputs(mockExecutor);
     const result = await runTerraformPlan(inputs);
@@ -219,17 +205,12 @@ describe("runTerraformPlan", () => {
   });
 
   it("adds -destroy flag when destroy=true", async () => {
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -237,8 +218,8 @@ describe("runTerraformPlan", () => {
     };
     await runTerraformPlan(inputs);
 
-    expect(mockExecutor.getExecOutput).toHaveBeenCalledWith(
-      "tfcmt",
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
+      "terraform",
       expect.arrayContaining(["-destroy"]),
       expect.any(Object),
     );
@@ -246,17 +227,12 @@ describe("runTerraformPlan", () => {
   });
 
   it("uses tfcmt-drift.yaml config when driftIssueNumber is set", async () => {
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 2,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(2); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -267,7 +243,7 @@ describe("runTerraformPlan", () => {
       "Drift detected: terraform plan has changes",
     );
 
-    expect(mockExecutor.getExecOutput).toHaveBeenCalledWith(
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
       "tfcmt",
       expect.arrayContaining([
         "-config",
@@ -278,17 +254,12 @@ describe("runTerraformPlan", () => {
   });
 
   it("throws error when drift detection mode and changes detected", async () => {
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 2,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(2); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -297,6 +268,77 @@ describe("runTerraformPlan", () => {
 
     await expect(runTerraformPlan(inputs)).rejects.toThrow(
       "Drift detected: terraform plan has changes",
+    );
+  });
+
+  it("calls tfcmt for both PR comment and Step Summary when stepSummaryPath is set", async () => {
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
+
+    const inputs = {
+      ...createBaseInputs(mockExecutor),
+      stepSummaryPath: "/tmp/step-summary",
+    };
+    await runTerraformPlan(inputs);
+
+    const tfcmtCalls = mockExecutor.exec.mock.calls.filter(
+      ([cmd]) => cmd === "tfcmt",
+    );
+    expect(tfcmtCalls).toHaveLength(2);
+    expect(tfcmtCalls[0][1]).not.toContain("--output");
+    expect(tfcmtCalls[1][1]).toEqual(
+      expect.arrayContaining(["--output", "/tmp/step-summary"]),
+    );
+  });
+
+  it("skips Step Summary tfcmt call when stepSummaryPath is empty", async () => {
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
+
+    const inputs = createBaseInputs(mockExecutor); // no stepSummaryPath
+    await runTerraformPlan(inputs);
+
+    const tfcmtCalls = mockExecutor.exec.mock.calls.filter(
+      ([cmd]) => cmd === "tfcmt",
+    );
+    expect(tfcmtCalls).toHaveLength(1);
+    expect(tfcmtCalls[0][1]).not.toContain("--output");
+  });
+
+  it("replays captured terraform plan output into tfcmt via bash", async () => {
+    mockExecutor.exec.mockResolvedValueOnce(2); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
+      stderr: "",
+    }); // terraform show
+
+    const inputs = createBaseInputs(mockExecutor);
+    await runTerraformPlan(inputs);
+
+    const tfcmtCall = mockExecutor.exec.mock.calls.find(
+      ([cmd]) => cmd === "tfcmt",
+    );
+    expect(tfcmtCall).toBeDefined();
+    expect(tfcmtCall![1]).toEqual(
+      expect.arrayContaining([
+        "plan",
+        "--",
+        "bash",
+        "-c",
+        'cat "$1" && exit "$2"',
+        "_",
+        path.join(tempDir, "plan.txt"),
+        "2",
+      ]),
     );
   });
 
@@ -313,18 +355,12 @@ describe("runTerraformPlan", () => {
       }),
     );
 
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 2,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
-        stderr: "",
-      });
-    mockExecutor.exec.mockResolvedValue(0);
+    mockExecutor.exec.mockResolvedValueOnce(2); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -355,17 +391,12 @@ describe("runTerraformPlan", () => {
       }),
     );
 
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 2,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(2); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -379,17 +410,12 @@ describe("runTerraformPlan", () => {
   });
 
   it("skips renovate check when PR author is not renovate", async () => {
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 2,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(2); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": [{"change": {"actions": ["update"]}}]}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -404,17 +430,12 @@ describe("runTerraformPlan", () => {
 
   it("writes plan JSON from terraform show output", async () => {
     const planJsonContent = '{"format_version": "1.0", "resource_changes": []}';
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: planJsonContent,
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: planJsonContent,
+      stderr: "",
+    }); // terraform show
 
     const inputs = createBaseInputs(mockExecutor);
     await runTerraformPlan(inputs);
@@ -426,17 +447,12 @@ describe("runTerraformPlan", () => {
   });
 
   it("sets artifact name outputs with normalized target", async () => {
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = createBaseInputs(mockExecutor);
     await runTerraformPlan(inputs);
@@ -466,17 +482,12 @@ describe("runTerraformPlan", () => {
       mockOctokit as unknown as ReturnType<typeof github.getOctokit>,
     );
 
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -500,17 +511,12 @@ describe("runTerraformPlan", () => {
       mockOctokit as unknown as ReturnType<typeof github.getOctokit>,
     );
 
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -528,17 +534,12 @@ describe("runTerraformPlan", () => {
       mockOctokit as unknown as ReturnType<typeof github.getOctokit>,
     );
 
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -556,17 +557,12 @@ describe("runTerraformPlan", () => {
       mockOctokit as unknown as ReturnType<typeof github.getOctokit>,
     );
 
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const inputs = {
       ...createBaseInputs(mockExecutor),
@@ -1225,17 +1221,12 @@ describe("main", () => {
 
   it("runs terraform plan for terraform job type", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const targetConfig: getTargetConfig.TargetConfig = {
       working_directory: "aws/test",
@@ -1253,7 +1244,12 @@ describe("main", () => {
 
     await main(targetConfig, runInputs);
 
-    expect(mockExecutor.getExecOutput).toHaveBeenCalledWith(
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
+      "terraform",
+      expect.arrayContaining(["plan"]),
+      expect.any(Object),
+    );
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
       "tfcmt",
       expect.arrayContaining(["plan", "--"]),
       expect.any(Object),
@@ -1322,17 +1318,12 @@ describe("main", () => {
 
   it("uses target config destroy setting", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const targetConfig: getTargetConfig.TargetConfig = {
       working_directory: "aws/test",
@@ -1351,8 +1342,8 @@ describe("main", () => {
 
     await main(targetConfig, runInputs);
 
-    expect(mockExecutor.getExecOutput).toHaveBeenCalledWith(
-      "tfcmt",
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
+      "terraform",
       expect.arrayContaining(["-destroy"]),
       expect.any(Object),
     );
@@ -1360,17 +1351,12 @@ describe("main", () => {
 
   it("passes driftIssueNumber to runTerraformPlan", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const targetConfig: getTargetConfig.TargetConfig = {
       working_directory: "aws/test",
@@ -1389,7 +1375,7 @@ describe("main", () => {
 
     await main(targetConfig, runInputs);
 
-    expect(mockExecutor.getExecOutput).toHaveBeenCalledWith(
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
       "tfcmt",
       expect.arrayContaining([
         "-config",
@@ -1401,17 +1387,12 @@ describe("main", () => {
 
   it("uses target config terraform_command", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
-    mockExecutor.getExecOutput
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: '{"resource_changes": []}',
-        stderr: "",
-      });
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
 
     const targetConfig: getTargetConfig.TargetConfig = {
       working_directory: "aws/test",
@@ -1429,9 +1410,9 @@ describe("main", () => {
 
     await main(targetConfig, runInputs);
 
-    expect(mockExecutor.getExecOutput).toHaveBeenCalledWith(
-      "tfcmt",
-      expect.arrayContaining(["tofu", "plan"]),
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
+      "tofu",
+      expect.arrayContaining(["plan"]),
       expect.any(Object),
     );
   });

--- a/src/actions/plan/run.ts
+++ b/src/actions/plan/run.ts
@@ -65,6 +65,7 @@ type Inputs = {
   prNumber?: number;
   executor: aqua.Executor;
   secrets?: Record<string, string>;
+  stepSummaryPath?: string;
 };
 
 export type RunInputs = {
@@ -76,6 +77,7 @@ export type RunInputs = {
   ciInfoTempDir?: string;
   prNumber?: number;
   secrets?: Record<string, string>;
+  stepSummaryPath?: string;
 };
 
 type TerraformPlanOutputs = {
@@ -385,58 +387,124 @@ export const runTerraformPlan = async (
 ): Promise<TerraformPlanOutputs> => {
   const installDir = path.join(lib.GitHubActionPath, "install");
 
-  // Create temp directory and copy plan binary
+  // Create temp directory for plan binary and captured plan output
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tfaction-"));
   const tempPlanBinary = path.join(tempDir, "tfplan.binary");
   const tempPlanJson = path.join(tempDir, "tfplan.json");
+  const tempPlanOutput = path.join(tempDir, "plan.txt");
 
-  const planArgs = [
-    "-var",
-    `target:${inputs.target}`,
-    "-var",
-    `destroy:${inputs.destroy}`,
-  ];
-  // Set TFCMT_CONFIG for drift detection mode
-  if (inputs.driftIssueNumber) {
-    planArgs.push("-config", path.join(installDir, "tfcmt-drift.yaml"));
-  }
-  planArgs.push(
-    "plan",
-    "--",
-    inputs.tfCommand,
+  const executor = inputs.executor;
+
+  // Run terraform plan directly, capturing combined stdout/stderr while
+  // streaming to the Actions log. The captured output is replayed into
+  // tfcmt below so terraform plan runs only once.
+  const terraformPlanArgs = [
     "plan",
     "-no-color",
     "-detailed-exitcode",
     "-out",
     tempPlanBinary,
     "-input=false",
-  );
+  ];
   if (inputs.destroy) {
-    planArgs.push("-destroy");
+    terraformPlanArgs.push("-destroy");
     core.warning("The destroy option is enabled");
   }
 
-  const executor = inputs.executor;
-
-  // Run terraform plan with tfcmt
-  const planResult = await executor.getExecOutput("tfcmt", planArgs, {
-    cwd: inputs.workingDirectory,
-    ignoreReturnCode: true,
-    secretEnvs: inputs.secrets,
-    group: `${inputs.tfCommand} plan`,
-    env: {
-      GITHUB_TOKEN: inputs.githubTokenForGitHubProvider || inputs.githubToken,
-      TFCMT_GITHUB_TOKEN: inputs.githubToken,
-      TERRAGRUNT_LOG_DISABLE: "true", // https://suzuki-shunsuke.github.io/tfcmt/terragrunt
+  let combinedPlanOutput = "";
+  const detailedExitcode = await executor.exec(
+    inputs.tfCommand,
+    terraformPlanArgs,
+    {
+      cwd: inputs.workingDirectory,
+      ignoreReturnCode: true,
+      secretEnvs: inputs.secrets,
+      group: `${inputs.tfCommand} plan`,
+      env: {
+        GITHUB_TOKEN: inputs.githubTokenForGitHubProvider || inputs.githubToken,
+        TERRAGRUNT_LOG_DISABLE: "true", // https://suzuki-shunsuke.github.io/tfcmt/terragrunt
+      },
+      listeners: {
+        stdout: (data: Buffer) => {
+          combinedPlanOutput += data.toString();
+        },
+        stderr: (data: Buffer) => {
+          combinedPlanOutput += data.toString();
+        },
+      },
     },
-  });
-
-  const detailedExitcode = planResult.exitCode;
+  );
+  fs.writeFileSync(tempPlanOutput, combinedPlanOutput);
 
   // Set detailed_exitcode output immediately
   core.setOutput("detailed_exitcode", detailedExitcode);
 
   core.setOutput("plan_binary", tempPlanBinary);
+
+  // Replay captured output into tfcmt for PR comment and Step Summary.
+  // Two tfcmt invocations are required because --output writes to a file
+  // instead of the PR; there is no single-call "both" mode.
+  const tfcmtGlobalArgs = [
+    "-var",
+    `target:${inputs.target}`,
+    "-var",
+    `destroy:${inputs.destroy}`,
+  ];
+  if (inputs.driftIssueNumber) {
+    tfcmtGlobalArgs.push("-config", path.join(installDir, "tfcmt-drift.yaml"));
+  }
+  // Use positional args ($1, $2) so the temp path / exit code are not
+  // interpolated into the shell script body.
+  const tfcmtReplayArgs = [
+    "plan",
+    "--",
+    "bash",
+    "-c",
+    'cat "$1" && exit "$2"',
+    "_",
+    tempPlanOutput,
+    String(detailedExitcode),
+  ];
+  const tfcmtEnv = {
+    TFCMT_GITHUB_TOKEN: inputs.githubToken,
+  };
+
+  try {
+    await executor.exec("tfcmt", [...tfcmtGlobalArgs, ...tfcmtReplayArgs], {
+      cwd: inputs.workingDirectory,
+      ignoreReturnCode: true,
+      group: "tfcmt plan",
+      env: tfcmtEnv,
+    });
+  } catch (e) {
+    core.warning(
+      `Failed to post tfcmt PR comment: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  if (inputs.stepSummaryPath) {
+    try {
+      await executor.exec(
+        "tfcmt",
+        [
+          "--output",
+          inputs.stepSummaryPath,
+          ...tfcmtGlobalArgs,
+          ...tfcmtReplayArgs,
+        ],
+        {
+          cwd: inputs.workingDirectory,
+          ignoreReturnCode: true,
+          group: "tfcmt plan (step summary)",
+          env: tfcmtEnv,
+        },
+      );
+    } catch (e) {
+      core.warning(
+        `Failed to write tfcmt Step Summary: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
 
   // If terraform plan failed, exit immediately
   if (detailedExitcode === 1) {
@@ -556,6 +624,7 @@ export const main = async (
     prNumber: runInputs.prNumber,
     executor,
     secrets: runInputs.secrets,
+    stepSummaryPath: runInputs.stepSummaryPath,
   };
 
   const jobType = runInputs.jobType;


### PR DESCRIPTION
## Summary

Previously, `terraform plan` results posted via `tfcmt` were visible only in the PR comment. This change mirrors the same rendered output into the GitHub Actions **Step Summary** so the result is visible from the Actions job page even without opening the PR (and stays useful for manual / drift-detection runs where there may be no PR at all). Aligns with the recent Step Summary work for trivy and tflint (#3968, #3970, #3971).

`terraform plan` still runs only once — the previously-internal child execution inside `tfcmt` is hoisted to a direct invocation, its combined stdout/stderr is captured to a temp file, and then replayed into `tfcmt` twice.

## Changes

### `src/actions/plan/run.ts` — `runTerraformPlan`

Refactored from a single `tfcmt ... plan -- terraform plan ...` call into three steps:

1. **Run `terraform plan` directly**, capturing combined stdout/stderr to `<tempDir>/plan.txt` via `listeners.stdout` / `listeners.stderr` while still streaming live to the Actions log. Exit code is preserved (`-detailed-exitcode`: 0 = no changes, 1 = error, 2 = changes). `TERRAGRUNT_LOG_DISABLE=true` and `GITHUB_TOKEN` are kept on this direct invocation so terragrunt logs don't pollute the captured output and the github provider keeps working.
2. **Post PR comment via `tfcmt`** by replaying the captured output:
   ```
   tfcmt -var target:X -var destroy:Y [ -config tfcmt-drift.yaml ] \
     plan -- bash -c 'cat "$1" && exit "$2"' _ <plan.txt> <exitcode>
   ```
   The temp file path and exit code are passed as positional `$1`/`$2` (not interpolated into the script body) to avoid shell-injection / metacharacter issues.
3. **Mirror to Step Summary** with the same args plus `--output "$GITHUB_STEP_SUMMARY"`, when `stepSummaryPath` is set. tfcmt's `--output` opens the file with `O_APPEND|O_CREATE|O_WRONLY` (see `tfcmt/pkg/notifier/localfile/output.go`), so it appends without clobbering content other steps wrote to `$GITHUB_STEP_SUMMARY`.

Both tfcmt calls use `ignoreReturnCode: true` and an independent `try/catch` that downgrades failures to `core.warning`, so a failed PR comment doesn't prevent the Step Summary write (and vice versa). The original failure semantics are preserved: if `terraform plan` exited with code 1, we still `throw new Error("terraform plan failed")` after the comments have been posted — same as before.

Why two `tfcmt` calls instead of one: `tfcmt --output` redirects to a file *instead of* the PR; there is no built-in "post to both" mode.

### `src/actions/plan/run.ts` — type plumbing

Added optional `stepSummaryPath?: string` to both `Inputs` and `RunInputs`, plumbed through `main()`.

### `src/actions/plan/index.ts`

Pass `stepSummaryPath: env.all.GITHUB_STEP_SUMMARY` from the action entry point. Per the repo convention, `env.ts` is referenced from `index.ts` only — `run.ts` receives the path through `RunInputs`.

### `src/actions/plan/run.test.ts`

Updated vitest mocks for the new exec sequence:

- `terraform plan` now goes through `executor.exec` (not `getExecOutput`), so existing `mockResolvedValueOnce({exitCode, stdout, stderr})` setups for the plan step became `mockExecutor.exec.mockResolvedValueOnce(<code>)`.
- The two tfcmt calls also use `executor.exec`; they fall through to the default `mockResolvedValue(0)` in `createMockExecutor()`.
- `getExecOutput` is now only mocked once per test, for the `terraform show -json` call.
- `expect.toHaveBeenCalledWith("tfcmt", expect.arrayContaining(["-destroy"]), ...)` etc. switched from `getExecOutput` to `exec`, and the `-destroy`/`plan` assertions now target the direct terraform call where appropriate.

Added three new test cases:

- `calls tfcmt for both PR comment and Step Summary when stepSummaryPath is set` — asserts the PR call has no `--output`, the second call does, and the path matches.
- `skips Step Summary tfcmt call when stepSummaryPath is empty` — only one tfcmt call.
- `replays captured terraform plan output into tfcmt via bash` — verifies the `bash -c 'cat "$1" && exit "$2"' _ <plan.txt> <code>` shape and that the exit code is stringified correctly.

## Test plan

- [x] `npm t` — 899 tests pass
- [x] `npm run lint` — clean (`eslint && tsc --noEmit`)
- [x] `npm run fmt` — clean
- [ ] Manual: run a workflow against `pr/<this-PR>` and verify the plan output appears in the Actions Step Summary in addition to the PR comment, for: no-change (exit 0), changes (exit 2), failure (exit 1), and drift-detection mode (`tfcmt-drift.yaml`).