### PR TITLE
Security: Unsafe JSON.parse without validation in mergeSecrets

### DIFF
--- a/src/lib/secret.ts
+++ b/src/lib/secret.ts
@@ -1,15 +1,40 @@
+function isPlainObject(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (Object.getPrototypeOf(value) !== Object.prototype) {
+    return false;
+  }
+  for (const key of Object.keys(value)) {
+    if (typeof (value as Record<string, unknown>)[key] !== "string") {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function mergeSecrets(
   secrets?: string,
   awsSecrets?: string,
 ): Record<string, string> | undefined {
-  const base = secrets
-    ? (JSON.parse(secrets) as Record<string, string>)
-    : undefined;
-  const aws = awsSecrets
-    ? (JSON.parse(awsSecrets) as Record<string, string>)
-    : undefined;
+  let base: Record<string, string> | undefined;
+  let aws: Record<string, string> | undefined;
+  if (secrets) {
+    const parsed = JSON.parse(secrets);
+    if (!isPlainObject(parsed)) {
+      throw new Error("secrets must be a JSON object with string values");
+    }
+    base = parsed;
+  }
+  if (awsSecrets) {
+    const parsed = JSON.parse(awsSecrets);
+    if (!isPlainObject(parsed)) {
+      throw new Error("aws_secrets must be a JSON object with string values");
+    }
+    aws = parsed;
+  }
   if (!base && !aws) {
     return undefined;
   }
-  return { ...base, ...aws };
+  return Object.assign(Object.create(null), base, aws);
 }


### PR DESCRIPTION
## Summary

Security: Unsafe JSON.parse without validation in mergeSecrets

## Problem

**Severity**: `High` | **File**: `src/lib/secret.ts:L1`

The `mergeSecrets` function in `src/lib/secret.ts` parses JSON strings inputs without any validation or sanitization. While the function uses type assertions, these don't provide runtime safety. Malformed JSON will throw a SyntaxError, and malicious JSON containing prototype pollution payloads could potentially affect downstream code that iterates over the returned object. The function is used in security-sensitive contexts for merging secrets.

## Solution

Add try-catch blocks around JSON.parse calls and validate the parsed output structure using a schema validator like Zod. Consider using Object.create(null) for the returned object to prevent prototype pollution, or at minimum validate that the parsed values are plain objects with string values.

## Changes

- `src/lib/secret.ts` (modified)