### PR TITLE
fix: pass secretEnvs to terraform providers and terraform show

### DIFF
--- a/src/actions/plan/run.test.ts
+++ b/src/actions/plan/run.test.ts
@@ -459,6 +459,30 @@ describe("runTerraformPlan", () => {
     );
   });
 
+  it("passes secretEnvs to terraform show", async () => {
+    const secrets = {
+      AWS_ACCESS_KEY_ID: "key",
+      AWS_SECRET_ACCESS_KEY: "secret",
+    };
+    mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
+    mockExecutor.getExecOutput.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    }); // terraform show
+
+    const inputs = { ...createBaseInputs(mockExecutor), secrets };
+    await runTerraformPlan(inputs);
+
+    expect(mockExecutor.getExecOutput).toHaveBeenCalledWith(
+      "terraform",
+      ["show", "-json", path.join(tempDir, "tfplan.binary")],
+      expect.objectContaining({
+        secretEnvs: secrets,
+      }),
+    );
+  });
+
   it("sets artifact name outputs with normalized target", async () => {
     mockExecutor.exec.mockResolvedValueOnce(0); // terraform plan
     mockExecutor.getExecOutput.mockResolvedValueOnce({
@@ -976,6 +1000,31 @@ describe("runTfmigratePlan", () => {
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       path.join(tempDir, "tfplan.json"),
       '{"resource_changes": []}',
+    );
+  });
+
+  it("passes secretEnvs to terraform show", async () => {
+    const secrets = {
+      AWS_ACCESS_KEY_ID: "key",
+      AWS_SECRET_ACCESS_KEY: "secret",
+    };
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    mockExecutor.exec.mockResolvedValue(0);
+    mockExecutor.getExecOutput.mockResolvedValue({
+      exitCode: 0,
+      stdout: '{"resource_changes": []}',
+      stderr: "",
+    });
+
+    const inputs = { ...createBaseInputs(mockExecutor), secrets };
+    await runTfmigratePlan(inputs);
+
+    expect(mockExecutor.getExecOutput).toHaveBeenCalledWith(
+      "terraform",
+      ["show", "-json", path.join(tempDir, "tfplan.binary")],
+      expect.objectContaining({
+        secretEnvs: secrets,
+      }),
     );
   });
 });

--- a/src/actions/plan/run.ts
+++ b/src/actions/plan/run.ts
@@ -347,6 +347,7 @@ export const runTfmigratePlan = async (
     {
       cwd: inputs.workingDirectory,
       silent: true,
+      secretEnvs: inputs.secrets,
       group: `${inputs.tfCommand} show`,
       comment: {
         token: inputs.githubToken,
@@ -517,6 +518,7 @@ export const runTerraformPlan = async (
     {
       cwd: inputs.workingDirectory,
       silent: true,
+      secretEnvs: inputs.secrets,
       group: `${inputs.tfCommand} show`,
       comment: {
         token: inputs.githubToken,

--- a/src/actions/terraform-init/run.test.ts
+++ b/src/actions/terraform-init/run.test.ts
@@ -112,6 +112,27 @@ describe("run", () => {
     );
   });
 
+  it("passes secretEnvs to providers", async () => {
+    const secrets = {
+      AWS_ACCESS_KEY_ID: "key",
+      AWS_SECRET_ACCESS_KEY: "secret",
+    };
+    const input = {
+      ...createBaseInput(mockExecutor),
+      secrets,
+    };
+
+    await run(input);
+
+    expect(mockExecutor.exec).toHaveBeenLastCalledWith(
+      "terraform",
+      ["providers"],
+      expect.objectContaining({
+        secretEnvs: secrets,
+      }),
+    );
+  });
+
   it("PR, init succeeds, lock not changed: init + providers lock + providers, no commit", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     const gitMod = await import("../../lib/git");

--- a/src/actions/terraform-init/run.ts
+++ b/src/actions/terraform-init/run.ts
@@ -140,6 +140,7 @@ export const run = async (input: RunInput): Promise<void> => {
     input.terragruntRunAvailable ? ["run", "--", "providers"] : ["providers"],
     {
       cwd: input.workingDir,
+      secretEnvs: input.secrets,
       group: input.terragruntRunAvailable
         ? `${input.tfCommand} run -- providers`
         : `${input.tfCommand} providers`,


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/suzuki-shunsuke/tfaction/blob/main/CONTRIBUTING.md)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/tfaction/issues/4310
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

Fixes #4310

## What happens

Three Terraform invocations run without the `secretEnvs` built from `output-github-secrets`.
Secrets configured through `target_groups[].secrets` are therefore missing from those commands' environment.

With an S3 backend whose credentials come only from GitHub Secrets, `terraform init` succeeds and `terraform providers` then fails:

```
Error: No valid credential sources found
```

## Changes

Pass `secretEnvs` to the three call sites that were missing it.

| File | Call |
| --- | --- |
| `src/actions/terraform-init/run.ts` | trailing `terraform providers` |
| `src/actions/plan/run.ts` | `terraform show -json` in `runTfmigratePlan` |
| `src/actions/plan/run.ts` | `terraform show -json` in `runTerraformPlan` |

`Executor.getExecOutput` builds its environment from `ExecOptions` the same way `Executor.exec` does, so `secretEnvs` takes effect on both.

Added one unit test per call site. All three fail without the source change.

## Verification

`npm ci`, `npm t`, `npm run lint` and `npm run fmt` pass on Node.js 24.20.0. 935 tests pass.

In the repository where the issue was found, exporting the same credentials through a step level `env:` block makes `terraform init` and every step after it succeed. That confirms the missing environment variables are the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVzUfHrRAntELcHXPkhvZm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Secret environment variables are now consistently passed when displaying Terraform plans and retrieving provider information.
  - Terraform workflows can now correctly access required secret-backed configuration during these operations.

- **Tests**
  - Added coverage to verify secret environment variables are forwarded correctly across Terraform plan, migration plan, and provider operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->