### PR TITLE
chore(renovate): keep typescript on v6 until typescript-eslint supports v7

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,4 +6,14 @@
     "github>aquaproj/aqua-renovate-config#2.13.0",
     "github>aquaproj/aqua-renovate-config:file#2.13.0(aqua/.*\\.yaml)",
   ],
+  packageRules: [
+    {
+      // typescript-eslint doesn't support TypeScript 7 yet.
+      // Its peer dependency is `typescript: ">=4.8.4 <6.1.0"`, so `npm i` fails with ERESOLVE.
+      // https://github.com/typescript-eslint/typescript-eslint/issues/12518
+      matchManagers: ["npm"],
+      matchDepNames: ["typescript"],
+      allowedVersions: "<7",
+    },
+  ],
 }


### PR DESCRIPTION
typescript-eslint doesn't support TypeScript 7 yet. Its latest version 8.65.0 still declares the peer dependency `typescript: ">=4.8.4 <6.1.0"`, so a TypeScript 7 bump makes `npm i` fail with ERESOLVE. Forcing the install doesn't help either, because TypeScript 7 is the Go based tsgo and typescript-estree crashes at runtime.

- https://github.com/typescript-eslint/typescript-eslint/issues/12518
- #4140 was closed for this reason

This `allowedVersions` rule stops Renovate from recreating the same broken PR every time a new TypeScript 7.0.x is released. Remove it once typescript-eslint supports TypeScript 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted automatic TypeScript updates to versions below 7 to maintain compatibility with existing tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->