### PR TITLE
fix: resolve YAML merge keys (`<<`) in config files

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -38,5 +38,26 @@ export default defineConfig([
       "@typescript-eslint/require-await": "error",
     },
   },
+  {
+    // js-yaml's load() doesn't resolve YAML merge keys (`<<`) by default since
+    // v5, so it must be called only through src/lib/yaml.ts.
+    // https://github.com/suzuki-shunsuke/tfaction/issues/4213
+    files: ["**/*.{ts,mts,cts}"],
+    ignores: ["src/lib/yaml.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "js-yaml",
+              message:
+                "Use loadYaml() in src/lib/yaml.ts instead. js-yaml's load() doesn't resolve YAML merge keys (`<<`) by default.",
+            },
+          ],
+        },
+      ],
+    },
+  },
   globalIgnores(["docusaurus.config.js", "website/*", "build/*", "dist/*"]),
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@types/js-yaml": "4.0.9",
         "@types/node": "24.13.3",
         "@types/semver": "7.7.1",
         "@types/tmp": "0.2.6",
@@ -1928,13 +1927,6 @@
       "version": "1.0.9",
       "resolved": "https://npm.flatt.tech/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://npm.flatt.tech/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@types/js-yaml": "4.0.9",
     "@types/node": "24.13.3",
     "@types/semver": "7.7.1",
     "@types/tmp": "0.2.6",

--- a/src/comment/index.ts
+++ b/src/comment/index.ts
@@ -2,10 +2,10 @@ import * as fs from "fs";
 import * as path from "path";
 import * as core from "@actions/core";
 import * as github from "@actions/github";
-import * as yaml from "js-yaml";
 import Handlebars from "handlebars";
 
 import * as lib from "../lib";
+import { loadYaml } from "../lib/yaml";
 
 export type Inputs = {
   octokit: ReturnType<typeof github.getOctokit>;
@@ -34,7 +34,7 @@ export type CommentConfig = {
 export const loadConfig = (): CommentConfig => {
   const configPath = path.join(lib.GitHubActionPath, "install", "comment.yaml");
   const content = fs.readFileSync(configPath, "utf8");
-  return yaml.load(content) as CommentConfig;
+  return loadYaml(content) as CommentConfig;
 };
 
 const block = "```";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,12 +1,12 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as core from "@actions/core";
-import { load } from "js-yaml";
 import { minimatch } from "minimatch";
 import { z } from "zod";
 import * as env from "./env";
 import { fileURLToPath } from "node:url";
 import { listWorkingDirFiles, getRootDir as getGitRootDir } from "./git";
+import { loadYaml } from "./yaml";
 import {
   RawConfig,
   Config,
@@ -62,7 +62,7 @@ export const applyConfigDefaults = async (
 export const getConfig = async (): Promise<Config> => {
   const configPath = env.TFACTION_CONFIG;
   const workspace = env.GITHUB_WORKSPACE;
-  const raw = RawConfig.parse(load(fs.readFileSync(configPath, "utf8")));
+  const raw = RawConfig.parse(loadYaml(fs.readFileSync(configPath, "utf8")));
   return await applyConfigDefaults(raw, configPath, workspace);
 };
 
@@ -116,7 +116,7 @@ export const getTargetFromTargetGroupsByWorkingDir = (
 };
 
 export const readTargetConfig = (p: string): TargetConfig => {
-  return TargetConfig.parse(load(fs.readFileSync(p, "utf8")));
+  return TargetConfig.parse(loadYaml(fs.readFileSync(p, "utf8")));
 };
 
 export const getJobConfig = (

--- a/src/lib/yaml.test.ts
+++ b/src/lib/yaml.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { loadYaml } from "./yaml";
+
+describe("loadYaml", () => {
+  it("resolves merge keys", () => {
+    // https://github.com/suzuki-shunsuke/tfaction/issues/4213
+    const content = `
+target_groups:
+  - <<: &default
+      aws_region: ap-northeast-1
+      terraform_plan_config:
+        aws_assume_role_arn: arn:aws:iam::123456789012:role/plan
+    working_directory: aws/dev/
+  - <<: *default
+    working_directory: aws/prod/
+`;
+    expect(loadYaml(content)).toEqual({
+      target_groups: [
+        {
+          aws_region: "ap-northeast-1",
+          terraform_plan_config: {
+            aws_assume_role_arn: "arn:aws:iam::123456789012:role/plan",
+          },
+          working_directory: "aws/dev/",
+        },
+        {
+          aws_region: "ap-northeast-1",
+          terraform_plan_config: {
+            aws_assume_role_arn: "arn:aws:iam::123456789012:role/plan",
+          },
+          working_directory: "aws/prod/",
+        },
+      ],
+    });
+  });
+
+  it("lets the merging map override merged fields", () => {
+    const content = `
+default: &default
+  aws_region: ap-northeast-1
+  destroy: false
+target:
+  <<: *default
+  aws_region: us-east-1
+`;
+    expect(loadYaml(content)).toEqual({
+      default: { aws_region: "ap-northeast-1", destroy: false },
+      target: { aws_region: "us-east-1", destroy: false },
+    });
+  });
+
+  it("resolves merge keys merging multiple maps", () => {
+    const content = `
+a: &a
+  aws_region: ap-northeast-1
+b: &b
+  destroy: true
+target:
+  <<: [*a, *b]
+`;
+    expect(loadYaml(content)).toEqual({
+      a: { aws_region: "ap-northeast-1" },
+      b: { destroy: true },
+      target: { aws_region: "ap-northeast-1", destroy: true },
+    });
+  });
+
+  it("doesn't resolve YAML 1.1 specific types", () => {
+    // js-yaml v4 didn't resolve them either, so the schema must not be
+    // YAML11_SCHEMA.
+    const content = `
+enabled: yes
+mode: 0700
+`;
+    expect(loadYaml(content)).toEqual({ enabled: "yes", mode: 700 });
+  });
+});

--- a/src/lib/yaml.ts
+++ b/src/lib/yaml.ts
@@ -1,0 +1,22 @@
+import { CORE_SCHEMA, load, mergeTag } from "js-yaml";
+
+/**
+ * js-yaml v5 changed the default schema of `load()` to CORE_SCHEMA, which
+ * doesn't include the merge type (`!!merge`) anymore. Without it, YAML merge
+ * keys (`<<: *anchor`) are kept as a literal `"<<"` key, and inherited fields
+ * are silently dropped from the config.
+ *
+ * tfaction has supported merge keys since it depended on js-yaml v4, so we opt
+ * back in explicitly. Note that we intentionally don't use YAML11_SCHEMA: it
+ * would also change the int/float/boolean syntax, which js-yaml v4 didn't do.
+ *
+ * https://github.com/suzuki-shunsuke/tfaction/issues/4213
+ * https://github.com/nodeca/js-yaml/blob/master/docs/migrate_v4_to_v5.md
+ */
+const schema = CORE_SCHEMA.withTags(mergeTag);
+
+/**
+ * Parse a YAML document, resolving merge keys (`<<`).
+ * Use this instead of js-yaml's `load()` directly.
+ */
+export const loadYaml = (content: string): unknown => load(content, { schema });


### PR DESCRIPTION
Fixes #4213

## Background

js-yaml v5 changed the default schema of `load()` to `CORE_SCHEMA`, which no longer includes the merge type (`!!merge`). tfaction updated js-yaml from v4 to v5 in #4091 / #4121, which shipped in v2.0.5.

Since then, YAML merge keys (`<<: *anchor`) in `tfaction-root.yaml` and `tfaction.yaml` are no longer resolved. The `<<` key is kept as a literal key, so the inherited fields are missing. Because the extra `"<<"` key is stripped by zod and the inherited fields are optional, the config still passes validation and the failure surfaces only much later. In the reported case, `target_groups[].terraform_plan_config.aws_assume_role_arn` inherited via `<<: *default` became empty, `Configure AWS Credentials` was skipped, and every plan job failed at `terraform init` with `Error: No valid credential sources found`.

This breaking change was not intentional, so this PR restores the previous behaviour.

## Changes

### Resolve merge keys again

Add `src/lib/yaml.ts`, which exports `loadYaml()`. It opts back into the merge type with the mechanism js-yaml v5 provides for this purpose:

```ts
const schema = CORE_SCHEMA.withTags(mergeTag);
export const loadYaml = (content: string): unknown => load(content, { schema });
```

All call sites of js-yaml's `load()` now go through it:

- `src/lib/index.ts` — `getConfig()` (`tfaction-root.yaml`) and `readTargetConfig()` (`tfaction.yaml`). These are the ones affected by the regression.
- `src/comment/index.ts` — `loadConfig()` (the bundled `install/comment.yaml`). This file doesn't use merge keys, so it isn't affected, but it goes through the same loader for consistency.

`YAML11_SCHEMA` is intentionally not used. It would restore merge keys too, but it would also switch to the YAML 1.1 int/float/boolean syntax (`yes`/`no` as booleans, `0700` as octal), which js-yaml v4 didn't do either. That would be a new behaviour change rather than a fix. A test pins this down.

No configuration option is added: merge keys are simply resolved again, as in v2.0.4 and earlier.

### Prevent the regression from coming back

Importing `js-yaml` outside `src/lib/yaml.ts` is now an ESLint error (`no-restricted-imports`), so a new call site can't silently reintroduce the problem.

### Drop the stale `@types/js-yaml`

js-yaml v5 ships its own type definitions, so the `@types/js-yaml` v4 devDependency is unnecessary. It is also a hazard: the v4 types declare neither `Schema.withTags()` nor `mergeTag`, so this fix wouldn't type-check if those types ever won module resolution.

## Tests

`src/lib/yaml.test.ts` covers the reproduction case from the issue, overriding a merged field in the merging map, merging multiple maps (`<<: [*a, *b]`), and the YAML 1.1 syntax not being resolved.

## Note for the release

Since the config loads successfully and fails at a distance, users hitting this may have pinned tfaction to v2.0.4. It's worth stating in the release notes that v2.0.5 stopped resolving merge keys and that this release fixes it.

Thanks to @gr1m0h for the detailed report and the reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML configuration loading to reliably support merge keys and override precedence.
  * Preserved existing YAML 1.1 scalar behavior while maintaining compatibility with updated parsing behavior.

* **Quality Improvements**
  * Standardized configuration parsing across application and comment settings.
  * Added automated coverage for YAML merging, overrides, and multiple-map configurations.
  * Added safeguards to ensure YAML files are parsed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->