### PR TITLE
fix: skip terraform plan and apply when skip_terraform is set

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -166,10 +166,6 @@ outputs:
   csm_actions_server_repository:
     description: CSM Actions Server Repository
 
-  # check-terraform-skip
-  skip_terraform:
-    description: whether terraform is skipped
-
   # list-module-caller
   file:
     description: |

--- a/src/actions/README.md
+++ b/src/actions/README.md
@@ -16,3 +16,4 @@ This document describes common inputs and environment variables shared across mu
 - `TFACTION_JOB_TYPE`: One of `terraform` | `tfmigrate` | `scaffold_working_dir`. Used to change the behavior of actions.
   - `terraform`: Runs terraform plan or apply
   - `tfmigrate`: Runs tfmigrate plan or apply
+- `TFACTION_SKIP_TERRAFORM`: `true` | `false`. If `true`, plan and apply do nothing

--- a/src/actions/README.md
+++ b/src/actions/README.md
@@ -16,4 +16,3 @@ This document describes common inputs and environment variables shared across mu
 - `TFACTION_JOB_TYPE`: One of `terraform` | `tfmigrate` | `scaffold_working_dir`. Used to change the behavior of actions.
   - `terraform`: Runs terraform plan or apply
   - `tfmigrate`: Runs tfmigrate plan or apply
-- `TFACTION_SKIP_TERRAFORM`

--- a/src/actions/apply/README.md
+++ b/src/actions/apply/README.md
@@ -13,19 +13,20 @@ All inputs are optional.
 ## Environment variables
 
 - `TFACTION_JOB_TYPE`
+- `TFACTION_SKIP_TERRAFORM`
 
 ## Steps
 
-1. Download the plan file from GitHub Artifacts
+1. If `TFACTION_SKIP_TERRAFORM` is `true`, warn and do nothing
+2. Download the plan file from GitHub Artifacts
    - Fails if `plan_workflow_name` is incorrect
-2. Run terraform apply and notify via tfcmt
-3. If drift detection is enabled, update the drift issue
-4. Update branches of other PRs that modify the same root module
+3. Run terraform apply and notify via tfcmt
+4. If drift detection is enabled, update the drift issue
+5. Update branches of other PRs that modify the same root module
 
 ## Skipping apply
 
-This action doesn't check `skip_terraform` by itself.
-To skip apply, gate the step with the `skip_terraform` field of the [list-targets](../list-targets/README.md) output.
+Gating the step with the `skip_terraform` field of the [list-targets](../list-targets/README.md) output is the recommended way to skip apply, because then this action doesn't run at all.
 
 ```yaml
 - uses: suzuki-shunsuke/tfaction@latest
@@ -33,3 +34,6 @@ To skip apply, gate the step with the `skip_terraform` field of the [list-target
   with:
     action: apply
 ```
+
+`TFACTION_SKIP_TERRAFORM` is a backstop for workflows that don't gate the step.
+This action warns when it skips because of the environment variable.

--- a/src/actions/apply/README.md
+++ b/src/actions/apply/README.md
@@ -13,13 +13,23 @@ All inputs are optional.
 ## Environment variables
 
 - `TFACTION_JOB_TYPE`
-- `TFACTION_SKIP_TERRAFORM`
 
 ## Steps
 
-1. If `skip_terraform` is enabled, do nothing
-2. Download the plan file from GitHub Artifacts
+1. Download the plan file from GitHub Artifacts
    - Fails if `plan_workflow_name` is incorrect
-3. Run terraform apply and notify via tfcmt
-4. If drift detection is enabled, update the drift issue
-5. Update branches of other PRs that modify the same root module
+2. Run terraform apply and notify via tfcmt
+3. If drift detection is enabled, update the drift issue
+4. Update branches of other PRs that modify the same root module
+
+## Skipping apply
+
+This action doesn't check `skip_terraform` by itself.
+To skip apply, gate the step with the `skip_terraform` field of the [list-targets](../list-targets/README.md) output.
+
+```yaml
+- uses: suzuki-shunsuke/tfaction@latest
+  if: matrix.target.skip_terraform != true
+  with:
+    action: apply
+```

--- a/src/actions/apply/index.ts
+++ b/src/actions/apply/index.ts
@@ -10,14 +10,17 @@ export const main = async () => {
   const jobType = env.all.TFACTION_JOB_TYPE;
   const secrets = mergeSecrets(input.secrets, input.awsSecrets);
 
-  if (env.TFACTION_SKIP_TERRAFORM) {
-    core.warning(warnSkipTerraform("apply"));
-  }
-
   const githubTokenForGitHubProvider =
     input.githubTokenForGitHubProvider || undefined;
 
   if (jobType === "terraform") {
+    // list-targets decides whether terraform apply is necessary, and the
+    // workflow is expected to gate this step with the skip_terraform field.
+    // Honor TFACTION_SKIP_TERRAFORM as a backstop for workflows that don't.
+    if (env.TFACTION_SKIP_TERRAFORM) {
+      core.warning(warnSkipTerraform("apply"));
+      return;
+    }
     await terraformApply.main(secrets, githubTokenForGitHubProvider);
   } else if (jobType === "tfmigrate") {
     await tfmigrateApply.main(secrets, githubTokenForGitHubProvider);

--- a/src/actions/apply/index.ts
+++ b/src/actions/apply/index.ts
@@ -1,12 +1,18 @@
+import * as core from "@actions/core";
 import * as terraformApply from "./terraform";
 import * as tfmigrateApply from "./tfmigrate";
 import * as env from "../../lib/env";
 import * as input from "../../lib/input";
 import { mergeSecrets } from "../../lib/secret";
+import { warnSkipTerraform } from "../../lib/skip-terraform";
 
 export const main = async () => {
   const jobType = env.all.TFACTION_JOB_TYPE;
   const secrets = mergeSecrets(input.secrets, input.awsSecrets);
+
+  if (env.TFACTION_SKIP_TERRAFORM) {
+    core.warning(warnSkipTerraform("apply"));
+  }
 
   const githubTokenForGitHubProvider =
     input.githubTokenForGitHubProvider || undefined;

--- a/src/actions/list-targets/README.md
+++ b/src/actions/list-targets/README.md
@@ -21,7 +21,8 @@ The outputs are intended to be used as `env`, `runs-on`, and `environment` in su
     "working_directory": "github/service/foo",
     "runs_on": "ubuntu-latest",
     "job_type": "terraform",
-    "environment": "production"
+    "environment": "production",
+    "skip_terraform": false
   }
 ]
 ```
@@ -29,6 +30,7 @@ The outputs are intended to be used as `env`, `runs-on`, and `environment` in su
 - `target`: Alias for `working_directory`. Defaults to the same value as `working_directory`
 - `runs_on`: Job execution environment. Defaults to `ubuntu-latest`
 - `environment`: GitHub Environments
+- `skip_terraform`: Whether terraform plan and apply are unnecessary. `true` if all changed files match `skip_terraform_files`, or if the skip label is added to the PR. The plan and apply steps have to be gated with this field
 
 Example workflow usage:
 
@@ -48,6 +50,12 @@ plan:
     fail-fast: false
     matrix:
       target: ${{fromJSON(needs.list.outputs.targets)}}
+  steps:
+    # ...
+    - uses: suzuki-shunsuke/tfaction@latest
+      if: matrix.target.skip_terraform != true
+      with:
+        action: plan
 ```
 
 Settings can be changed in `tfaction-root.yaml`:

--- a/src/actions/list-targets/README.md
+++ b/src/actions/list-targets/README.md
@@ -30,7 +30,7 @@ The outputs are intended to be used as `env`, `runs-on`, and `environment` in su
 - `target`: Alias for `working_directory`. Defaults to the same value as `working_directory`
 - `runs_on`: Job execution environment. Defaults to `ubuntu-latest`
 - `environment`: GitHub Environments
-- `skip_terraform`: Whether terraform plan and apply are unnecessary. `true` if all changed files match `skip_terraform_files`, or if the skip label is added to the PR. The plan and apply steps have to be gated with this field
+- `skip_terraform`: Whether terraform plan and apply are unnecessary. `true` if all changed files match `skip_terraform_files`, or if the skip label is added to the PR. The workflow has to act on this field, either by gating the plan and apply steps with it or by passing it as `TFACTION_SKIP_TERRAFORM`
 
 Example workflow usage:
 

--- a/src/actions/plan/README.md
+++ b/src/actions/plan/README.md
@@ -4,3 +4,15 @@ Runs terraform plan or tfmigrate plan and comments the results on the PR via tfc
 Uploads the plan file in both binary and JSON format to GitHub Artifacts.
 If configured, runs Conftest against the plan file.
 If the PR is from Renovate and the plan result is not "No Change" and the setting is enabled, disables auto-merge.
+
+## Skipping plan
+
+This action doesn't check `skip_terraform` by itself.
+To skip plan, gate the step with the `skip_terraform` field of the [list-targets](../list-targets/README.md) output.
+
+```yaml
+- uses: suzuki-shunsuke/tfaction@latest
+  if: matrix.target.skip_terraform != true
+  with:
+    action: plan
+```

--- a/src/actions/plan/README.md
+++ b/src/actions/plan/README.md
@@ -5,10 +5,13 @@ Uploads the plan file in both binary and JSON format to GitHub Artifacts.
 If configured, runs Conftest against the plan file.
 If the PR is from Renovate and the plan result is not "No Change" and the setting is enabled, disables auto-merge.
 
+## Environment variables
+
+- `TFACTION_SKIP_TERRAFORM`: If `true`, this action warns and does nothing. Not applied to drift detection jobs
+
 ## Skipping plan
 
-This action doesn't check `skip_terraform` by itself.
-To skip plan, gate the step with the `skip_terraform` field of the [list-targets](../list-targets/README.md) output.
+Gating the step with the `skip_terraform` field of the [list-targets](../list-targets/README.md) output is the recommended way to skip plan, because then this action doesn't run at all.
 
 ```yaml
 - uses: suzuki-shunsuke/tfaction@latest
@@ -16,3 +19,6 @@ To skip plan, gate the step with the `skip_terraform` field of the [list-targets
   with:
     action: plan
 ```
+
+`TFACTION_SKIP_TERRAFORM` is a backstop for workflows that don't gate the step.
+This action warns when it skips because of the environment variable.

--- a/src/actions/plan/index.ts
+++ b/src/actions/plan/index.ts
@@ -11,6 +11,7 @@ import { getTargetConfig } from "../get-target-config";
 import { main as runPlan } from "./run";
 import { create as createCommit } from "../../commit";
 import { mergeSecrets } from "../../lib/secret";
+import { warnSkipTerraform } from "../../lib/skip-terraform";
 
 export const main = async () => {
   // Step 1: Get target config
@@ -27,6 +28,10 @@ export const main = async () => {
 
   const jobType = env.all.TFACTION_JOB_TYPE;
   const driftIssueNumber = env.all.TFACTION_DRIFT_ISSUE_NUMBER;
+
+  if (env.TFACTION_SKIP_TERRAFORM && !driftIssueNumber) {
+    core.warning(warnSkipTerraform("plan"));
+  }
 
   await runPlan(targetConfig, {
     githubToken: input.githubToken,

--- a/src/actions/plan/index.ts
+++ b/src/actions/plan/index.ts
@@ -29,8 +29,16 @@ export const main = async () => {
   const jobType = env.all.TFACTION_JOB_TYPE;
   const driftIssueNumber = env.all.TFACTION_DRIFT_ISSUE_NUMBER;
 
-  if (env.TFACTION_SKIP_TERRAFORM && !driftIssueNumber) {
+  // list-targets decides whether terraform plan is necessary, and the workflow
+  // is expected to gate this step with the skip_terraform field.
+  // Honor TFACTION_SKIP_TERRAFORM as a backstop for workflows that don't.
+  if (
+    jobType === "terraform" &&
+    !driftIssueNumber &&
+    env.TFACTION_SKIP_TERRAFORM
+  ) {
     core.warning(warnSkipTerraform("plan"));
+    return;
   }
 
   await runPlan(targetConfig, {

--- a/src/actions/update-drift-issue/README.md
+++ b/src/actions/update-drift-issue/README.md
@@ -8,3 +8,7 @@ This is an independent action to ensure it always runs in apply jobs and drift d
 ## Environment variables
 
 - `TFACTION_SKIP_TERRAFORM`: If `true`, the issue isn't closed. Set it in apply jobs so that skipping apply doesn't close the drift issue
+
+Unlike plan and apply, this step must not be gated with `skip_terraform`.
+It has to keep running with `if: always()` so that a failure elsewhere in the job still comments on the drift issue and reopens it.
+`TFACTION_SKIP_TERRAFORM` only suppresses closing the issue.

--- a/src/actions/update-drift-issue/README.md
+++ b/src/actions/update-drift-issue/README.md
@@ -4,3 +4,7 @@ Updates the specified drift issue based on plan or apply results.
 Closes the issue if plan or apply succeeds, and reopens it if they fail.
 
 This is an independent action to ensure it always runs in apply jobs and drift detection jobs.
+
+## Environment variables
+
+- `TFACTION_SKIP_TERRAFORM`: If `true`, the issue isn't closed. Set it in apply jobs so that skipping apply doesn't close the drift issue

--- a/src/lib/skip-terraform.test.ts
+++ b/src/lib/skip-terraform.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { warnSkipTerraform } from "./skip-terraform";
+
+describe("warnSkipTerraform", () => {
+  it("tells the user to gate the plan step", () => {
+    const msg = warnSkipTerraform("plan");
+    expect(msg).toContain("TFACTION_SKIP_TERRAFORM is true");
+    expect(msg).toContain("action: plan");
+    expect(msg).toContain("if: matrix.target.skip_terraform != true");
+  });
+
+  it("tells the user to gate the apply step", () => {
+    const msg = warnSkipTerraform("apply");
+    expect(msg).toContain("action: apply");
+    expect(msg).toContain(
+      "https://suzuki-shunsuke.github.io/tfaction/docs/skip-terraform",
+    );
+  });
+});

--- a/src/lib/skip-terraform.test.ts
+++ b/src/lib/skip-terraform.test.ts
@@ -5,6 +5,7 @@ import { warnSkipTerraform } from "./skip-terraform";
 describe("warnSkipTerraform", () => {
   it("tells the user to gate the plan step", () => {
     const msg = warnSkipTerraform("plan");
+    expect(msg).toContain("terraform plan is skipped");
     expect(msg).toContain("TFACTION_SKIP_TERRAFORM is true");
     expect(msg).toContain("action: plan");
     expect(msg).toContain("if: matrix.target.skip_terraform != true");
@@ -12,6 +13,7 @@ describe("warnSkipTerraform", () => {
 
   it("tells the user to gate the apply step", () => {
     const msg = warnSkipTerraform("apply");
+    expect(msg).toContain("terraform apply is skipped");
     expect(msg).toContain("action: apply");
     expect(msg).toContain(
       "https://suzuki-shunsuke.github.io/tfaction/docs/skip-terraform",

--- a/src/lib/skip-terraform.ts
+++ b/src/lib/skip-terraform.ts
@@ -1,0 +1,19 @@
+/**
+ * Builds a warning message telling the user that the step should have been
+ * gated with the `skip_terraform` field of the list-targets output.
+ *
+ * tfaction doesn't skip terraform plan and apply by itself.
+ * list-targets decides whether they're necessary and reports it as
+ * `skip_terraform`, and the workflow has to gate the steps with it.
+ */
+export const warnSkipTerraform = (action: "plan" | "apply"): string =>
+  `TFACTION_SKIP_TERRAFORM is true, but the ${action} action is running.
+tfaction doesn't skip terraform ${action} by itself.
+Gate the step with the skip_terraform field of the list-targets output:
+
+  - uses: suzuki-shunsuke/tfaction@latest
+    if: matrix.target.skip_terraform != true
+    with:
+      action: ${action}
+
+https://suzuki-shunsuke.github.io/tfaction/docs/skip-terraform`;

--- a/src/lib/skip-terraform.ts
+++ b/src/lib/skip-terraform.ts
@@ -1,15 +1,16 @@
 /**
- * Builds a warning message telling the user that the step should have been
- * gated with the `skip_terraform` field of the list-targets output.
+ * Builds a warning message for a plan or apply step that runs even though
+ * terraform is skipped.
  *
- * tfaction doesn't skip terraform plan and apply by itself.
- * list-targets decides whether they're necessary and reports it as
- * `skip_terraform`, and the workflow has to gate the steps with it.
+ * list-targets decides whether terraform plan and apply are necessary and
+ * reports it as the `skip_terraform` field of each target. Gating the step
+ * with that field is the recommended way to act on it, so that the action
+ * doesn't run at all. Honoring `TFACTION_SKIP_TERRAFORM` is a backstop for
+ * workflows that don't gate the step.
  */
 export const warnSkipTerraform = (action: "plan" | "apply"): string =>
-  `TFACTION_SKIP_TERRAFORM is true, but the ${action} action is running.
-tfaction doesn't skip terraform ${action} by itself.
-Gate the step with the skip_terraform field of the list-targets output:
+  `terraform ${action} is skipped because TFACTION_SKIP_TERRAFORM is true.
+Gate the step with the skip_terraform field of the list-targets output so that the action doesn't run at all:
 
   - uses: suzuki-shunsuke/tfaction@latest
     if: matrix.target.skip_terraform != true

--- a/website/docs/actions.md
+++ b/website/docs/actions.md
@@ -333,6 +333,10 @@ Environment variables:
 
 - TFACTION_SKIP_TERRAFORM: If `true`, the issue is not closed. Set it in apply jobs so that skipping apply does not close the drift issue
 
+Don't gate this step with `skip_terraform`.
+It has to keep running with `if: always()` so that a failure elsewhere in the job still comments on the drift issue and reopens it.
+`TFACTION_SKIP_TERRAFORM` only suppresses closing the issue.
+
 ## update-pr-branch
 
 Updates the branch of PRs that modify the same root module after apply runs.

--- a/website/docs/actions.md
+++ b/website/docs/actions.md
@@ -24,7 +24,6 @@ Environment variables:
 - TFACTION_JOB_TYPE: One of `terraform` | `tfmigrate` | `scaffold_working_dir`. Controls the behavior of the action.
   - `terraform`: Runs terraform plan or apply
   - `tfmigrate`: Runs tfmigrate plan or apply
-- TFACTION_SKIP_TERRAFORM
 - TFACTION_IS_APPLY: `true` | `false`. Set to `true` in apply workflows and `false` in plan workflows.
   - Required to switch between plan-specific and apply-specific configuration.
   ```yaml title="tfaction.yaml"
@@ -49,13 +48,15 @@ All inputs are optional.
 Environment variables:
 
 - TFACTION_JOB_TYPE
-- TFACTION_SKIP_TERRAFORM
 
-1. If skip_terraform is enabled, does nothing
 1. Downloads the plan file from GitHub Artifacts
    1. Fails if plan_workflow_name is incorrect
 1. Runs terraform apply and notifies via tfcmt
 1. If drift detection is enabled, updates the drift issue
+
+This action does not check `skip_terraform` by itself.
+To skip apply, gate the step with the `skip_terraform` field of the [list-targets](#list-targets) output.
+See [Skipping terraform plan and apply](skip-terraform.md).
 
 ## create-drift-issues
 
@@ -136,6 +137,7 @@ The outputs are intended to be used as env, runs-on, and environment in subseque
     "runs_on": "ubuntu-latest",
     "job_type": "terraform",
     "environment": "production",
+    "skip_terraform": false,
     "type": "module"
   }
 ]
@@ -144,6 +146,7 @@ The outputs are intended to be used as env, runs-on, and environment in subseque
 - target: Alias for working_directory. By default, same as `working_directory`
 - runs_on: Job execution environment. Defaults to `ubuntu-latest`
 - environment: GitHub Environments
+- skip_terraform: Whether terraform plan and apply are unnecessary. Gate the plan and apply steps with this field. See [Skipping terraform plan and apply](skip-terraform.md)
 - type: Working directory type. Set to `module` for modules
 
 ```yaml title=".github/workflows/test.yaml"
@@ -162,6 +165,12 @@ plan:
     fail-fast: false
     matrix:
       target: ${{fromJSON(needs.list.outputs.targets)}}
+  steps:
+    # ...
+    - uses: suzuki-shunsuke/tfaction@latest
+      if: matrix.target.skip_terraform != true
+      with:
+        action: plan
 ```
 
 You can customize the settings in tfaction-root.yaml.
@@ -216,6 +225,10 @@ Runs terraform plan or tfmigrate plan and comments the results on the PR via tfc
 Uploads the plan file in both binary and JSON formats to GitHub Artifacts.
 If configured, runs Conftest against the plan file.
 If the plan result is not "No Change" on a Renovate PR and the setting is enabled, disables auto-merge.
+
+This action does not check `skip_terraform` by itself.
+To skip plan, gate the step with the `skip_terraform` field of the [list-targets](#list-targets) output.
+See [Skipping terraform plan and apply](skip-terraform.md).
 
 ## release-module
 
@@ -315,6 +328,10 @@ Runs linting, formatting, and documentation generation tools such as terraform v
 Updates a specified drift issue based on plan or apply results.
 Closes the issue on success; reopens it on failure.
 This is a separate action so it can always run in apply jobs and drift detection jobs.
+
+Environment variables:
+
+- TFACTION_SKIP_TERRAFORM: If `true`, the issue is not closed. Set it in apply jobs so that skipping apply does not close the drift issue
 
 ## update-pr-branch
 

--- a/website/docs/actions.md
+++ b/website/docs/actions.md
@@ -24,6 +24,7 @@ Environment variables:
 - TFACTION_JOB_TYPE: One of `terraform` | `tfmigrate` | `scaffold_working_dir`. Controls the behavior of the action.
   - `terraform`: Runs terraform plan or apply
   - `tfmigrate`: Runs tfmigrate plan or apply
+- TFACTION_SKIP_TERRAFORM: `true` | `false`. If `true`, plan and apply do nothing. See [Skipping terraform plan and apply](skip-terraform.md)
 - TFACTION_IS_APPLY: `true` | `false`. Set to `true` in apply workflows and `false` in plan workflows.
   - Required to switch between plan-specific and apply-specific configuration.
   ```yaml title="tfaction.yaml"
@@ -48,14 +49,15 @@ All inputs are optional.
 Environment variables:
 
 - TFACTION_JOB_TYPE
+- TFACTION_SKIP_TERRAFORM
 
+1. If TFACTION_SKIP_TERRAFORM is `true`, warns and does nothing
 1. Downloads the plan file from GitHub Artifacts
    1. Fails if plan_workflow_name is incorrect
 1. Runs terraform apply and notifies via tfcmt
 1. If drift detection is enabled, updates the drift issue
 
-This action does not check `skip_terraform` by itself.
-To skip apply, gate the step with the `skip_terraform` field of the [list-targets](#list-targets) output.
+Gating the step with the `skip_terraform` field of the [list-targets](#list-targets) output is the recommended way to skip apply.
 See [Skipping terraform plan and apply](skip-terraform.md).
 
 ## create-drift-issues
@@ -146,7 +148,7 @@ The outputs are intended to be used as env, runs-on, and environment in subseque
 - target: Alias for working_directory. By default, same as `working_directory`
 - runs_on: Job execution environment. Defaults to `ubuntu-latest`
 - environment: GitHub Environments
-- skip_terraform: Whether terraform plan and apply are unnecessary. Gate the plan and apply steps with this field. See [Skipping terraform plan and apply](skip-terraform.md)
+- skip_terraform: Whether terraform plan and apply are unnecessary. The workflow has to act on this field. See [Skipping terraform plan and apply](skip-terraform.md)
 - type: Working directory type. Set to `module` for modules
 
 ```yaml title=".github/workflows/test.yaml"
@@ -226,8 +228,11 @@ Uploads the plan file in both binary and JSON formats to GitHub Artifacts.
 If configured, runs Conftest against the plan file.
 If the plan result is not "No Change" on a Renovate PR and the setting is enabled, disables auto-merge.
 
-This action does not check `skip_terraform` by itself.
-To skip plan, gate the step with the `skip_terraform` field of the [list-targets](#list-targets) output.
+Environment variables:
+
+- TFACTION_SKIP_TERRAFORM: If `true`, warns and does nothing. Not applied to drift detection jobs
+
+Gating the step with the `skip_terraform` field of the [list-targets](#list-targets) output is the recommended way to skip plan.
 See [Skipping terraform plan and apply](skip-terraform.md).
 
 ## release-module

--- a/website/docs/monorepo.md
+++ b/website/docs/monorepo.md
@@ -92,6 +92,13 @@ jobs:
         with:
           persist-credentials: false
       # ...
+      - name: Plan
+        uses: suzuki-shunsuke/tfaction@latest
+        # Skip plan for root modules where terraform plan is unnecessary.
+        # https://suzuki-shunsuke.github.io/tfaction/docs/skip-terraform
+        if: matrix.target.skip_terraform != true
+        with:
+          action: plan
 ```
 
 3. Update `tfaction-root.yaml`'s `target_groups` so that root modules are matched.

--- a/website/docs/skip-terraform.md
+++ b/website/docs/skip-terraform.md
@@ -11,8 +11,8 @@ Two things trigger this:
 1. The skip label: a label named `<label_prefixes.skip><target>` is added to the pull request
 
 The [list-targets](actions.md#list-targets) action makes the decision and reports it as the `skip_terraform` field of each target.
-tfaction does not skip anything on its own, so your workflow has to gate the `plan` and `apply` steps with that field.
-This means the feature requires a workflow that runs jobs from list-targets output. See [Monorepo](monorepo.md).
+Your workflow has to act on that field, either by gating the `plan` and `apply` steps with it or by passing it as the `TFACTION_SKIP_TERRAFORM` environment variable.
+Either way, the feature requires a workflow that runs jobs from list-targets output. See [Monorepo](monorepo.md).
 
 Only terraform plan and apply are skipped; other operations such as linting and formatting still run.
 
@@ -35,7 +35,24 @@ Only terraform plan and apply are skipped; other operations such as linting and 
 Both steps must be gated.
 If only the plan step is gated, no plan file is uploaded to GitHub Artifacts and the apply step fails while downloading it.
 
-If [Drift Detection](drift-detection.md) is enabled, set `TFACTION_SKIP_TERRAFORM` as well so that the [update-drift-issue](actions.md#update-drift-issue) action does not close the drift issue when apply was skipped:
+## TFACTION_SKIP_TERRAFORM
+
+If the `TFACTION_SKIP_TERRAFORM` environment variable is `true`, the plan and apply actions warn and do nothing.
+This is a backstop for workflows that don't gate the steps, so that a missing gate doesn't silently plan and apply a root module that was supposed to be skipped.
+
+```yaml title=".github/workflows/test.yaml"
+jobs:
+  plan:
+    env:
+      TFACTION_SKIP_TERRAFORM: ${{matrix.target.skip_terraform}}
+```
+
+Gating the steps is still recommended, because then the actions don't run at all.
+The environment variable isn't applied to drift detection jobs, where terraform plan always has to run.
+
+## Drift Detection
+
+If [Drift Detection](drift-detection.md) is enabled, set `TFACTION_SKIP_TERRAFORM` in the apply job so that the [update-drift-issue](actions.md#update-drift-issue) action does not close the drift issue when apply was skipped:
 
 ```yaml title=".github/workflows/apply.yaml"
 jobs:

--- a/website/docs/skip-terraform.md
+++ b/website/docs/skip-terraform.md
@@ -4,11 +4,53 @@ sidebar_position: 3000
 
 # Skipping terraform plan and apply
 
-When only files matching `skip_terraform_files` under a working directory are modified, terraform plan and apply are skipped.
+tfaction can tell you that `terraform plan` and `apply` are unnecessary for a given root module.
+Two things trigger this:
+
+1. `skip_terraform_files`: only files matching the configured patterns under the working directory are modified
+1. The skip label: a label named `<label_prefixes.skip><target>` is added to the pull request
+
+The [list-targets](actions.md#list-targets) action makes the decision and reports it as the `skip_terraform` field of each target.
+tfaction does not skip anything on its own, so your workflow has to gate the `plan` and `apply` steps with that field.
+This means the feature requires a workflow that runs jobs from list-targets output. See [Monorepo](monorepo.md).
+
+Only terraform plan and apply are skipped; other operations such as linting and formatting still run.
+
+## Gate the plan and apply steps
+
+```yaml title=".github/workflows/test.yaml"
+- uses: suzuki-shunsuke/tfaction@latest
+  if: matrix.target.skip_terraform != true
+  with:
+    action: plan
+```
+
+```yaml title=".github/workflows/apply.yaml"
+- uses: suzuki-shunsuke/tfaction@latest
+  if: matrix.target.skip_terraform != true
+  with:
+    action: apply
+```
+
+Both steps must be gated.
+If only the plan step is gated, no plan file is uploaded to GitHub Artifacts and the apply step fails while downloading it.
+
+If [Drift Detection](drift-detection.md) is enabled, set `TFACTION_SKIP_TERRAFORM` as well so that the [update-drift-issue](actions.md#update-drift-issue) action does not close the drift issue when apply was skipped:
+
+```yaml title=".github/workflows/apply.yaml"
+jobs:
+  apply:
+    env:
+      TFACTION_SKIP_TERRAFORM: ${{matrix.target.skip_terraform}}
+```
+
+## skip_terraform_files
+
+When only files matching `skip_terraform_files` under a working directory are modified, `skip_terraform` becomes `true`.
 This is intended to avoid unnecessary terraform plan and apply runs when editing files that do not affect their results.
 This feature is disabled by default.
 
-```yaml
+```yaml title="tfaction-root.yaml"
 skip_terraform_files:
   - "**/*.md" # Ignore markdown edits. Paths are relative to each working directory
   - "!README.md" # Do not ignore README.md at the working directory root
@@ -16,4 +58,14 @@ skip_terraform_files:
 
 Lines starting with `!` are negation patterns that exclude files matched by preceding globs.
 
-Only terraform plan and apply are skipped; other operations such as linting and formatting still run.
+## Skip label
+
+Adding a `skip:<target>` label to a pull request sets `skip_terraform` to `true` for that target.
+The prefix is `skip:` by default and can be changed with `label_prefixes.skip`.
+
+```yaml title="tfaction-root.yaml"
+label_prefixes:
+  skip: "skip:"
+```
+
+This is useful when you know the plan is meaningless or harmful for a specific root module, for example when [moving resources across states](tfmigrate.md#moving-resources-across-states).

--- a/website/docs/skip-terraform.md
+++ b/website/docs/skip-terraform.md
@@ -44,6 +44,10 @@ jobs:
       TFACTION_SKIP_TERRAFORM: ${{matrix.target.skip_terraform}}
 ```
 
+Don't gate the update-drift-issue step itself.
+It has to keep running with `if: always()` so that a failure elsewhere in the job still comments on the drift issue and reopens it.
+`TFACTION_SKIP_TERRAFORM` only suppresses closing the issue.
+
 ## skip_terraform_files
 
 When only files matching `skip_terraform_files` under a working directory are modified, `skip_terraform` becomes `true`.

--- a/website/docs/tfmigrate.md
+++ b/website/docs/tfmigrate.md
@@ -89,8 +89,8 @@ By adding a `skip:bar` label, `list-targets` reports `skip_terraform: true` for 
 
 :::warning
 The label alone does not stop anything.
-Your workflow has to gate the plan and apply steps with `skip_terraform`, otherwise terraform plan and apply run in `bar` anyway.
-Without the gate, `bar` produces a destroy plan and applies it once the pull request is merged, deleting the resources you are moving.
+Your workflow has to act on `skip_terraform`, either by gating the plan and apply steps with it or by passing it as `TFACTION_SKIP_TERRAFORM`.
+Otherwise `bar` produces a destroy plan and applies it once the pull request is merged, deleting the resources you are moving.
 See [Skipping terraform plan and apply](skip-terraform.md).
 :::
 

--- a/website/docs/tfmigrate.md
+++ b/website/docs/tfmigrate.md
@@ -80,9 +80,25 @@ target_groups:
 ## Moving Resources Across States
 
 tfmigrate supports moving resources between different states.
-When doing this with tfaction, use an ignore label to prevent terraform plan from running.
+When doing this with tfaction, use a skip label to prevent terraform plan from running.
 
 For example, suppose you are moving resources from working directory `foo` to `bar` and running tfmigrate in `foo`.
 Both `foo` and `bar` require code changes, so CI runs in both directories.
 In `foo`, tfmigrate moves the resources from `foo` to `bar`, but in `bar`, terraform plan and apply would also run.
-By adding an `ignore:bar` label, you can prevent terraform plan and apply from running in `bar`.
+By adding a `skip:bar` label, `list-targets` reports `skip_terraform: true` for `bar`.
+
+:::warning
+The label alone does not stop anything.
+Your workflow has to gate the plan and apply steps with `skip_terraform`, otherwise terraform plan and apply run in `bar` anyway.
+Without the gate, `bar` produces a destroy plan and applies it once the pull request is merged, deleting the resources you are moving.
+See [Skipping terraform plan and apply](skip-terraform.md).
+:::
+
+```yaml
+- uses: suzuki-shunsuke/tfaction@latest
+  if: matrix.target.skip_terraform != true
+  with:
+    action: plan
+```
+
+The label prefix is `skip:` by default and can be changed with `label_prefixes.skip`.

--- a/website/docs/v2-upgrade-guide.md
+++ b/website/docs/v2-upgrade-guide.md
@@ -181,6 +181,9 @@ Gate the plan and apply steps with the field:
     action: apply
 ```
 
+Setting `TFACTION_SKIP_TERRAFORM` on the job also works: the plan and apply actions then warn and do nothing.
+Gating the steps is recommended, because then the actions don't run at all.
+
 If [Drift Detection](drift-detection.md) is enabled, set `TFACTION_SKIP_TERRAFORM` in the apply job as well so that the update-drift-issue action does not close the drift issue when apply was skipped:
 
 ```yaml title=".github/workflows/apply.yaml"

--- a/website/docs/v2-upgrade-guide.md
+++ b/website/docs/v2-upgrade-guide.md
@@ -34,7 +34,7 @@ If it isn't, check the `TFACTION_CONFIG` environment variable in your workflow f
   - If AWS or Google Cloud authentication is required, explicitly run `aws-actions/configure-aws-credentials` or `google-github-actions/auth`
   - Remove the feature that exports secrets as environment variables via export-secrets or export-aws-secrets-manager
   - Migrate tfaction-go to `suzuki-shunsuke/tfaction/*`
-  - Add the `TFACTION_SKIP_TERRAFORM` environment variable to jobs
+  - Gate the plan and apply steps with `skip_terraform`
   - Remove module testing jobs that use `test-module`
   - Remove workflows that use scaffold-module or create-scaffold-module-pr
   - Remove SSH Key configuration
@@ -161,14 +161,36 @@ After:
     action: create-drift-issues
 ```
 
-## Add the `TFACTION_SKIP_TERRAFORM` environment variable to jobs
+## Gate the plan and apply steps with `skip_terraform`
 
-```yaml
+In v1, the terraform-plan and terraform-apply actions decided by themselves whether to skip terraform plan and apply.
+In v2, the [list-targets](actions.md#list-targets) action makes the decision and reports it as the `skip_terraform` field of each target, and the workflow decides what to do with it.
+Gate the plan and apply steps with the field:
+
+```yaml title=".github/workflows/test.yaml"
+- uses: suzuki-shunsuke/tfaction@latest
+  if: matrix.target.skip_terraform != true
+  with:
+    action: plan
+```
+
+```yaml title=".github/workflows/apply.yaml"
+- uses: suzuki-shunsuke/tfaction@latest
+  if: matrix.target.skip_terraform != true
+  with:
+    action: apply
+```
+
+If [Drift Detection](drift-detection.md) is enabled, set `TFACTION_SKIP_TERRAFORM` in the apply job as well so that the update-drift-issue action does not close the drift issue when apply was skipped:
+
+```yaml title=".github/workflows/apply.yaml"
 jobs:
-  plan:
+  apply:
     env:
       TFACTION_SKIP_TERRAFORM: "${{matrix.target.skip_terraform}}"
 ```
+
+See [Skipping terraform plan and apply](skip-terraform.md).
 
 ## Remove module testing jobs that use `test-module`
 

--- a/website/docs/v2-upgrade-guide.md
+++ b/website/docs/v2-upgrade-guide.md
@@ -190,6 +190,10 @@ jobs:
       TFACTION_SKIP_TERRAFORM: "${{matrix.target.skip_terraform}}"
 ```
 
+Don't gate the update-drift-issue step itself.
+It has to keep running with `if: always()` so that a failure elsewhere in the job still comments on the drift issue and reopens it.
+`TFACTION_SKIP_TERRAFORM` only suppresses closing the issue.
+
 See [Skipping terraform plan and apply](skip-terraform.md).
 
 ## Remove module testing jobs that use `test-module`


### PR DESCRIPTION
Fixes #4265

## Background

In v1, the `terraform-plan` and `terraform-apply` actions called `check-terraform-skip` and gated their steps with the result. In v2 the skip decision moved to `list-targets`, which reports it as the `skip_terraform` field of each target, but the consumers were removed in #3635 without adding an equivalent gate anywhere. `TFACTION_SKIP_TERRAFORM` ended up being read only by `update-drift-issue`.

As a result neither the `skip:<target>` label nor `skip_terraform_files` stopped `terraform plan` and `apply`. The documentation still described the v1 behaviour, so users had no way to know they were responsible for the gate. For a cross-state migration this is destructive: the source directory produces a destroy plan and applies it on merge.

## What this PR does

`list-targets` keeps making the decision, and the workflow acts on it. There are now two ways to do that, and both are documented.

Recommended: gate the steps, so the actions don't run at all.

```yaml
- uses: suzuki-shunsuke/tfaction@latest
  if: matrix.target.skip_terraform != true
  with:
    action: plan
```

Backstop: `TFACTION_SKIP_TERRAFORM`. The plan and apply actions now warn and do nothing when it's `true`, so a workflow that misses the gate doesn't silently plan and apply a root module that was supposed to be skipped. This also restores what the v2 upgrade guide already told users to configure. Drift detection jobs are unaffected, where terraform plan always has to run.

Changes:

- Honor `TFACTION_SKIP_TERRAFORM` in the `plan` and `apply` actions again, with a warning pointing at the recommended gate
- Document the `skip_terraform` field of the `list-targets` output and both ways to act on it, in `website/docs/skip-terraform.md`, `website/docs/actions.md`, `website/docs/monorepo.md`, `website/docs/v2-upgrade-guide.md` and the action READMEs
- Document that the `update-drift-issue` step must not be gated. It has to keep running with `if: always()` so that a failure elsewhere in the job still comments on the drift issue and reopens it. `TFACTION_SKIP_TERRAFORM` only suppresses closing the issue there
- Fix `website/docs/tfmigrate.md`, which told users to add an `ignore:bar` label. The default prefix is `skip:`, so the documented label set no flag at all
- Remove the `skip_terraform` output from `action.yaml`. It belonged to the removed `check-terraform-skip` action and nothing sets it

## Note

`action.yaml` still declares outputs for actions that no longer exist, such as `get-global-config` and `list-module-caller`. Cleaning those up is left out of this PR.
