### PR TITLE
fix(docs):  fix 'github_secrets' to 'secrets' in secret.md

### DIFF
--- a/website/docs/secret.md
+++ b/website/docs/secret.md
@@ -35,7 +35,7 @@ Pass all secrets to the output-github-secrets action. It outputs only the requir
 - uses: suzuki-shunsuke/tfaction@latest
   with:
     action: terraform-init
-    github_secrets: ${{ steps.github-secrets.outputs.secrets }}
+    secrets: ${{ steps.github-secrets.outputs.secrets }}
 ```
 
 ## AWS Secrets Manager


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

fix typo

ref:
- https://github.com/suzuki-shunsuke/tfaction/blob/main/src/actions/apply/index.ts#L9
- https://github.com/suzuki-shunsuke/tfaction/blob/main/src/actions/plan/index.ts#L39
- https://github.com/suzuki-shunsuke/tfaction/blob/main/src/actions/terraform-init/index.ts#L55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub Secrets workflow example to use the current `secrets` input when passing secret values to the Terraform initialization action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->