### PR TITLE
ci(security): use takumi guard for npm install

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,7 +5,9 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -20,7 +22,12 @@ jobs:
         with:
           node-version-file: .node-version
           cache: npm
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm ci
+      - name: Restore .npmrc to avoid committing the registry auth token
+        run: git checkout -- .npmrc
 
       - run: aqua upc -prune
       - run: aqua upc -prune

--- a/.github/workflows/create-pr-branch.yaml
+++ b/.github/workflows/create-pr-branch.yaml
@@ -18,17 +18,22 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     with:
       pr: ${{fromJSON(inputs.pr)}}
       is_comment: ${{inputs.is_comment}}
     secrets:
       gh_app_id: ${{secrets.APP_ID}}
       gh_app_private_key: ${{secrets.APP_PRIVATE_KEY}}
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
   release:
     uses: ./.github/workflows/wc-release.yaml
     with:
       version: latest
       pr: ${{fromJSON(inputs.pr)}}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,9 @@ jobs:
     uses: ./.github/workflows/wc-release.yaml
     with:
       version: latest
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ jobs:
     with:
       version: ${{inputs.tag}}
       pr: ${{inputs.pr}}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,9 @@ jobs:
     secrets:
       gh_app_id: ${{secrets.APP_ID}}
       gh_app_private_key: ${{secrets.APP_PRIVATE_KEY}}
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write

--- a/.github/workflows/wc-create-pr-branch.yaml
+++ b/.github/workflows/wc-create-pr-branch.yaml
@@ -18,6 +18,8 @@ on:
         required: true
       gh_app_private_key:
         required: true
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   create-pr-branch:
@@ -26,9 +28,12 @@ jobs:
       version: pr/${{inputs.pr}}
       pr: ${{inputs.pr}}
       is_comment: ${{inputs.is_comment}}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
   test-normal:
     name: Test Normal (${{matrix.env.key}})

--- a/.github/workflows/wc-release.yaml
+++ b/.github/workflows/wc-release.yaml
@@ -17,6 +17,9 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   release:
@@ -25,6 +28,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -45,6 +49,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: npm
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm ci
 
       - run: cmdx -v

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -1,15 +1,23 @@
 ---
 name: wc-test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   test:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm ci
       - run: npm t
       - run: npx eslint

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -6,6 +6,8 @@ on:
         required: false
       gh_app_private_key:
         required: false
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   path-filter:
     # Get changed files to filter jobs
@@ -52,7 +54,10 @@ jobs:
 
   test:
     uses: ./.github/workflows/wc-test.yaml
-    permissions: {}
+    permissions:
+      id-token: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
 
   create-pr-branch:
     uses: ./.github/workflows/wc-create-pr-branch.yaml
@@ -62,11 +67,13 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     with:
       pr: ${{github.event.pull_request.number}}
     secrets:
       gh_app_id: ${{secrets.gh_app_id}}
       gh_app_private_key: ${{secrets.gh_app_private_key}}
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
 
   typos:
     uses: ./.github/workflows/workflow_call_typos.yaml

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @jsr:registry=https://npm.jsr.io
+registry=https://npm.flatt.tech/


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://shisho.dev/docs/r/202604-takumi-guard-rate-limit/#getting-started-with-organization-usage) to authenticate npm installs against the private registry (`npm.flatt.tech`), mirroring csm-actions/securefix-action#668 (the same change already applied to label-action, update-branch-action, and lock-action).

## Changes

- **`.npmrc`** — point the npm registry at `https://npm.flatt.tech/` (alongside the existing `@jsr` registry). This routes installs through Takumi Guard, which requires authentication.
- **Add `setup-takumi-guard-npm@v1.1.1` before each `npm ci`** in the three workflows that install dependencies, granting each job `id-token: write` for OIDC:
  - `autofix.yaml`
  - `wc-release.yaml`
  - `wc-test.yaml`
- **Thread the `TAKUMI_GUARD_BOT_ID` credential** through the reusable workflows and their callers:
  - `wc-release.yaml`, `wc-test.yaml`, `wc-create-pr-branch.yaml`, `workflow_call_test.yaml` declare it as a required `workflow_call` secret.
  - `wc-create-pr-branch.yaml` passes it down to its `wc-release` call.
  - `test.yaml`, `main.yaml`, `release.yaml`, `create-pr-branch.yaml` pass it down and propagate `id-token: write`.
- **Restore `.npmrc` in `autofix`** — `setup-takumi-guard-npm` writes a short-lived registry auth token into `.npmrc`, and autofix-ci commits the whole working tree. `git checkout -- .npmrc` runs right after `npm ci` so the token is never committed to the public PR branch.

`wc-create-pr-branch.yaml`'s test jobs don't install npm dependencies (they consume the `dist` artifact built by `wc-release` via `download-artifact`), so they need no Takumi Guard step.

## Prerequisite

A repository/organization secret **`TAKUMI_GUARD_BOT_ID`** (the bot ID issued by Shisho Cloud) must be configured, otherwise OIDC authentication fails.

## Validation

- `ghalint run` passes.
- `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
