### PR TITLE
chore(hk): exclude README.md from langcheck

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -17,6 +17,10 @@ local linters = new Mapping<String, Step> {
   ["langcheck"] {
     // https://github.com/suzuki-shunsuke/langcheck
     glob = List("**/*")
+    // README.md lists the titles of Japanese blog posts about tfaction, which
+    // langcheck reports as disallowed characters. The titles must stay as they
+    // are, so the file is excluded.
+    exclude = List("README.md")
     check = "langcheck check {{files}}"
     fix = "langcheck check {{files}}" // run as check in fix mode (no real fix possible)
   }


### PR DESCRIPTION
## Why

`README.md` has a "Who uses tfaction?" section that lists blog posts about tfaction written by users.
Several of those posts have Japanese titles, and the list keeps the titles as they are so readers can recognize them.

langcheck reports any line containing Han, Hiragana, or Katakana characters, so those lines are always reported:

```
README.md:22
  - [Terraform の CI を AWS CodeBuild から GitHub Actions + tfaction に移行しました](https://blog.studysapuri.jp/entry/2022/02/04/080000)
...
```

langcheck has no way to ignore specific lines, so the pre-commit hook fails whenever `README.md` is staged, regardless of what the change actually is.
That blocks unrelated `README.md` edits, such as adding a new entry to the list or documenting a new feature.

## What

Exclude `README.md` from the langcheck step in `hk.pkl` using the step's `exclude` option.

The exclusion is scoped to that one file, so langcheck keeps checking everything else.

## Test

```console
# README.md is skipped
$ hk check --step langcheck README.md
  files - Fetching git status
  files - Fetching git status (1 file)
✔ files - Fetching git status (1 file)

# other files are still checked
$ hk check --step langcheck ja/comment.md
ja/comment.md:152
...
hk ERROR To fix, run: langcheck check ja/comment.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6jVCW9YtfYcfYUygDrPgw