### PR TITLE
docs: remove the DeepWiki link from the website navbar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -102,11 +102,6 @@ const config = {
             label: "GitHub",
             position: "right",
           },
-          {
-            href: "https://deepwiki.com/suzuki-shunsuke/tfaction",
-            label: "DeepWiki",
-            position: "right",
-          },
         ],
       },
       footer: {


### PR DESCRIPTION
## Why

DeepWiki is advertised as updating once a week, but in practice it has gone for months without being updated.
Linking to it from the documentation points readers at content that can be badly out of date, so we stop linking to it.

## What

Remove the DeepWiki entry from the website navbar in `website/docusaurus.config.js`.

The DeepWiki badge in `README.md` is left as it is for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6jVCW9YtfYcfYUygDrPgw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the DeepWiki link from the website’s navigation bar.
  * The GitHub link remains available in the navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->