### PR TITLE
feat(executor): write Job Summary on command failure

### DIFF
--- a/src/aqua/index.test.ts
+++ b/src/aqua/index.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@actions/exec", () => ({
+  exec: vi.fn(),
+  getExecOutput: vi.fn(),
+}));
+
+vi.mock("@actions/core", () => ({
+  startGroup: vi.fn(),
+  endGroup: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  addPath: vi.fn(),
+  summary: {
+    addRaw: vi.fn().mockReturnThis(),
+    write: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../lib", () => ({
+  aquaGlobalConfig: "/path/to/aqua.yaml",
+}));
+
+vi.mock("../lib/env", () => ({
+  all: {
+    PATH: "/usr/bin",
+    AQUA_ROOT_DIR: "",
+    XDG_DATA_HOME: "",
+    AQUA_GLOBAL_CONFIG: "",
+  },
+}));
+
+vi.mock("../comment/exec", () => ({
+  execAndComment: vi.fn(),
+}));
+
+import * as core from "@actions/core";
+import * as exec from "@actions/exec";
+import { execAndComment } from "../comment/exec";
+import { Executor, buildFailureSummary } from "./index";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildFailureSummary", () => {
+  it("includes joined command and fenced output body", () => {
+    const out = buildFailureSummary("terraform", ["init"], "boom\n");
+    expect(out).toBe("## :x: `terraform init` failed\n\n```\nboom\n```\n");
+  });
+
+  it("omits the fenced block when output is empty", () => {
+    expect(buildFailureSummary("aqua", ["i"], "")).toBe(
+      "## :x: `aqua i` failed\n",
+    );
+    expect(buildFailureSummary("aqua", ["i"], "   \n  ")).toBe(
+      "## :x: `aqua i` failed\n",
+    );
+  });
+
+  it("handles missing args", () => {
+    expect(buildFailureSummary("ls", undefined, "x")).toBe(
+      "## :x: `ls` failed\n\n```\nx\n```\n",
+    );
+  });
+});
+
+describe("Executor.exec failure summary", () => {
+  it("writes Job Summary when command fails and ignoreReturnCode is not set", async () => {
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
+      options?.listeners?.stdout?.(Buffer.from("stdout-line\n"));
+      options?.listeners?.stderr?.(Buffer.from("stderr-line\n"));
+      return Promise.reject(new Error("Command failed with exit code 1"));
+    });
+
+    const executor = new Executor("");
+    await expect(
+      executor.exec("terraform", ["init"], { cwd: "/wd" }),
+    ).rejects.toThrow("Command failed with exit code 1");
+
+    expect(core.summary.addRaw).toHaveBeenCalledTimes(1);
+    const arg = vi.mocked(core.summary.addRaw).mock.calls[0][0];
+    expect(arg).toBe(
+      "## :x: `terraform init` failed\n\n```\nstdout-line\nstderr-line\n```\n",
+    );
+    expect(core.summary.write).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not write a summary when ignoreReturnCode is true", async () => {
+    vi.mocked(exec.exec).mockResolvedValue(1);
+
+    const executor = new Executor("");
+    const code = await executor.exec("tflint", ["--format", "sarif"], {
+      ignoreReturnCode: true,
+    });
+
+    expect(code).toBe(1);
+    expect(core.summary.addRaw).not.toHaveBeenCalled();
+    expect(core.summary.write).not.toHaveBeenCalled();
+  });
+
+  it("does not write a summary when the command succeeds", async () => {
+    vi.mocked(exec.exec).mockResolvedValue(0);
+
+    const executor = new Executor("");
+    await executor.exec("terraform", ["init"]);
+
+    expect(core.summary.addRaw).not.toHaveBeenCalled();
+    expect(core.summary.write).not.toHaveBeenCalled();
+  });
+
+  it("still invokes caller-provided listeners while capturing for the summary", async () => {
+    const userStdout = vi.fn();
+    const userStderr = vi.fn();
+
+    vi.mocked(exec.exec).mockImplementation((_cmd, _args, options) => {
+      options?.listeners?.stdout?.(Buffer.from("a"));
+      options?.listeners?.stderr?.(Buffer.from("b"));
+      return Promise.reject(new Error("fail"));
+    });
+
+    const executor = new Executor("");
+    await expect(
+      executor.exec("trivy", ["config", "."], {
+        listeners: { stdout: userStdout, stderr: userStderr },
+      }),
+    ).rejects.toThrow("fail");
+
+    expect(userStdout).toHaveBeenCalledWith(Buffer.from("a"));
+    expect(userStderr).toHaveBeenCalledWith(Buffer.from("b"));
+    expect(vi.mocked(core.summary.addRaw).mock.calls[0][0]).toContain(
+      "## :x: `trivy config .` failed",
+    );
+  });
+
+  it("ends the log group even when the command fails", async () => {
+    vi.mocked(exec.exec).mockRejectedValue(new Error("nope"));
+
+    const executor = new Executor("");
+    await expect(
+      executor.exec("aqua", ["i"], { group: "aqua install" }),
+    ).rejects.toThrow("nope");
+
+    expect(core.startGroup).toHaveBeenCalledWith("aqua install");
+    expect(core.endGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the generic summary when execAndComment posted a PR comment (avoids duplication)", async () => {
+    vi.mocked(execAndComment).mockImplementation((_cmd, _args, _c, opts) => {
+      opts?.listeners?.stdout?.(Buffer.from("comment-output\n"));
+      return Promise.resolve({
+        exitCode: 2,
+        stdout: "comment-output\n",
+        stderr: "",
+        commentPosted: true,
+      });
+    });
+
+    const executor = new Executor("");
+    await expect(
+      executor.exec("terraform", ["plan"], {
+        comment: { token: "t" },
+      }),
+    ).rejects.toThrow("Command failed with exit code 2: terraform plan");
+
+    expect(core.summary.addRaw).not.toHaveBeenCalled();
+    expect(core.summary.write).not.toHaveBeenCalled();
+  });
+
+  it("writes the generic summary when execAndComment did NOT post a PR comment", async () => {
+    vi.mocked(execAndComment).mockImplementation((_cmd, _args, _c, opts) => {
+      opts?.listeners?.stdout?.(Buffer.from("no-template-output\n"));
+      return Promise.resolve({
+        exitCode: 3,
+        stdout: "no-template-output\n",
+        stderr: "",
+        commentPosted: false,
+      });
+    });
+
+    const executor = new Executor("");
+    await expect(
+      executor.exec("terraform", ["plan"], {
+        comment: { token: "t" },
+      }),
+    ).rejects.toThrow("Command failed with exit code 3: terraform plan");
+
+    expect(core.summary.addRaw).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(core.summary.addRaw).mock.calls[0][0]).toBe(
+      "## :x: `terraform plan` failed\n\n```\nno-template-output\n```\n",
+    );
+  });
+
+  it("does not throw when execAndComment returns success with commentPosted=true", async () => {
+    vi.mocked(execAndComment).mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      commentPosted: true,
+    });
+
+    const executor = new Executor("");
+    const code = await executor.exec("terraform", ["plan"], {
+      comment: { token: "t" },
+    });
+
+    expect(code).toBe(0);
+    expect(core.summary.addRaw).not.toHaveBeenCalled();
+  });
+
+  it("does not throw or write a generic summary when comment + ignoreReturnCode + non-zero exit", async () => {
+    vi.mocked(execAndComment).mockResolvedValue({
+      exitCode: 4,
+      stdout: "",
+      stderr: "",
+      commentPosted: false,
+    });
+
+    const executor = new Executor("");
+    const code = await executor.exec("terraform", ["plan"], {
+      comment: { token: "t" },
+      ignoreReturnCode: true,
+    });
+
+    expect(code).toBe(4);
+    expect(core.summary.addRaw).not.toHaveBeenCalled();
+  });
+});
+
+describe("Executor.getExecOutput failure summary", () => {
+  it("writes Job Summary on failure when ignoreReturnCode is not set", async () => {
+    vi.mocked(exec.getExecOutput).mockImplementation((_cmd, _args, options) => {
+      options?.listeners?.stdout?.(Buffer.from("hello\n"));
+      return Promise.reject(new Error("Command failed"));
+    });
+
+    const executor = new Executor("");
+    await expect(executor.getExecOutput("tflint", ["--help"])).rejects.toThrow(
+      "Command failed",
+    );
+
+    expect(core.summary.addRaw).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(core.summary.addRaw).mock.calls[0][0]).toBe(
+      "## :x: `tflint --help` failed\n\n```\nhello\n```\n",
+    );
+  });
+
+  it("does not write a summary when ignoreReturnCode is true", async () => {
+    vi.mocked(exec.getExecOutput).mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: "",
+    });
+
+    const executor = new Executor("");
+    await executor.getExecOutput("tflint", ["--init"], {
+      ignoreReturnCode: true,
+    });
+
+    expect(core.summary.addRaw).not.toHaveBeenCalled();
+  });
+});

--- a/src/aqua/index.ts
+++ b/src/aqua/index.ts
@@ -108,6 +108,45 @@ export interface ExecOptions extends exec.ExecOptions {
   comment?: Comment;
 }
 
+export const buildFailureSummary = (
+  command: string,
+  args: string[] | undefined,
+  output: string,
+): string => {
+  const joined = [command, ...(args ?? [])].join(" ");
+  const body = output.trim();
+  const block = body.length > 0 ? `\n\n\`\`\`\n${body}\n\`\`\`\n` : "\n";
+  return `## :x: \`${joined}\` failed${block}`;
+};
+
+const writeFailureSummary = async (
+  command: string,
+  args: string[] | undefined,
+  output: string,
+): Promise<void> => {
+  core.summary.addRaw(buildFailureSummary(command, args, output));
+  await core.summary.write();
+};
+
+const buildCapturingListeners = (
+  options: ExecOptions | undefined,
+  append: (chunk: string) => void,
+): exec.ExecOptions["listeners"] => {
+  const userStdout = options?.listeners?.stdout;
+  const userStderr = options?.listeners?.stderr;
+  return {
+    ...options?.listeners,
+    stdout: (data: Buffer) => {
+      append(data.toString());
+      userStdout?.(data);
+    },
+    stderr: (data: Buffer) => {
+      append(data.toString());
+      userStderr?.(data);
+    },
+  };
+};
+
 export class Executor {
   installDir: string;
   githubToken?: string;
@@ -144,6 +183,14 @@ export class Executor {
   ): Promise<number> {
     const bArgs = this.buildArgs(command, args);
     const envVars = this.env(options);
+    const captureForSummary = !options?.ignoreReturnCode;
+    let captured = "";
+    let summaryHandled = false;
+    const listeners = captureForSummary
+      ? buildCapturingListeners(options, (chunk) => {
+          captured += chunk;
+        })
+      : options?.listeners;
     try {
       if (options?.group) {
         core.startGroup(options.group);
@@ -153,14 +200,29 @@ export class Executor {
           bArgs.command,
           bArgs.args,
           options.comment,
-          { ...options, env: envVars },
+          { ...options, env: envVars, listeners },
         );
+        if (captureForSummary && result.exitCode !== 0) {
+          if (!result.commentPosted) {
+            await writeFailureSummary(bArgs.command, bArgs.args, captured);
+          }
+          summaryHandled = true;
+          throw new Error(
+            `Command failed with exit code ${result.exitCode}: ${[bArgs.command, ...(bArgs.args ?? [])].join(" ")}`,
+          );
+        }
         return result.exitCode;
       }
       return await exec.exec(bArgs.command, bArgs.args, {
         ...options,
         env: envVars,
+        listeners,
       });
+    } catch (error) {
+      if (captureForSummary && !summaryHandled) {
+        await writeFailureSummary(bArgs.command, bArgs.args, captured);
+      }
+      throw error;
     } finally {
       if (options?.group) {
         core.endGroup();
@@ -175,6 +237,14 @@ export class Executor {
   ): Promise<exec.ExecOutput> {
     const bArgs = this.buildArgs(command, args);
     const envVars = this.env(options);
+    const captureForSummary = !options?.ignoreReturnCode;
+    let captured = "";
+    let summaryHandled = false;
+    const listeners = captureForSummary
+      ? buildCapturingListeners(options, (chunk) => {
+          captured += chunk;
+        })
+      : options?.listeners;
     try {
       if (options?.group) {
         console.log("");
@@ -185,14 +255,33 @@ export class Executor {
           bArgs.command,
           bArgs.args,
           options.comment,
-          { ...options, env: envVars },
+          { ...options, env: envVars, listeners },
         );
-        return result;
+        if (captureForSummary && result.exitCode !== 0) {
+          if (!result.commentPosted) {
+            await writeFailureSummary(bArgs.command, bArgs.args, captured);
+          }
+          summaryHandled = true;
+          throw new Error(
+            `Command failed with exit code ${result.exitCode}: ${[bArgs.command, ...(bArgs.args ?? [])].join(" ")}`,
+          );
+        }
+        return {
+          exitCode: result.exitCode,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        };
       }
       return await exec.getExecOutput(bArgs.command, bArgs.args, {
         ...options,
         env: envVars,
+        listeners,
       });
+    } catch (error) {
+      if (captureForSummary && !summaryHandled) {
+        await writeFailureSummary(bArgs.command, bArgs.args, captured);
+      }
+      throw error;
     } finally {
       if (options?.group) {
         console.log("");

--- a/src/comment/exec.ts
+++ b/src/comment/exec.ts
@@ -17,6 +17,7 @@ export type ExecResult = {
   exitCode: number;
   stdout: string;
   stderr: string;
+  commentPosted: boolean;
 };
 
 export const evaluateWhen = (
@@ -103,18 +104,14 @@ export const execAndComment = async (
   });
 
   const exitCode = result.exitCode;
+  let commentPosted = false;
 
   const config = loadConfig();
   const key = comment.key ?? "default";
   const templates = config.exec[key] ?? config.exec["default"];
   if (!templates) {
     core.warning(`No exec comment templates found for key "${key}"`);
-    if (exitCode !== 0 && !execOptions?.ignoreReturnCode) {
-      throw new Error(
-        `Command failed with exit code ${exitCode}: ${command} ${(args ?? []).join(" ")}`,
-      );
-    }
-    return { exitCode, stdout, stderr };
+    return { exitCode, stdout, stderr, commentPosted };
   }
 
   const celContext = {
@@ -153,13 +150,8 @@ export const execAndComment = async (
       comment.org,
       comment.repo,
     );
+    commentPosted = true;
   }
 
-  if (exitCode !== 0 && !execOptions?.ignoreReturnCode) {
-    throw new Error(
-      `Command failed with exit code ${exitCode}: ${command} ${(args ?? []).join(" ")}`,
-    );
-  }
-
-  return { exitCode, stdout, stderr };
+  return { exitCode, stdout, stderr, commentPosted };
 };


### PR DESCRIPTION
## Summary

`executor.exec` / `executor.getExecOutput` (`src/aqua/index.ts`) now mirror failed commands into the GitHub Actions Job Summary, so a workflow failure is visible at a glance without having to drill into the per-step log.

When the underlying command throws (i.e. `ignoreReturnCode` is not `true` and exit code is non-zero), the executor writes a block like:

```
## :x: `terraform init` failed

​```
<combined stdout + stderr>
​```
```

Per the project convention on error visibility, the output block is **not** wrapped in `<details>` — the error must be readable from the first glance.

## Changes

### `src/aqua/index.ts` — Executor

- New `buildFailureSummary(command, args, output)` helper builds the markdown block. Exported for unit testing; the empty-output case omits the fenced block.
- New `writeFailureSummary` (private) calls `core.summary.addRaw` + `core.summary.write`.
- New `buildCapturingListeners` (private) merges caller-supplied `listeners.stdout` / `listeners.stderr` with our capture buffer so existing call sites that already attach listeners (e.g. `actions/apply/terraform.ts`) keep working.
- `Executor.exec` and `Executor.getExecOutput`:
  - When `!options.ignoreReturnCode`, wire the capturing listeners and run the underlying call inside a `try { ... } catch { writeFailureSummary; throw }` so any thrown failure produces the summary.
  - For the `comment:` branch, the throw is now produced explicitly by the executor (using `Command failed with exit code N: <joined cmd>`), guarded by a new `commentPosted` check (see below). When `execAndComment` posted a PR comment, the generic failure block is suppressed because `postComment` (`src/comment/index.ts:106-107`) already wrote the templated content to the Summary — avoiding duplication.
  - A `summaryHandled` flag prevents the catch handler from re-writing the summary after the comment branch already made the decision.
  - `getExecOutput`'s comment branch now returns a plain `ExecOutput` (`{ exitCode, stdout, stderr }`) so the new `commentPosted` field stays internal to the comment module.

### `src/comment/exec.ts` — `execAndComment`

- `ExecResult` gains `commentPosted: boolean`.
- Both `throw new Error("Command failed with exit code ...")` paths (the no-templates branch and the trailing one) are **removed**. The throw responsibility moves to the caller (`Executor`), which has the additional context needed to decide whether the generic failure summary should also fire.
- `commentPosted` is set to `true` immediately after a successful `postComment` call, and returned in every exit path.
- The `core.warning("No exec comment templates found for key …")` log is kept for misconfiguration cases.

### `src/aqua/index.test.ts` — new (263 lines)

First test file for `Executor`. Covers:

- `buildFailureSummary`: command/args joined, fenced block for non-empty output, no fenced block for empty/whitespace-only output, undefined args.
- `Executor.exec`:
  - Writes Summary on failure when `ignoreReturnCode` is unset; format matches the spec.
  - Does **not** write a summary when `ignoreReturnCode: true` even on non-zero exit.
  - Does not write a summary on success.
  - Caller-provided `listeners.stdout` / `listeners.stderr` still receive data while we capture for the summary.
  - `endGroup` runs even when the command fails.
  - Comment branch: `commentPosted: true` + non-zero exit → no generic summary (PR comment already in Summary via `postComment`), but the executor still throws.
  - Comment branch: `commentPosted: false` + non-zero exit → generic summary IS written, executor throws.
  - Comment branch: `commentPosted: true` + exit 0 → no throw, no generic summary.
  - Comment branch: `comment:` + `ignoreReturnCode: true` + non-zero exit → no throw, no generic summary (regardless of `commentPosted`).
- `Executor.getExecOutput`: writes Summary on failure when `ignoreReturnCode` unset; skips when `ignoreReturnCode: true`.

## Behavior matrix

| `comment:` | exit code | `ignoreReturnCode` | `commentPosted` | Summary output | Throws |
|---|---|---|---|---|---|
| no | 0 | — | — | none | no |
| no | ≠0 | true | — | none | no |
| no | ≠0 | false/unset | — | generic `## :x:` | yes |
| yes | 0 | — | true | PR-comment template (via `postComment`) | no |
| yes | 0 | — | false | none | no |
| yes | ≠0 | true | true | PR-comment template | no |
| yes | ≠0 | true | false | none | no |
| yes | ≠0 | false/unset | true | PR-comment template only (no duplication) | yes |
| yes | ≠0 | false/unset | false | generic `## :x:` | yes |

## Notable behavior change for existing call sites

Every executor call that does **not** set `ignoreReturnCode: true` will now produce a Job Summary entry on failure. New sites benefiting from this (none of which had a per-tool summary before):

- `terraform init` / `providers lock` / `providers` — `src/actions/terraform-init/run.ts`
- `tfcmt` post for drift issues — `src/actions/apply/terraform.ts`
- `tfmigrate apply` — `src/actions/apply/tfmigrate.ts`
- `conftest` — `src/conftest/index.ts`
- `terraform-docs` — `src/terraform-docs/index.ts`
- `aqua i -l -a` install — `src/aqua/index.ts`

The pre-existing tflint / trivy human-readable Summary writers are untouched because they pass `ignoreReturnCode: true` and handle the re-run themselves.

## Test plan

- [x] `npm t` — 913 tests pass (51 files, includes 14 new in `src/aqua/index.test.ts`)
- [x] `npm run lint` — `eslint && tsc --noEmit` clean
- [x] `npm run fmt` — Prettier clean
- [ ] Manual: trigger a workflow where a `terraform init` step fails, confirm Job Summary shows `## :x: \`terraform init …\` failed` with the captured output
- [ ] Manual: trigger a `terraform plan` failure with the existing `comment:` integration, confirm only the PR-comment template appears in the Summary (no duplicate generic block)
- [ ] Manual: confirm no Summary entry is added for the pre-existing tflint / trivy fail paths (still `ignoreReturnCode: true`-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)