### PR TITLE
docs: fix outdated documentation links

### DIFF
--- a/src/actions/create-scaffold-pr/run.ts
+++ b/src/actions/create-scaffold-pr/run.ts
@@ -57,7 +57,7 @@ gh pr create -R "${repository}" ${draftOpt}\\
   -b "${escapedBody}"
 \`\`\`
 
-[Reference](https://suzuki-shunsuke.github.io/tfaction/docs/feature/skip-creating-pr)
+[Reference](https://suzuki-shunsuke.github.io/tfaction/docs/skip-create-pr)
 `;
 
   core.summary.addRaw(summary);

--- a/src/actions/scaffold-tfmigrate/run.ts
+++ b/src/actions/scaffold-tfmigrate/run.ts
@@ -126,12 +126,12 @@ gh pr create -R "${repository}" ${draftFlag}\\
   -l "${label}" \\
   -H "${branch}" \\
   -t "Scaffold tfmigrate migration (${target})" \\
-  -b "This pull request was created by [GitHub Actions](${runURL}). About tfmigrate, please see https://github.com/minamijoyo/tfmigrate [tfaction - tfmigrate](https://suzuki-shunsuke.github.io/tfaction/docs/feature/tfmigrate)"
+  -b "This pull request was created by [GitHub Actions](${runURL}). About tfmigrate, please see https://github.com/minamijoyo/tfmigrate [tfaction - tfmigrate](https://suzuki-shunsuke.github.io/tfaction/docs/tfmigrate)"
 \`\`\`
 
 Then please fix the generated migration file.
 
-[Reference](https://suzuki-shunsuke.github.io/tfaction/docs/feature/skip-creating-pr)
+[Reference](https://suzuki-shunsuke.github.io/tfaction/docs/skip-create-pr)
 `;
 
   fs.appendFileSync(stepSummaryPath, guide);
@@ -298,7 +298,7 @@ export const run = async (input: RunInput): Promise<void> => {
     ? Handlebars.compile(config?.scaffold_tfmigrate?.pull_request?.body)(vars)
     : `@${actor} This pull request was created by [GitHub Actions workflow_dispatch event](${runURL})
     About tfmigrate, please see https://github.com/minamijoyo/tfmigrate
-    [tfaction - tfmigrate](https://suzuki-shunsuke.github.io/tfaction/docs/feature/tfmigrate)
+    [tfaction - tfmigrate](https://suzuki-shunsuke.github.io/tfaction/docs/tfmigrate)
     Please fix the generated migration file.`;
 
   const prComment = config?.scaffold_tfmigrate?.pull_request?.comment

--- a/src/actions/sync-drift-issue-description/run.test.ts
+++ b/src/actions/sync-drift-issue-description/run.test.ts
@@ -27,7 +27,7 @@ describe("buildBody", () => {
       "https://suzuki-shunsuke.github.io/tfaction/docs/",
     );
     expect(result).toContain(
-      "https://suzuki-shunsuke.github.io/tfaction/docs/feature/drift-detection",
+      "https://suzuki-shunsuke.github.io/tfaction/docs/drift-detection",
     );
   });
 
@@ -41,7 +41,7 @@ describe("buildBody", () => {
     expect(result).toBe(
       `This issue was created by [tfaction](https://suzuki-shunsuke.github.io/tfaction/docs/).
 
-About this issue, please see [the document](https://suzuki-shunsuke.github.io/tfaction/docs/feature/drift-detection).
+About this issue, please see [the document](https://suzuki-shunsuke.github.io/tfaction/docs/drift-detection).
 
 ## Latest comment
 

--- a/src/actions/sync-drift-issue-description/run.ts
+++ b/src/actions/sync-drift-issue-description/run.ts
@@ -26,7 +26,7 @@ export type RunInput = {
 export const buildBody = (comment: Comment): string => {
   return `This issue was created by [tfaction](https://suzuki-shunsuke.github.io/tfaction/docs/).
 
-About this issue, please see [the document](https://suzuki-shunsuke.github.io/tfaction/docs/feature/drift-detection).
+About this issue, please see [the document](https://suzuki-shunsuke.github.io/tfaction/docs/drift-detection).
 
 ## Latest comment
 

--- a/src/lib/drift.ts
+++ b/src/lib/drift.ts
@@ -19,7 +19,7 @@ export const createIssue = async (
   const body = `
   This issues was created by [tfaction](https://suzuki-shunsuke.github.io/tfaction/docs/).
 
-  About this issue, please see [the document](https://suzuki-shunsuke.github.io/tfaction/docs/feature/drift-detection).
+  About this issue, please see [the document](https://suzuki-shunsuke.github.io/tfaction/docs/drift-detection).
   `;
 
   const issue = await octokit.rest.issues.create({

--- a/website/docs/v1/config/tfaction-root-yaml.md
+++ b/website/docs/v1/config/tfaction-root-yaml.md
@@ -109,7 +109,7 @@ aqua:
     prune: true # default is false
 
 # tfaction >= v1.3.0
-# https://suzuki-shunsuke.github.io/tfaction/docs/feature/local-path-module
+# https://suzuki-shunsuke.github.io/tfaction/docs/detect-module-dependency
 # https://github.com/suzuki-shunsuke/tfaction/pull/1528
 update_local_path_module_caller:
   enabled: true


### PR DESCRIPTION
Close #4017

## Context

Several code, documentation, and test files contained links pointing to the URL path `https://suzuki-shunsuke.github.io/tfaction/docs/feature/...`, which no longer exists.

The old docs were moved under `website/docs/v1/feature/`, and the current docs are published flat at `website/docs/*.md`. Because Docusaurus is configured with `routeBasePath: "/"` and `baseUrl: "/tfaction/docs/"`, each `website/docs/<file>.md` is served at `https://suzuki-shunsuke.github.io/tfaction/docs/<file>`. The intermediate `feature/` segment is gone.

This PR updates the stale links to the new flat doc URLs.

## Changes

Based on the diff against `main`, the following link replacements were made:

| Old link | New link | New doc file |
| --- | --- | --- |
| `docs/feature/skip-creating-pr` | `docs/skip-create-pr` | `website/docs/skip-create-pr.md` |
| `docs/feature/tfmigrate` | `docs/tfmigrate` | `website/docs/tfmigrate.md` |
| `docs/feature/drift-detection` | `docs/drift-detection` | `website/docs/drift-detection.md` |
| `docs/feature/local-path-module` | `docs/detect-module-dependency` | `website/docs/detect-module-dependency.md` |

Note: `local-path-module` was renamed to `detect-module-dependency` in the new docs; the mapping was confirmed by matching content (the `update_local_path_module_caller` feature description).

### Files

- `src/actions/scaffold-tfmigrate/run.ts` — tfmigrate (×2) and skip-create-pr links in the generated PR body / reference text
- `src/actions/create-scaffold-pr/run.ts` — skip-create-pr reference link
- `src/actions/sync-drift-issue-description/run.ts` — drift-detection link in the issue body
- `src/actions/sync-drift-issue-description/run.test.ts` — updated expected values to match `run.ts`
- `src/lib/drift.ts` — drift-detection link in the issue body
- `website/docs/v1/config/tfaction-root-yaml.md` — local-path-module → detect-module-dependency link in a YAML comment

## Verification

- `git grep "docs/feature/"` → 0 hits
- `npm t` → 918 tests passed
- `npm run lint` → no errors
- `npm run fmt` → no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)