### PR TITLE
fix: restore the lock files deleted by the commit bug

### DIFF
--- a/tests/opentofu/bar-2/.terraform.lock.hcl
+++ b/tests/opentofu/bar-2/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.3"
+  constraints = "3.2.3"
+  hashes = [
+    "h1:0xQDChDFXoS81rOclIVHtZg7KWQBhpzPeh/ln++aEhU=",
+    "h1:GebqZSnOIwCTZxIG9fg/Dyeo9zURxukLyRouHsGQa40=",
+    "h1:LF8arSzHfhbyQSFtTMTYEqCM34klzrbAQBJMHYCs9d8=",
+    "h1:LN7WjQlMDIYGsXlum1kvMk5M8XzS2gzPTHmbEkxB6B0=",
+    "h1:ZD7F/BQPzRy/smJgSwnDs0vrqstk71sx2p0qtUcc/iU=",
+    "h1:giMJ2oPzWYoPPSgJDEqyE8lZSuAmlD0K2khaKixieSw=",
+    "h1:i3Ittuf/TzZobkdJ4BcdZmENXMJspPJzvpDHHE49/Kc=",
+    "h1:nNa5j1vTtxcpdC2i61O2tRkZjdkBNsxzYXYIx0VNsjc=",
+    "h1:qNt8jVloxhUTt3QB7X8hHCQ9Mws0qlEQmJCScckGnC4=",
+    "h1:rb475WMNa1Ps+RAxqKOcMobLVkbmnVoWET0oO5JfpxE=",
+    "zh:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac",
+    "zh:65b7f9799b88464d9c2ec529713b7f52ea744275b61a8dc86cdedab1b2dcb933",
+    "zh:80d3e9c95b7b4ae7c54005cd127cae82e5c53d2b7023ef24c147337bac9dadd9",
+    "zh:841b60c07683e4bf456799ccd718896fdafdcc2c49252ae09967f2e74d8c8a03",
+    "zh:8fa1c592a9c78222e35713c6edb3f1f818a4c6f3524a30a209f0a7e919827b68",
+    "zh:bb795cc1429e09466840c09d39a28edf1db5070b1ec76822fc1173906a264572",
+    "zh:da1784818a89bea29dfe660632f0060a7a843e4e564d74435fbeca002b0f7d2a",
+    "zh:f409bf21b1cdaa6dac47cd79806f3d93f67e9507fe4dbf33b0165335f53bc2e1",
+    "zh:fbea7a1ff84b430ba9594698e93196d81d03e4036de3d1cafccb2a96d5b38581",
+    "zh:fbf0c84663a7e85881388d7d71ac862184f05fbf2d17ecf76bc5d3d7503ea260",
+  ]
+}

--- a/tests/terragrunt/zoo-2/.terraform.lock.hcl
+++ b/tests/terragrunt/zoo-2/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.3"
+  constraints = "3.2.3"
+  hashes = [
+    "h1:0xQDChDFXoS81rOclIVHtZg7KWQBhpzPeh/ln++aEhU=",
+    "h1:GebqZSnOIwCTZxIG9fg/Dyeo9zURxukLyRouHsGQa40=",
+    "h1:LF8arSzHfhbyQSFtTMTYEqCM34klzrbAQBJMHYCs9d8=",
+    "h1:LN7WjQlMDIYGsXlum1kvMk5M8XzS2gzPTHmbEkxB6B0=",
+    "h1:ZD7F/BQPzRy/smJgSwnDs0vrqstk71sx2p0qtUcc/iU=",
+    "h1:giMJ2oPzWYoPPSgJDEqyE8lZSuAmlD0K2khaKixieSw=",
+    "h1:i3Ittuf/TzZobkdJ4BcdZmENXMJspPJzvpDHHE49/Kc=",
+    "h1:nNa5j1vTtxcpdC2i61O2tRkZjdkBNsxzYXYIx0VNsjc=",
+    "h1:qNt8jVloxhUTt3QB7X8hHCQ9Mws0qlEQmJCScckGnC4=",
+    "h1:rb475WMNa1Ps+RAxqKOcMobLVkbmnVoWET0oO5JfpxE=",
+    "zh:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac",
+    "zh:65b7f9799b88464d9c2ec529713b7f52ea744275b61a8dc86cdedab1b2dcb933",
+    "zh:80d3e9c95b7b4ae7c54005cd127cae82e5c53d2b7023ef24c147337bac9dadd9",
+    "zh:841b60c07683e4bf456799ccd718896fdafdcc2c49252ae09967f2e74d8c8a03",
+    "zh:8fa1c592a9c78222e35713c6edb3f1f818a4c6f3524a30a209f0a7e919827b68",
+    "zh:bb795cc1429e09466840c09d39a28edf1db5070b1ec76822fc1173906a264572",
+    "zh:da1784818a89bea29dfe660632f0060a7a843e4e564d74435fbeca002b0f7d2a",
+    "zh:f409bf21b1cdaa6dac47cd79806f3d93f67e9507fe4dbf33b0165335f53bc2e1",
+    "zh:fbea7a1ff84b430ba9594698e93196d81d03e4036de3d1cafccb2a96d5b38581",
+    "zh:fbf0c84663a7e85881388d7d71ac862184f05fbf2d17ecf76bc5d3d7503ea260",
+  ]
+}


### PR DESCRIPTION
Restores the two lock files that the commit bug deleted from this branch.

The `Change checkout path` jobs deleted these instead of updating them. `commit.create` resolved their paths against `$GITHUB_WORKSPACE` rather than the git root, which differ in those jobs because the repository is checked out into `yoo/`. With `deleteIfNotExist: true`, the file that could not be found became a deletion entry:

```
7923cee8  removed   tests/opentofu/bar-2/.terraform.lock.hcl
c9d8ca68  removed   tests/terragrunt/zoo-2/.terraform.lock.hcl
```

The same run updated the non-`yoo` siblings correctly:

```
897aad19  modified  tests/opentofu/bar/.terraform.lock.hcl
8e5289dd  modified  tests/terragrunt/zoo/.terraform.lock.hcl
```

The code fix is #4276. This is the data half — #4276 stops it recurring but does not bring the deleted files back, and #4188 stays red without them.

## Content

Restored to match the siblings rather than to the pre-bump state from `main`, because `bar-2` is identical to `bar` and `zoo-2` to `zoo` on `main`, and the siblings already carry the OpenTofu 1.12.6 update this pull request is making. So this is the content those files would have had if the bug had not run.

## Ordering

This needs #4276 in the branch first. The `Change checkout path` jobs run tfaction from the checkout, so until this branch has the fix, the next run will simply delete the files again.

Suggested order: merge #4276, update #4188 with `main`, then merge this.
