### PR TITLE
fix(hk): don't batch whole-repo pre-commit steps

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -6,42 +6,42 @@ local linters = new Mapping<String, Step> {
     fix = check
   }
   // ["lychee"] = Builtins.lychee
+  // nllint / langcheck take the target files as arguments ({{files}}), but do
+  // not need batching: without batch, hk passes all matched files to a single
+  // invocation, avoiding the overhead of spawning one process per batch.
   ["nllint"] {
     glob = List("**/*")
     check = "nllint -s {{files}}"
     fix = "nllint -s -f {{files}}"
-    batch = true
   }
   ["langcheck"] {
     // https://github.com/suzuki-shunsuke/langcheck
     glob = List("**/*")
     check = "langcheck check {{files}}"
     fix = "langcheck check {{files}}" // run as check in fix mode (no real fix possible)
-    batch = true
   }
+  // These run whole-repo commands that ignore {{files}}, so they must not be
+  // batched. batch = true would split the changed files into groups and run
+  // the same command once per group in parallel (redundant).
   ["fmt"] {
     glob = List("**/*")
     check = "npm run fmt"
     fix = "npm run fmt"
-    batch = true
   }
   ["build"] {
     glob = List("**/*")
     check = "npm run build"
     fix = "npm run build"
-    batch = true
   }
   ["lint"] {
     glob = List("**/*")
     check = "npm run lint"
     fix = "npm run lint"
-    batch = true
   }
   ["test"] {
     glob = List("**/*")
     check = "npm t"
     fix = "npm t"
-    batch = true
   }
 }
 


### PR DESCRIPTION
## What

Remove `batch = true` from the pre-commit steps in `hk.pkl`.

## Why

The `fmt`, `build`, `lint`, and `test` steps run whole-repo commands (`npm run fmt` / `npm run build` / `npm run lint` / `npm t`) that ignore `{{files}}`, but they had `batch = true`.

`batch` splits the changed files into groups and runs the command once per group in parallel. Since these commands don't use `{{files}}`, batching just runs the same whole-repo command redundantly — once per changed file. For a commit that touches N files, `npm run lint` (and build/test/fmt) ran N times in parallel.

`nllint` and `langcheck` do take the target files as arguments (`{{files}}`), but they don't benefit from batching either: a single invocation with all files avoids the overhead of spawning one process per batch. So `batch` is removed from every step.

`batch` is meant for otherwise single-threaded per-file linters (like eslint/prettier) where running parallel process-level chunks is faster; none of these steps fit that.

https://hk.jdx.dev/gen/pkl-config.html#step-batch-boolean

> `<STEP>.batch: Boolean`
> Default: false
> 
> If true, hk will run the linter on batches of files instead of all files at once.
> This takes advantage of parallel processing for otherwise single-threaded linters like eslint and prettier.

## Verification

- `hk validate` passes.
- Running only `nllint` across all files now produces a single `nllint -s <all files>` invocation instead of one process per batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
