### PR TITLE
fix(comment): quote bare boolean `when` fields

### DIFF
--- a/install/comment.yaml
+++ b/install/comment.yaml
@@ -135,7 +135,7 @@ exec:
         {{hidden_combined_output}}
 
   tfmigrate-apply:
-    - when: true
+    - when: "true"
       template: |
         ## {{status}} {{#if Vars.tfaction_target}}{{Vars.tfaction_target}}: {{/if}} tfmigrate apply
 
@@ -146,7 +146,7 @@ exec:
         {{hidden_combined_output}}
 
   drift-apply:
-    - when: true
+    - when: "true"
       template: |
         ## {{status}} tfmigrate apply
 
@@ -170,7 +170,7 @@ exec:
         {{{CombinedOutput}}}
 
   tfmigrate-plan:
-    - when: true
+    - when: "true"
       template: |
         ## {{status}} {{#if Vars.tfaction_target}}{{Vars.tfaction_target}}: {{/if}} tfmigrate plan
 


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #4050
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

Closes #4050.

### What changed

Quote the bare boolean `when` literals in `install/comment.yaml` so `@marcbachmann/cel-js`'s `evaluate()` receives a string. Affected entries: `tfmigrate-plan`, `tfmigrate-apply`, `drift-apply`.

### Why

js-yaml parses bare `true` as a JavaScript boolean. `evaluateWhen` in `src/comment/exec.ts` then passes the value to cel-js, which rejects non-string inputs with `Expression must be a string` (see `marcbachmann/cel-js/lib/parser.js`). As a result, every `tfmigrate plan` / `tfmigrate apply` job in v2 crashes right after the migrator finishes. Full analysis and a minimum reproduction are in #4050.

### Notes

- Investigated and patched with Claude Code (AI-assisted).
