### PR TITLE
fix(drift): default drift_detection.enabled to true when drift_detection is set

### DIFF
--- a/src/lib/drift.ts
+++ b/src/lib/drift.ts
@@ -48,7 +48,10 @@ export const checkDriftDetectionEnabled = (
   if (targetGroup?.drift_detection) {
     return targetGroup.drift_detection.enabled ?? true;
   }
-  return cfg.drift_detection?.enabled ?? false;
+  if (cfg.drift_detection) {
+    return cfg.drift_detection.enabled ?? true;
+  }
+  return false;
 };
 
 export interface DriftIssueRepo {

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -538,6 +538,13 @@ describe("checkDriftDetectionEnabled", () => {
     expect(checkDriftDetectionEnabled(cfg, targetGroup, wdCfg)).toBe(false);
   });
 
+  it("defaults to true when cfg.drift_detection exists but enabled is undefined", () => {
+    const cfg = createConfig({});
+    const targetGroup = createTargetGroup(undefined);
+    const wdCfg = createTargetConfig(undefined);
+    expect(checkDriftDetectionEnabled(cfg, targetGroup, wdCfg)).toBe(true);
+  });
+
   it("handles undefined targetGroup", () => {
     const cfg = createConfig({ enabled: true });
     const wdCfg = createTargetConfig(undefined);


### PR DESCRIPTION
## Summary

Fix a regression where `checkDriftDetectionEnabled` returned `false` when the root config had `drift_detection` defined but omitted `enabled`. This caused `create-drift-issues` to create an issue for every target and immediately archive it on every workflow run.

## Background

In `src/lib/drift.ts`, `checkDriftDetectionEnabled` resolves the effective `enabled` flag across three layers in priority order: working-directory config, target group, root config. Two of those layers already defaulted to `true` when `drift_detection` was set without an explicit `enabled`, but the root-config branch defaulted to `false`:

```ts
if (wdCfg.drift_detection)        return wdCfg.drift_detection.enabled ?? true;
if (targetGroup?.drift_detection) return targetGroup.drift_detection.enabled ?? true;
return cfg.drift_detection?.enabled ?? false;   // ← inconsistent default
```

When users configure drift detection at the root (e.g. `drift_detection: { minimum_detection_interval: 120, num_of_issues: 3 }`) without setting `enabled: true`, the function returned `false`, so `targetWDMap` in `src/actions/create-drift-issues/run.ts` ended up empty.

The create loop in `create-drift-issues/run.ts:224` iterates `m.values()` (every target), not `targetWDMap`, so it still created an issue for each target. The archive loop right below then archived each newly-created issue because the target was missing from `targetWDMap`. The observable symptom is a sequence like:

```
Created an issue for test/only_plan: …/4716
Archiving an issue for test/only_plan: …/4716
```

happening within the same workflow run, observed in `suzuki-shunsuke/tfaction-example` run `26348000285`.

## Changes

- `src/lib/drift.ts` — when `cfg.drift_detection` is defined, default `enabled` to `true` (matching the wdCfg and targetGroup branches). When `cfg.drift_detection` is undefined, still return `false`.
- `src/lib/index.test.ts` — add a unit test covering the new default: `cfg.drift_detection = {}` (no `enabled`) → returns `true`.

The original early-exit `if (!config.drift_detection) return undefined;` in `create-drift-issues/run.ts` still short-circuits when drift detection is wholly unconfigured, so behaviour for configs without any `drift_detection` block is unchanged.

## Test plan

- [x] `npm t` (918 tests pass, including the new case)
- [x] `npm run lint`
- [x] `npm run fmt`
- [ ] Verify on `tfaction-example` that the next drift-issues workflow run no longer creates+archives issues when root `drift_detection` omits `enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)