### PR TITLE
fix: pass rootDir through to createCommit

### DIFF
--- a/src/commit/index.ts
+++ b/src/commit/index.ts
@@ -8,7 +8,7 @@ import { run } from "./run";
 type Inputs = {
   commitMessage: string;
   githubToken: string;
-  /** A relative path from github.workspace to Git Root Directory */
+  /** An absolute path to the Git Root Directory */
   rootDir?: string;
   /** Relative paths from Git Root Directory */
   files: Set<string>;
@@ -53,6 +53,7 @@ export const create = async (inputs: Inputs): Promise<string> => {
 
   return run({
     commitMessage: inputs.commitMessage,
+    rootDir: inputs.rootDir,
     files: inputs.files,
     branch,
     repoOwner: github.context.repo.owner,

--- a/src/commit/run.test.ts
+++ b/src/commit/run.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as commit from "@suzuki-shunsuke/commit-ts";
 import { run, type RunInput, type Logger } from "./run";
 
 describe("run", () => {
@@ -50,6 +51,30 @@ describe("run", () => {
     expect(result).toBe("");
     expect(octokit.rest.repos.get).not.toHaveBeenCalled();
     expect(octokit.rest.pulls.create).not.toHaveBeenCalled();
+  });
+
+  it("passes rootDir to createCommit so paths resolve from the git root", async () => {
+    const octokit = createMockOctokit();
+    const logger = createMockLogger();
+    const input: RunInput = {
+      commitMessage: "test commit",
+      rootDir: "/home/runner/work/repo/repo/yoo",
+      files: new Set(["tests/opentofu/bar-2/.terraform.lock.hcl"]),
+      branch: "feature-branch",
+      repoOwner: "owner",
+      repoName: "repo",
+      octokit: octokit as unknown as RunInput["octokit"],
+      logger,
+    };
+
+    await run(input);
+
+    expect(commit.createCommit).toHaveBeenCalledWith(
+      octokit,
+      expect.objectContaining({
+        rootDir: "/home/runner/work/repo/repo/yoo",
+      }),
+    );
   });
 
   it("creates PR and returns html_url when pr is specified", async () => {

--- a/src/commit/run.ts
+++ b/src/commit/run.ts
@@ -19,6 +19,8 @@ export type PullRequest = {
 
 export type RunInput = {
   commitMessage: string;
+  /** An absolute path to the Git Root Directory */
+  rootDir?: string;
   files: Set<string>;
   branch: string;
   repoOwner: string;
@@ -37,6 +39,7 @@ export const run = async (input: RunInput): Promise<string> => {
     repo: repoName,
     branch,
     message: commitMessage,
+    rootDir: input.rootDir,
     files: [...files],
     deleteIfNotExist: true,
     logger: {


### PR DESCRIPTION
`commit.create` accepts a `rootDir` and never forwards it, so file paths are resolved against `process.cwd()` rather than the git root. Where those differ, a commit meant to update a file deletes it instead.

## What happens

`src/commit/index.ts` declares `rootDir` and `src/commit/run.ts` never sets it on `commit.createCommit`, so `commit-ts` falls back to `path.join("" , filePath)` — cwd-relative.

The `Change checkout path` tests check the repository out into `yoo/`, so the git root is `$GITHUB_WORKSPACE/yoo` while cwd stays `$GITHUB_WORKSPACE`. `commit-ts` then stats `$GITHUB_WORKSPACE/tests/opentofu/bar-2/.terraform.lock.hcl`, which does not exist. Callers pass `deleteIfNotExist: true`, so the missing file is turned into a deletion entry and the commit removes the file it was supposed to update.

That is visible on `renovate/opentofu-opentofu-1.x` (#4188). Four bot commits, all titled `chore: update .terraform.lock.hcl`:

```
7923cee8  removed   tests/opentofu/bar-2/.terraform.lock.hcl     <- yoo checkout
c9d8ca68  removed   tests/terragrunt/zoo-2/.terraform.lock.hcl   <- yoo checkout
897aad19  modified  tests/opentofu/bar/.terraform.lock.hcl       <- normal checkout
8e5289dd  modified  tests/terragrunt/zoo/.terraform.lock.hcl     <- normal checkout
```

Once the file is gone the failure becomes permanent: the next run sends a deletion for a path no longer in `base_tree`, and GitHub rejects it:

```
creating a tree with 1 files: base_tree=c96eb65...
##[error]GitRPC::BadObjectState - https://docs.github.com/rest/git/trees#create-a-tree
```

It also explains why the job never stops trying. `terraform-init` guards the commit on `!existedBefore || hasFileChanged(...)`, and with the lock file deleted from the branch every run recreates it, so `existedBefore` is false and the commit path fires regardless of what `providers lock` reports.

`Change checkout path (terraform)` passes only because an OpenTofu bump leaves the terraform lock files unchanged, so the commit path is never reached. It is not safe — it would fail the same way on the first terraform lock change.

## The change

Forwards `rootDir` from `create` through `run` to `createCommit`. `getRootDir` returns an absolute path and `commit-ts` uses `path.join`, so an absolute `rootDir` resolves correctly.

The doc comment on `Inputs.rootDir` said "A relative path from github.workspace"; the value passed by every caller is absolute, so it is corrected.

Five other call sites pass the same dead `rootDir` and are fixed by the same change: `plan`, `create-follow-up-pr`, `aqua-update-checksum`, `scaffold-tfmigrate`, `generate-config-out`. `rootDir` has been unused since #3385 added it.

## Verification

Added a test asserting `rootDir` reaches `createCommit`. It fails without this change and passes with it:

```
$ npm test          # with the fix removed
FAIL  src/commit/run.test.ts > run > passes rootDir to createCommit so paths resolve from the git root
Tests  1 failed | 928 passed (929)

$ npm test          # with the fix
Tests  929 passed (929)
```

`npm run lint` and `npm run typecheck` pass.

## Note

`deleteIfNotExist: true` turning "could not read this file" into "delete it" is what made a path bug destructive rather than a hard error. Worth considering separately whether callers that mean "update these files" should get a mode that fails instead.

The lock files deleted from #4188's branch still need restoring; they are intact on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying an absolute Git root directory when creating commits.
  * Commit operations now resolve file paths relative to the configured Git root directory.

* **Documentation**
  * Clarified that the Git root directory must be provided as an absolute path.

* **Bug Fixes**
  * Improved commit handling for projects where the working directory differs from the Git repository root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->