### PR TITLE
feat: stop re-requesting review after dismissing approvals

### DIFF
--- a/src/actions/plan/run.test.ts
+++ b/src/actions/plan/run.test.ts
@@ -498,11 +498,7 @@ describe("runTerraformPlan", () => {
 
     // 1 list query + 1 dismiss mutation
     expect(mockOctokit.graphql).toHaveBeenCalledTimes(2);
-    expect(mockOctokit.rest.pulls.requestReviewers).toHaveBeenCalledWith(
-      expect.objectContaining({
-        reviewers: ["user1"],
-      }),
-    );
+    expect(mockOctokit.rest.pulls.requestReviewers).not.toHaveBeenCalled();
   });
 
   it("skips dismissApprovalReviews when disabled", async () => {
@@ -670,11 +666,7 @@ describe("dismissApprovalReviews", () => {
         ),
       }),
     );
-    expect(mockOctokit.rest.pulls.requestReviewers).toHaveBeenCalledWith(
-      expect.objectContaining({
-        reviewers: ["user1", "user2"],
-      }),
-    );
+    expect(mockOctokit.rest.pulls.requestReviewers).not.toHaveBeenCalled();
   });
 
   it("handles GraphQL query failure gracefully", async () => {
@@ -717,12 +709,6 @@ describe("dismissApprovalReviews", () => {
     );
     // 1 list query + 2 dismiss mutations (both attempted)
     expect(mockOctokit.graphql).toHaveBeenCalledTimes(3);
-    // Only user2 was successfully dismissed
-    expect(mockOctokit.rest.pulls.requestReviewers).toHaveBeenCalledWith(
-      expect.objectContaining({
-        reviewers: ["user2"],
-      }),
-    );
   });
 
   it("does not prepend mention for deleted user (null author)", async () => {
@@ -745,8 +731,6 @@ describe("dismissApprovalReviews", () => {
         message: expect.stringMatching(/^Dismissing approval/),
       }),
     );
-    // null author means no login, so no re-review request
-    expect(mockOctokit.rest.pulls.requestReviewers).not.toHaveBeenCalled();
   });
 
   it("does not prepend mention for bot author", async () => {
@@ -781,8 +765,6 @@ describe("dismissApprovalReviews", () => {
         message: expect.stringMatching(/^Dismissing approval/),
       }),
     );
-    // Bot author has no User login, so no re-review request
-    expect(mockOctokit.rest.pulls.requestReviewers).not.toHaveBeenCalled();
   });
 
   it("does nothing when no approved reviews exist", async () => {
@@ -798,60 +780,6 @@ describe("dismissApprovalReviews", () => {
 
     // Only the list query, no dismiss mutations
     expect(mockOctokit.graphql).toHaveBeenCalledTimes(1);
-    expect(mockOctokit.rest.pulls.requestReviewers).not.toHaveBeenCalled();
-  });
-
-  it("requests re-review with deduplicated logins", async () => {
-    const mockOctokit = createMockOctokit();
-    mockOctokit.graphql
-      .mockResolvedValueOnce(
-        graphqlReviewsResponse(
-          [
-            { id: "PRR_1", author: { __typename: "User", login: "user1" } },
-            { id: "PRR_2", author: { __typename: "User", login: "user1" } },
-          ],
-          false,
-          null,
-        ),
-      )
-      .mockResolvedValueOnce({}) // dismiss PRR_1
-      .mockResolvedValueOnce({}); // dismiss PRR_2
-    vi.mocked(github.getOctokit).mockReturnValue(
-      mockOctokit as unknown as ReturnType<typeof github.getOctokit>,
-    );
-
-    await dismissApprovalReviews("test-token", 42);
-
-    expect(mockOctokit.rest.pulls.requestReviewers).toHaveBeenCalledWith(
-      expect.objectContaining({
-        reviewers: ["user1"],
-      }),
-    );
-  });
-
-  it("handles requestReviewers failure gracefully", async () => {
-    const mockOctokit = createMockOctokit();
-    mockOctokit.graphql
-      .mockResolvedValueOnce(
-        graphqlReviewsResponse(
-          [{ id: "PRR_1", author: { __typename: "User", login: "user1" } }],
-          false,
-          null,
-        ),
-      )
-      .mockResolvedValueOnce({}); // dismiss PRR_1
-    mockOctokit.rest.pulls.requestReviewers.mockRejectedValueOnce(
-      new Error("Request reviewers failed"),
-    );
-    vi.mocked(github.getOctokit).mockReturnValue(
-      mockOctokit as unknown as ReturnType<typeof github.getOctokit>,
-    );
-
-    await dismissApprovalReviews("test-token", 42);
-
-    expect(core.warning).toHaveBeenCalledWith(
-      "Failed to request reviewers: Request reviewers failed",
-    );
   });
 });
 

--- a/src/actions/plan/run.ts
+++ b/src/actions/plan/run.ts
@@ -213,7 +213,6 @@ export const dismissApprovalReviews = async (
       cursor = result.repository.pullRequest.reviews.pageInfo.endCursor;
     }
 
-    const dismissedLogins: string[] = [];
     for (const review of reviewIds) {
       try {
         await octokit.graphql(
@@ -229,28 +228,9 @@ export const dismissApprovalReviews = async (
             message: `${review.login ? `@${review.login} ` : ""}Dismissing approval because terraform plan has been re-run. Please review the new plan output before approving again.`,
           },
         );
-        if (review.login) {
-          dismissedLogins.push(review.login);
-        }
       } catch (e) {
         core.warning(
           `Failed to dismiss review ${review.id}: ${e instanceof Error ? e.message : String(e)}`,
-        );
-      }
-    }
-
-    const uniqueLogins = [...new Set(dismissedLogins)];
-    if (uniqueLogins.length > 0) {
-      try {
-        await octokit.rest.pulls.requestReviewers({
-          owner,
-          repo,
-          pull_number: prNumber,
-          reviewers: uniqueLogins,
-        });
-      } catch (e) {
-        core.warning(
-          `Failed to request reviewers: ${e instanceof Error ? e.message : String(e)}`,
         );
       }
     }


### PR DESCRIPTION
## Overview

Closes #4077

When `terraform plan` is re-run on a PR, the plan action dismisses existing approvals (so reviewers re-approve after seeing the new plan output). Previously it also automatically re-requested review from the dismissed reviewers.

The problem: after a plan re-run the PR is not necessarily in a reviewable state — the plan may have failed or produced unexpected output. Automatically requesting review in that situation is wrong. Making it a config option doesn't help either, because "is this PR reviewable right now?" isn't something the user can decide up front. So this removes the re-request-review behavior unconditionally.

Dismissing approvals (with the mention message asking reviewers to re-review the new plan) is unchanged.

## Changes

`src/actions/plan/run.ts`
- In `dismissApprovalReviews`, removed the `dismissedLogins` tracking array and the `octokit.rest.pulls.requestReviewers(...)` call (and its error handling). Reviews are still dismissed as before.

`src/actions/plan/run.test.ts`
- Replaced the `requestReviewers` "called with" assertions with `not.toHaveBeenCalled()` regression guards in the main dismiss tests, locking in the new behavior.
- Removed the now-redundant `requestReviewers` assertions/comments from the deleted-user, bot-author, mutation-failure, and no-approved-reviews tests.
- Deleted the two tests that existed solely for the removed feature (`requests re-review with deduplicated logins`, `handles requestReviewers failure gracefully`).

No documentation changes — the re-request-review behavior was never documented.

## Verification

- `npm t` — 916 tests pass
- `npm run lint` — clean
- `npm run fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)