### PR TITLE
feat(apply): mirror tfcmt apply result to GitHub Actions Step Summary

### DIFF
--- a/src/actions/apply/terraform.test.ts
+++ b/src/actions/apply/terraform.test.ts
@@ -39,7 +39,7 @@ vi.mock("fs", async () => {
   return {
     ...actual,
     mkdtempSync: vi.fn(),
-    createWriteStream: vi.fn(),
+    writeFileSync: vi.fn(),
     readFileSync: vi.fn(),
     rmdirSync: vi.fn(),
   };
@@ -78,6 +78,7 @@ vi.mock("../../lib/env", () => ({
     CI_INFO_PR_NUMBER: "42",
     CI_INFO_TEMP_DIR: "/tmp/ci-info",
     CI_INFO_HEAD_REF: "feature-branch",
+    GITHUB_STEP_SUMMARY: "",
   },
 }));
 
@@ -111,12 +112,6 @@ const createMockExecutor = () => ({
   githubToken: "mock-token",
   env: vi.fn(),
   buildArgs: vi.fn(),
-});
-
-// Helper to create a mock write stream
-const createMockWriteStream = () => ({
-  write: vi.fn(),
-  end: vi.fn(),
 });
 
 // Helper to create a mock config
@@ -172,7 +167,6 @@ const setupMainMocks = async (
   const config = createMockConfig(options.config ?? {});
   const targetConfig = createMockTargetConfig(options.targetConfig ?? {});
   const mockExecutor = createMockExecutor();
-  const mockWriteStream = createMockWriteStream();
 
   vi.mocked(lib.getConfig).mockResolvedValue(config as never);
   vi.mocked(getTargetConfigMod.getTargetConfig).mockResolvedValue(
@@ -187,11 +181,9 @@ const setupMainMocks = async (
     Object.assign(envMod.all, options.envOverrides);
   }
 
-  // Mock fs for downloadPlanFile
+  // Mock fs for downloadPlanFile and apply output capture
   vi.mocked(fs.mkdtempSync).mockReturnValue("/tmp/tfaction-test");
-  vi.mocked(fs.createWriteStream).mockReturnValue(
-    mockWriteStream as unknown as fs.WriteStream,
-  );
+  vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
   vi.mocked(fs.readFileSync).mockReturnValue(
     JSON.stringify({
       head: { sha: options.prHeadSha ?? "abc123" },
@@ -225,7 +217,7 @@ const setupMainMocks = async (
     mockOctokit as unknown as ReturnType<typeof github.getOctokit>,
   );
 
-  return { config, targetConfig, mockExecutor, mockWriteStream, mockOctokit };
+  return { config, targetConfig, mockExecutor, mockOctokit };
 };
 
 describe("main", () => {
@@ -240,6 +232,7 @@ describe("main", () => {
       CI_INFO_PR_NUMBER: "42",
       CI_INFO_TEMP_DIR: "/tmp/ci-info",
       CI_INFO_HEAD_REF: "feature-branch",
+      GITHUB_STEP_SUMMARY: "",
     });
   });
 
@@ -252,15 +245,10 @@ describe("main", () => {
 
     await main();
 
-    // Verify tfcmt apply was called with terraform
+    // Step A: terraform apply runs directly (not via tfcmt --)
     expect(mockExecutor.exec).toHaveBeenCalledWith(
-      "tfcmt",
+      "terraform",
       expect.arrayContaining([
-        "-var",
-        "target:aws/dev/vpc",
-        "apply",
-        "--",
-        "terraform",
         "apply",
         "-auto-approve",
         "-no-color",
@@ -269,6 +257,25 @@ describe("main", () => {
       expect.objectContaining({
         cwd: path.join("/git/root", "aws/dev/vpc"),
         ignoreReturnCode: true,
+      }),
+    );
+
+    // Step B: tfcmt apply replays the captured output for the PR comment
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
+      "tfcmt",
+      expect.arrayContaining([
+        "-var",
+        "target:aws/dev/vpc",
+        "apply",
+        "--",
+        "bash",
+        "-c",
+        'cat "$1" && exit "$2"',
+      ]),
+      expect.objectContaining({
+        cwd: path.join("/git/root", "aws/dev/vpc"),
+        ignoreReturnCode: true,
+        group: "tfcmt apply",
       }),
     );
   });
@@ -281,9 +288,90 @@ describe("main", () => {
     await main();
 
     expect(mockExecutor.exec).toHaveBeenCalledWith(
-      "tfcmt",
-      expect.arrayContaining(["tofu", "apply"]),
+      "tofu",
+      expect.arrayContaining(["apply", "-auto-approve"]),
       expect.any(Object),
+    );
+  });
+
+  it("does not call tfcmt --output when GITHUB_STEP_SUMMARY is empty", async () => {
+    const { mockExecutor } = await setupMainMocks();
+
+    await main();
+
+    const stepSummaryCall = mockExecutor.exec.mock.calls.find(
+      (call: unknown[]) =>
+        call[0] === "tfcmt" &&
+        Array.isArray(call[1]) &&
+        (call[1] as string[]).includes("--output"),
+    );
+    expect(stepSummaryCall).toBeUndefined();
+  });
+
+  it("writes Step Summary via tfcmt --output when GITHUB_STEP_SUMMARY is set", async () => {
+    const { mockExecutor } = await setupMainMocks({
+      envOverrides: { GITHUB_STEP_SUMMARY: "/tmp/step-summary.md" },
+    });
+
+    await main();
+
+    expect(mockExecutor.exec).toHaveBeenCalledWith(
+      "tfcmt",
+      expect.arrayContaining([
+        "--output",
+        "/tmp/step-summary.md",
+        "-var",
+        "target:aws/dev/vpc",
+        "apply",
+        "--",
+      ]),
+      expect.objectContaining({
+        group: "tfcmt apply (step summary)",
+        ignoreReturnCode: true,
+      }),
+    );
+  });
+
+  it("warns but does not throw when the PR comment tfcmt call fails", async () => {
+    const { mockExecutor } = await setupMainMocks();
+
+    mockExecutor.exec.mockImplementation((cmd: string, args?: string[]) => {
+      if (
+        cmd === "tfcmt" &&
+        args &&
+        args.includes("apply") &&
+        args.includes("--") &&
+        !args.includes("--output") &&
+        !args.some((a) => a.includes("tfcmt-drift.yaml"))
+      ) {
+        return Promise.reject(new Error("network error"));
+      }
+      return Promise.resolve(0);
+    });
+
+    await main();
+
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to post tfcmt PR comment"),
+    );
+  });
+
+  it("warns but does not throw when the Step Summary tfcmt call fails", async () => {
+    const { mockExecutor } = await setupMainMocks({
+      envOverrides: { GITHUB_STEP_SUMMARY: "/tmp/step-summary.md" },
+    });
+
+    mockExecutor.exec.mockImplementation((cmd: string, args?: string[]) => {
+      if (cmd === "tfcmt" && args && args.includes("--output")) {
+        return Promise.reject(new Error("write error"));
+      }
+      return Promise.resolve(0);
+    });
+
+    await main();
+
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to write tfcmt Step Summary"),
     );
   });
 
@@ -390,9 +478,14 @@ describe("main", () => {
   it('throws "terraform apply failed" when exit code is non-zero', async () => {
     const { mockExecutor } = await setupMainMocks();
 
-    // Make tfcmt apply return non-zero
-    mockExecutor.exec.mockImplementation((_cmd: string, args?: string[]) => {
-      if (args && args.includes("apply") && args.includes("-auto-approve")) {
+    // Make the direct terraform apply call return non-zero
+    mockExecutor.exec.mockImplementation((cmd: string, args?: string[]) => {
+      if (
+        cmd === "terraform" &&
+        args &&
+        args.includes("apply") &&
+        args.includes("-auto-approve")
+      ) {
         return Promise.resolve(1);
       }
       return Promise.resolve(0);

--- a/src/actions/apply/terraform.ts
+++ b/src/actions/apply/terraform.ts
@@ -55,56 +55,93 @@ export const main = async (
     throw new Error("PLAN_FILE_PATH is not set");
   }
 
-  // Create a temporary file for apply output
+  // Create a temp directory for the captured apply output. The same file
+  // is later replayed into tfcmt (for the PR comment and Job Summary) and
+  // into the drift issue notification.
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tfaction-"));
   const applyOutput = path.join(tempDir, "apply_output.txt");
-  const outputStream = fs.createWriteStream(applyOutput);
 
-  // Run terraform apply with tfcmt
-  let exitCode = 0;
+  // Run terraform/terragrunt apply directly, capturing combined
+  // stdout/stderr while @actions/exec streams to the Actions log. The
+  // captured output is replayed into tfcmt below so apply runs only once.
+  let combinedApplyOutput = "";
+  const exitCode = await executor.exec(
+    tfCommand,
+    ["apply", "-auto-approve", "-no-color", "-input=false", planFilePath],
+    {
+      cwd: workingDir,
+      ignoreReturnCode: true,
+      secretEnvs: secrets,
+      group: `${tfCommand} apply`,
+      env: {
+        GITHUB_TOKEN: githubTokenForGitHubProvider || githubToken,
+        TERRAGRUNT_LOG_DISABLE: "true", // https://suzuki-shunsuke.github.io/tfcmt/terragrunt
+      },
+      listeners: {
+        stdout: (data: Buffer) => {
+          combinedApplyOutput += data.toString();
+        },
+        stderr: (data: Buffer) => {
+          combinedApplyOutput += data.toString();
+        },
+      },
+    },
+  );
+  fs.writeFileSync(applyOutput, combinedApplyOutput);
+
+  // Replay captured output into tfcmt for PR comment and Step Summary.
+  // Two tfcmt invocations are required because --output writes to a file
+  // instead of the PR; there is no single-call "both" mode.
+  const tfcmtGlobalArgs = ["-var", `target:${targetConfig.target}`];
+  // Positional args ($1, $2) keep the temp path / exit code out of the
+  // shell script body.
+  const tfcmtReplayArgs = [
+    "apply",
+    "--",
+    "bash",
+    "-c",
+    'cat "$1" && exit "$2"',
+    "_",
+    applyOutput,
+    String(exitCode),
+  ];
+  const tfcmtEnv = {
+    GITHUB_TOKEN: githubTokenForGitHubProvider || githubToken,
+    TFCMT_GITHUB_TOKEN: githubToken,
+    TERRAGRUNT_LOG_DISABLE: "true",
+  };
+
   try {
-    await executor
-      .exec(
+    await executor.exec("tfcmt", [...tfcmtGlobalArgs, ...tfcmtReplayArgs], {
+      cwd: workingDir,
+      ignoreReturnCode: true,
+      group: "tfcmt apply",
+      env: tfcmtEnv,
+    });
+  } catch (e) {
+    core.warning(
+      `Failed to post tfcmt PR comment: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  const stepSummaryPath = env.all.GITHUB_STEP_SUMMARY;
+  if (stepSummaryPath) {
+    try {
+      await executor.exec(
         "tfcmt",
-        [
-          "-var",
-          `target:${targetConfig.target}`,
-          "apply",
-          "--",
-          tfCommand,
-          "apply",
-          "-auto-approve",
-          "-no-color",
-          "-input=false",
-          planFilePath,
-        ],
+        ["--output", stepSummaryPath, ...tfcmtGlobalArgs, ...tfcmtReplayArgs],
         {
           cwd: workingDir,
           ignoreReturnCode: true,
-          secretEnvs: secrets,
-          group: `${tfCommand} apply`,
-          env: {
-            GITHUB_TOKEN: githubTokenForGitHubProvider || githubToken,
-            TFCMT_GITHUB_TOKEN: githubToken,
-            TERRAGRUNT_LOG_DISABLE: "true", // https://suzuki-shunsuke.github.io/tfcmt/terragrunt
-          },
-          listeners: {
-            stdout: (data: Buffer) => {
-              process.stdout.write(data);
-              outputStream.write(data);
-            },
-            stderr: (data: Buffer) => {
-              process.stderr.write(data);
-              outputStream.write(data);
-            },
-          },
+          group: "tfcmt apply (step summary)",
+          env: tfcmtEnv,
         },
-      )
-      .then((code) => {
-        exitCode = code;
-      });
-  } finally {
-    outputStream.end();
+      );
+    } catch (e) {
+      core.warning(
+        `Failed to write tfcmt Step Summary: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
   }
 
   // If this is a drift issue, post the result to the drift issue


### PR DESCRIPTION
## Summary

- Apply (`src/actions/apply/terraform.ts`) now runs `terraform/terragrunt apply` directly and replays the captured output into `tfcmt apply` twice — once for the PR comment, once with `tfcmt --output $GITHUB_STEP_SUMMARY` so the result is mirrored to the Job Summary. This matches the two-step pattern already established by plan (`src/actions/plan/run.ts` `runTerraformPlan`).
- Apply results are now visible in the Job Summary regardless of exit code (success or failure). The `:white_check_mark:` / `:x:` heading is produced by tfcmt's own template, consistent with plan's existing behavior.
- The drift-issue notification (`TFACTION_DRIFT_ISSUE_NUMBER`) reuses the same captured-output file and behaves identically to before.

## Context

### Problem

The existing apply path called `executor.exec("tfcmt", [..., "apply", "--", tfCommand, "apply", ...], { ignoreReturnCode: true, ... })` — a single `tfcmt` invocation that internally ran `terraform apply`. Two consequences:

1. `tfcmt` only posts a PR comment; nothing reached the Actions Job Summary.
2. Because `ignoreReturnCode: true` is set, the recently added `writeFailureSummary` helper in `src/aqua/index.ts` could not pick up apply failures either.

Plan had already solved the equivalent problem by running `terraform plan` directly, persisting its combined output to a temp file, and replaying that file into `tfcmt` twice (PR comment + `--output` Step Summary). This PR brings apply in line.

### Implementation (`src/actions/apply/terraform.ts`)

The single `tfcmt -- terraform apply` call is replaced by three sequential steps:

1. **Step A — direct apply.** `executor.exec(tfCommand, ["apply", "-auto-approve", "-no-color", "-input=false", planFilePath], { ignoreReturnCode: true, ... })` with `listeners.stdout`/`stderr` accumulating into `combinedApplyOutput`. The exit code is captured. After the call returns, the buffered output is written to `applyOutput` via `fs.writeFileSync`.
2. **Step B — tfcmt replay for PR comment.** `executor.exec("tfcmt", [..., "apply", "--", "bash", "-c", 'cat "$1" && exit "$2"', "_", applyOutput, String(exitCode)], { ignoreReturnCode: true, group: "tfcmt apply", ... })`. Wrapped in `try`/`catch` with `core.warning` on failure so a network blip doesn't suppress the Job Summary step.
3. **Step C — tfcmt replay for Step Summary.** Skipped when `env.all.GITHUB_STEP_SUMMARY` is empty. Otherwise invokes `tfcmt` again with `--output <stepSummaryPath>` prepended to the same args. Same `try`/`catch` + warning policy.
4. **Step D — drift notification (unchanged).** Continues to use the captured `applyOutput` file via `bash -c "cat ${applyOutput} && exit ${exitCode}"`.

The previous double-write listeners (`process.stdout.write(data)` *and* `outputStream.write(data)`) are removed: `@actions/exec` already streams the child process output to the Actions log, so duplication is unnecessary. `fs.createWriteStream` / `outputStream.end()` are no longer needed.

Final `throw new Error("terraform apply failed")` on non-zero exit code is preserved.

Positional shell args (`"_", applyOutput, String(exitCode)`) keep the temp path / exit code out of the script body, mirroring `runTerraformPlan` (see `src/actions/plan/run.ts:456-467`).

### Out of scope

- `src/actions/apply/tfmigrate.ts` — already routes through `execAndComment` → `postComment`, which writes the rendered comment body to the Job Summary via `core.summary.addRaw(message).addEOL()` (`src/comment/index.ts:106-107`).
- `src/aqua/index.ts` Executor — no new generic `alwaysSummary` option; Summary responsibility stays with `tfcmt --output`, matching plan's design.
- Drift Issue notification (`terraform.ts` 147-191) — unchanged.

### Tests (`src/actions/apply/terraform.test.ts`)

Mock plumbing updated:

- `fs` mock: replace `createWriteStream` with `writeFileSync`.
- `env` mock: add `GITHUB_STEP_SUMMARY: ""` default and reset in `beforeEach`.
- `setupMainMocks`: drop `mockWriteStream`, wire `fs.writeFileSync.mockReturnValue(undefined)`.

Assertion updates and new cases (13 tests total, all passing):

- *runs full terraform apply flow*: asserts the direct `terraform apply` call AND the subsequent `tfcmt apply -- bash -c …` replay call.
- *uses custom terraform_command from target config*: now asserts that `tofu` is invoked directly (no longer wrapped in tfcmt args).
- *does not call tfcmt --output when GITHUB_STEP_SUMMARY is empty* (new).
- *writes Step Summary via tfcmt --output when GITHUB_STEP_SUMMARY is set* (new).
- *warns but does not throw when the PR comment tfcmt call fails* (new) — verifies `core.warning("Failed to post tfcmt PR comment …")`.
- *warns but does not throw when the Step Summary tfcmt call fails* (new) — verifies `core.warning("Failed to write tfcmt Step Summary …")`.
- *throws "terraform apply failed" when exit code is non-zero*: matcher now targets the direct `terraform apply` call (`cmd === "terraform"`).

## Test plan

- [x] `npm t` — 51 files / 917 tests pass locally
- [x] `npm run lint` — clean
- [x] `npm run fmt` — no changes
- [ ] Manual smoke test via `pr/<this PR number>` branch on a tfaction workflow:
  - [ ] apply success: PR comment posted + Job Summary contains tfcmt success summary
  - [ ] apply failure: PR comment posted + Job Summary contains tfcmt failure summary
  - [ ] drift route (`TFACTION_DRIFT_ISSUE_NUMBER` set): drift issue comment is posted as before
  - [ ] terragrunt target (custom `terraform_command`): direct `terragrunt apply` invocation + tfcmt replay both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)