### PR TITLE
docs: use the real input names in the CSM Actions example

### DIFF
--- a/skills/tfaction/references/csm-actions.md
+++ b/skills/tfaction/references/csm-actions.md
@@ -40,6 +40,6 @@ csm_actions:
   with:
     action: plan
     github_token: ${{steps.generate_token.outputs.token}}
-    csm_action_app_id: ${{vars.CSM_APP_ID}}
-    csm_action_app_private_key: ${{secrets.CSM_APP_PRIVATE_KEY}}
+    csm_app_id: ${{vars.CSM_APP_ID}}
+    csm_app_private_key: ${{secrets.CSM_APP_PRIVATE_KEY}}
 ```


### PR DESCRIPTION
The CSM Actions example passes `csm_action_app_id` and `csm_action_app_private_key`. Neither input exists.

`action.yaml` declares `csm_app_id` and `csm_app_private_key`, and the action reads nothing under the other names. GitHub Actions doesn't reject unknown `with` keys, so copying this example gives a step that runs without the GitHub App rather than one that fails — which is the worse of the two outcomes.

v2 renamed `securefix_action_app_id` and `securefix_action_app_private_key` to `csm_app_id` and `csm_app_private_key`. `ja/rename-securefix-action.md` and the v2 upgrade guide both use the new names; this page ended up with a spelling that was never either of them.

Found while looking at what #4319 should document. Kept separate because it is unrelated to that change and worth merging on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the tfaction action example to use the current CSM credentials input names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->